### PR TITLE
Bugfixes: token count in search results, unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,9 @@ clean: ## Remove build related file
 	rm -f ./junit-report.xml checkstyle-report.xml ./coverage.xml ./profile.cov yamllint-checkstyle.xml
 
 ## Test:
+## don't parallelize testing as there are sideefects to some DB tests
 test: ## Run project tests
-ifeq ($(EXPORT_RESULT), true)
-	GO111MODULE=off go get -u github.com/jstemmer/go-junit-report
-	$(eval OUTPUT_OPTIONS = | tee /dev/tty | go-junit-report -set-exit-code > junit-report.xml)
-endif
-	$(GOTEST) ./... $(OUTPUT_OPTIONS)
+	$(GOTEST) -p 1 ./...
 
 coverage: ## Run the tests of the project and export the coverage
 	$(GOTEST) -cover -covermode=count -coverprofile=profile.cov ./...

--- a/pkg/extractors/initialize.go
+++ b/pkg/extractors/initialize.go
@@ -27,7 +27,7 @@ func Initialize(appState *models.AppState) {
 	)
 	attach(
 		"TokenCountExtractor",
-		appState.Config.Extractors.Embeddings.Enabled,
+		true, // TokenCounter always operates
 		func() models.Extractor { return NewTokenCountExtractor() },
 	)
 }

--- a/pkg/memorystore/postgres.go
+++ b/pkg/memorystore/postgres.go
@@ -656,7 +656,7 @@ func getMessages(
 		}
 	}
 
-	// if we do have a summary, determine the date of the last message in the summary
+	// if we do have a summary, determine the index of the last message in the summary
 	var summaryPointIndex int64 = 0
 	if summary != nil {
 		summaryPointIndex, err = lastSummaryPointIndex(
@@ -717,7 +717,7 @@ func lastSummaryPointIndex(
 	configuredMessageWindow int,
 ) (int64, error) {
 	var messages []*PgMessageStore
-	// We need to retrieve twice as many messages as the configured message window to ensure we
+	// We need to retrieve X as many messages as the configured message window to ensure we
 	// get the last SummaryPoint, with some buffer in case the configured message window is
 	// increased.
 	qLimit := configuredMessageWindow * 5

--- a/pkg/memorystore/postgres.go
+++ b/pkg/memorystore/postgres.go
@@ -348,6 +348,7 @@ func searchMessages(
 		ColumnExpr("m.role AS message__role").
 		ColumnExpr("m.content AS message__content").
 		ColumnExpr("m.metadata AS message__metadata").
+		ColumnExpr("m.token_count AS message__token_count").
 		ColumnExpr("1 - (embedding <=> ? ) AS dist", vector).
 		Where("m.session_id = ?", sessionID).
 		Order("dist DESC").


### PR DESCRIPTION
- add token count to search result
- check for token count in search tests
- clean up tests
- ensure tests don't run in parallel as there are side effects to some db operations.