### PR TITLE
Upgrade cosign version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@main
         with:
-          cosign-release: 'v2.0.2'
+          cosign-release: 'v3.0.3'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461


### PR DESCRIPTION
Getting error on cosign signing. Upgrading to latest release.

cosign-release: 'v3.0.3'