### PR TITLE
OpenAI Retry Client

### DIFF
--- a/cmd/zep/run.go
+++ b/cmd/zep/run.go
@@ -52,7 +52,7 @@ func run() {
 // and creates the OpenAI client
 func NewAppState(cfg *config.Config) *models.AppState {
 	appState := &models.AppState{
-		OpenAIClient: llms.CreateOpenAIClient(cfg),
+		OpenAIClient: llms.NewOpenAIRetryClient(cfg),
 		Config:       cfg,
 	}
 

--- a/pkg/extractors/embedder.go
+++ b/pkg/extractors/embedder.go
@@ -37,7 +37,7 @@ func (ee *EmbeddingExtractor) Extract(
 	for i, r := range messageEvent.Messages {
 		embeddingRecords[i] = models.Embeddings{
 			TextUUID:  r.UUID,
-			Embedding: (*embeddings)[i].Embedding,
+			Embedding: embeddings[i].Embedding,
 		}
 	}
 	err = appState.MemoryStore.PutMessageVectors(

--- a/pkg/extractors/embedder_test.go
+++ b/pkg/extractors/embedder_test.go
@@ -28,7 +28,7 @@ func TestEmbeddingExtractor_Extract(t *testing.T) {
 	store, err := memorystore.NewPostgresMemoryStore(appState, db)
 	assert.NoError(t, err)
 	appState.MemoryStore = store
-	appState.OpenAIClient = llms.CreateOpenAIClient(cfg)
+	appState.OpenAIClient = llms.NewOpenAIRetryClient(cfg)
 
 	sessionID, err := test.GenerateRandomSessionID(16)
 	assert.NoError(t, err)
@@ -64,7 +64,7 @@ func TestEmbeddingExtractor_Extract(t *testing.T) {
 		expectedEmbeddingRecords[i] = models.Embeddings{
 			TextUUID:  r.UUID,
 			Text:      r.Content,
-			Embedding: (*embeddings)[i].Embedding,
+			Embedding: embeddings[i].Embedding,
 		}
 	}
 

--- a/pkg/extractors/summarizer_test.go
+++ b/pkg/extractors/summarizer_test.go
@@ -27,7 +27,7 @@ func TestSummarize(t *testing.T) {
 	store, err := memorystore.NewPostgresMemoryStore(appState, db)
 	assert.NoError(t, err)
 
-	appState.OpenAIClient = llms.CreateOpenAIClient(cfg)
+	appState.OpenAIClient = llms.NewOpenAIRetryClient(cfg)
 	appState.MemoryStore = store
 
 	windowSize := 10

--- a/pkg/llms/embeddings_openai_test.go
+++ b/pkg/llms/embeddings_openai_test.go
@@ -15,7 +15,7 @@ func TestEmbedMessages(t *testing.T) {
 	cfg := test.NewTestConfig()
 
 	appState := &models.AppState{Config: cfg}
-	appState.OpenAIClient = CreateOpenAIClient(cfg)
+	appState.OpenAIClient = NewOpenAIRetryClient(cfg)
 
 	vectorLength := 1536
 
@@ -27,10 +27,10 @@ func TestEmbedMessages(t *testing.T) {
 	embeddings, err := EmbedMessages(ctx, appState, messageContents)
 	assert.NoError(t, err)
 	assert.NotNil(t, embeddings)
-	assert.Len(t, *embeddings, 2)
+	assert.Len(t, embeddings, 2)
 
 	// Check if the embeddings are of the correct length
-	for _, embedding := range *embeddings {
+	for _, embedding := range embeddings {
 		assert.Len(t, embedding.Embedding, int(vectorLength))
 	}
 }

--- a/pkg/llms/openai_retry_client.go
+++ b/pkg/llms/openai_retry_client.go
@@ -1,0 +1,1 @@
+package llms

--- a/pkg/llms/openai_retry_client.go
+++ b/pkg/llms/openai_retry_client.go
@@ -1,1 +1,0 @@
-package llms

--- a/pkg/llms/openairetryclient/client.go
+++ b/pkg/llms/openairetryclient/client.go
@@ -1,0 +1,98 @@
+package openairetryclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/getzep/zep/internal"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/sashabaranov/go-openai"
+)
+
+var log = internal.GetLogger()
+
+type OpenAIRetryClient struct {
+	openai.Client
+	Config struct {
+		Timeout     time.Duration
+		MaxAttempts uint
+	}
+}
+
+func (c *OpenAIRetryClient) CreateChatCompletionWithRetry(
+	ctx context.Context,
+	request openai.ChatCompletionRequest,
+) (*openai.ChatCompletionResponse, error) {
+	fn := func(ctx context.Context, arg interface{}) (interface{}, error) {
+		req := arg.(openai.ChatCompletionRequest)
+		return c.CreateChatCompletion(ctx, req)
+	}
+
+	result, err := c.retryFunction(ctx, c.Config.Timeout, c.Config.MaxAttempts, fn, request)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected response from OpenAI API: %w", err)
+	}
+
+	response, ok := result.(openai.ChatCompletionResponse)
+	if !ok {
+		return nil, errors.New(
+			"unexpected type returned from openai client CreateChatCompletion",
+		)
+	}
+	return &response, nil
+}
+
+func (c *OpenAIRetryClient) CreateEmbeddingsWithRetry(
+	ctx context.Context,
+	request openai.EmbeddingRequest,
+) (*openai.EmbeddingResponse, error) {
+	fn := func(ctx context.Context, arg interface{}) (interface{}, error) {
+		req := arg.(openai.EmbeddingRequest)
+		return c.CreateEmbeddings(ctx, req)
+	}
+
+	result, err := c.retryFunction(ctx, c.Config.Timeout, c.Config.MaxAttempts, fn, request)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected response from OpenAI API: %w", err)
+	}
+
+	response, ok := result.(openai.EmbeddingResponse)
+	if !ok {
+		return nil, errors.New("unexpected type returned from openai client CreateEmbeddings")
+	}
+	return &response, nil
+}
+
+func (c *OpenAIRetryClient) retryFunction(
+	ctx context.Context,
+	timeout time.Duration,
+	maxAttempts uint,
+	fn func(context.Context, interface{}) (interface{}, error),
+	arg interface{}) (interface{}, error) {
+	var result interface{}
+	var err error
+	retryCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	err = retry.Do(
+		func() error {
+			result, err = fn(retryCtx, arg)
+			return err
+		},
+		retry.Attempts(maxAttempts),
+		retry.Context(retryCtx),
+		retry.DelayType(retry.BackOffDelay),
+		retry.OnRetry(func(n uint, err error) {
+			log.Warningf("Retrying function attempt #%d: %s\n", n, err)
+		}),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/pkg/llms/openairetryclient/client.go
+++ b/pkg/llms/openairetryclient/client.go
@@ -86,7 +86,7 @@ func (c *OpenAIRetryClient) retryFunction(
 		retry.Context(retryCtx),
 		retry.DelayType(retry.BackOffDelay),
 		retry.OnRetry(func(n uint, err error) {
-			log.Warningf("Retrying function attempt #%d: %s\n", n, err)
+			log.Warningf("retrying function attempt #%d: %s\n", n, err)
 		}),
 	)
 

--- a/pkg/memorystore/postgres_search.go
+++ b/pkg/memorystore/postgres_search.go
@@ -42,7 +42,7 @@ func searchMessages(
 	if err != nil {
 		return nil, NewStorageError("failed to embed query", err)
 	}
-	vector := pgvector.NewVector((*e)[0].Embedding)
+	vector := pgvector.NewVector(e[0].Embedding)
 
 	var results []models.SearchResult
 	err = db.NewSelect().

--- a/pkg/memorystore/postgres_test.go
+++ b/pkg/memorystore/postgres_test.go
@@ -47,7 +47,7 @@ func setup() {
 	cfg := test.NewTestConfig()
 
 	appState = &models.AppState{}
-	appState.OpenAIClient = llms.CreateOpenAIClient(cfg)
+	appState.OpenAIClient = llms.NewOpenAIRetryClient(cfg)
 	appState.Config = cfg
 	store, err := NewPostgresMemoryStore(appState, testDB)
 	if err != nil {

--- a/pkg/models/appstate.go
+++ b/pkg/models/appstate.go
@@ -2,13 +2,13 @@ package models
 
 import (
 	"github.com/getzep/zep/config"
-	"github.com/sashabaranov/go-openai"
+	openairetryclient "github.com/getzep/zep/pkg/llms/openairetryclient"
 )
 
 // AppState is a struct that holds the state of the application
 // Use cmd.NewAppState to create a new instance
 type AppState struct {
-	OpenAIClient *openai.Client
+	OpenAIClient *openairetryclient.OpenAIRetryClient
 	MemoryStore  MemoryStore[any]
 	Config       *config.Config
 }


### PR DESCRIPTION
- Move OpenAI retry logic into a new wrapper for the OpenAI client
- Create generic retryFunction method for wrapper, easily allowing additional methods to be wrapped
- Make clear the source of OpenAI errors - not in Zep, rather failed OpenAI API requests.