### PR TITLE
feat: Use a custom URL for OpenAI API endpoints

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 llm:
-  # gpt-3.5-turbo, gpt-3.5-turbo-0613, or gpt-4, gpt-4-0613
+  # gpt-3.5-turbo or gpt-4
   model: "gpt-3.5-turbo"
   # Only used for Azure OpenAI API
   azure_openai_endpoint:

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 llm:
   # gpt-3.5-turbo or gpt-4
+  openai_endpoint:
   model: "gpt-3.5-turbo"
   azure_openai_endpoint:
   openai_org_id:

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,10 @@
 llm:
-  # gpt-3.5-turbo or gpt-4
-  openai_endpoint:
+  # gpt-3.5-turbo, gpt-3.5-turbo-0613, or gpt-4, gpt-4-0613
   model: "gpt-3.5-turbo"
+  # Only used for Azure OpenAI API
   azure_openai_endpoint:
+  # Use only with an alternate OpenAI-compatible API endpoint
+  openai_endpoint:
   openai_org_id:
 nlp:
   server_url: "http://localhost:8080"

--- a/config/models.go
+++ b/config/models.go
@@ -24,6 +24,7 @@ type LLM struct {
 	// OpenAIAPIKey is loaded from ENV not config file.
 	OpenAIAPIKey        string `mapstructure:"openai_api_key"`
 	AzureOpenAIEndpoint string `mapstructure:"azure_openai_endpoint"`
+	OpenAIEndpoint string `mapstructure:"openai_endpoint"`
 	OpenAIOrgID         string `mapstructure:"openai_org_id"`
 }
 

--- a/config/models.go
+++ b/config/models.go
@@ -24,7 +24,7 @@ type LLM struct {
 	// OpenAIAPIKey is loaded from ENV not config file.
 	OpenAIAPIKey        string `mapstructure:"openai_api_key"`
 	AzureOpenAIEndpoint string `mapstructure:"azure_openai_endpoint"`
-	OpenAIEndpoint string `mapstructure:"openai_endpoint"`
+	OpenAIEndpoint      string `mapstructure:"openai_endpoint"`
 	OpenAIOrgID         string `mapstructure:"openai_org_id"`
 }
 

--- a/http-client.private.env.json
+++ b/http-client.private.env.json
@@ -1,0 +1,5 @@
+{
+  "dev": {
+    "host": "http://localhost:8000"
+  }
+}

--- a/pkg/llms/llm_base.go
+++ b/pkg/llms/llm_base.go
@@ -24,13 +24,15 @@ func NewLLMError(message string, originalError error) *LLMError {
 }
 
 var MaxLLMTokensMap = map[string]int{
-	"gpt-3.5-turbo":     4096,
-	"gpt-3.5-turbo0301": 8192,
-	"gpt-4":             8192,
+	"gpt-3.5-turbo":      4096,
+	"gpt-3.5-turbo-0613": 4096,
+	"gpt-4":              8192,
+	"gpt-4-0613":         8192,
 }
 
 var ValidLLMMap = map[string]bool{
-	"gpt-3.5-turbo":     true,
-	"gpt-3.5-turbo0301": true,
-	"gpt-4":             true,
+	"gpt-3.5-turbo":      true,
+	"gpt-3.5-turbo-0613": true,
+	"gpt-4":              true,
+	"gpt-4-0613":         true,
 }

--- a/pkg/llms/llm_base.go
+++ b/pkg/llms/llm_base.go
@@ -24,15 +24,11 @@ func NewLLMError(message string, originalError error) *LLMError {
 }
 
 var MaxLLMTokensMap = map[string]int{
-	"gpt-3.5-turbo":      4096,
-	"gpt-3.5-turbo-0613": 4096,
-	"gpt-4":              8192,
-	"gpt-4-0613":         8192,
+	"gpt-3.5-turbo": 4096,
+	"gpt-4":         8192,
 }
 
 var ValidLLMMap = map[string]bool{
-	"gpt-3.5-turbo":      true,
-	"gpt-3.5-turbo-0613": true,
-	"gpt-4":              true,
-	"gpt-4-0613":         true,
+	"gpt-3.5-turbo": true,
+	"gpt-4":         true,
 }

--- a/pkg/llms/llm_openai.go
+++ b/pkg/llms/llm_openai.go
@@ -38,6 +38,13 @@ func NewOpenAIRetryClient(cfg *config.Config) *openairetryclient.OpenAIRetryClie
 		openAIClientConfig.OrgID = cfg.LLM.OpenAIOrgID
 	}
 
+	// Support a local LLM that utilizes OpenAI style endpoints
+	openAIEndpoint := cfg.LLM.OpenAIEndpoint
+	if localEndpoint != "" {
+		openAIClientConfig = openai.DefaultConfig(apiKey)
+		openAIClientConfig.BaseURL = openAIEndpoint
+	}
+
 	client := openai.NewClientWithConfig(openAIClientConfig)
 
 	return &openairetryclient.OpenAIRetryClient{

--- a/pkg/llms/llm_openai.go
+++ b/pkg/llms/llm_openai.go
@@ -24,29 +24,38 @@ var (
 )
 
 func NewOpenAIRetryClient(cfg *config.Config) *openairetryclient.OpenAIRetryClient {
+	// Retrieve the OpenAIAPIKey from configuration
 	apiKey := cfg.LLM.OpenAIAPIKey
+	// If the key is not set, log a fatal error and exit
 	if apiKey == "" {
 		log.Fatal(OpenAIAPIKeyNotSetError)
 	}
+	if cfg.LLM.AzureOpenAIEndpoint != "" && cfg.LLM.OpenAIEndpoint != "" {
+		log.Fatal("only one of AzureOpenAIEndpoint or OpenAIEndpoint can be set")
+	}
 
-	var openAIClientConfig openai.ClientConfig
-	azureEndpoint := cfg.LLM.AzureOpenAIEndpoint
-	if azureEndpoint != "" {
-		openAIClientConfig = openai.DefaultAzureConfig(apiKey, azureEndpoint)
-	} else {
-		openAIClientConfig = openai.DefaultConfig(apiKey)
+	// Initiate the openAIClientConfig with the default configuration
+	openAIClientConfig := openai.DefaultConfig(apiKey)
+
+	switch {
+	case cfg.LLM.AzureOpenAIEndpoint != "":
+		// Check configuration for AzureOpenAIEndpoint; if it's set, use the DefaultAzureConfig
+		// and provided endpoint URL
+		openAIClientConfig = openai.DefaultAzureConfig(apiKey, cfg.LLM.AzureOpenAIEndpoint)
+	case cfg.LLM.OpenAIEndpoint != "":
+		// If an alternate OpenAI-compatible endpoint URL is set, use this as the base URL for requests
+		openAIClientConfig.BaseURL = cfg.LLM.OpenAIEndpoint
+	default:
+		// If no specific endpoints are defined, use the default configuration with the OpenAIOrgID
+		// This optional and may just be an empty string
 		openAIClientConfig.OrgID = cfg.LLM.OpenAIOrgID
 	}
 
-	// Support a local LLM that utilizes OpenAI style endpoints
-	openAIEndpoint := cfg.LLM.OpenAIEndpoint
-	if openAIEndpoint != "" {
-		openAIClientConfig = openai.DefaultConfig(apiKey)
-		openAIClientConfig.BaseURL = openAIEndpoint
-	}
-
+	// Create a new client instance with the final openAIClientConfig
 	client := openai.NewClientWithConfig(openAIClientConfig)
 
+	// Return a new retry client. This client contains a pre-configured OpenAI client
+	// and additional retry logic (timeout duration and maximum number of attempts)
 	return &openairetryclient.OpenAIRetryClient{
 		Client: *client,
 		Config: struct {

--- a/pkg/llms/llm_openai.go
+++ b/pkg/llms/llm_openai.go
@@ -40,7 +40,7 @@ func NewOpenAIRetryClient(cfg *config.Config) *openairetryclient.OpenAIRetryClie
 
 	// Support a local LLM that utilizes OpenAI style endpoints
 	openAIEndpoint := cfg.LLM.OpenAIEndpoint
-	if localEndpoint != "" {
+	if openAIEndpoint != "" {
 		openAIClientConfig = openai.DefaultConfig(apiKey)
 		openAIClientConfig.BaseURL = openAIEndpoint
 	}

--- a/pkg/llms/llm_openai_test.go
+++ b/pkg/llms/llm_openai_test.go
@@ -1,0 +1,1 @@
+package llms

--- a/pkg/llms/llm_openai_test.go
+++ b/pkg/llms/llm_openai_test.go
@@ -1,1 +1,57 @@
 package llms
+
+import (
+	"testing"
+	"time"
+
+	"github.com/getzep/zep/config"
+	"github.com/getzep/zep/pkg/llms/openairetryclient"
+	"github.com/stretchr/testify/assert"
+)
+
+// Minimal set of test cases. We'd need to refactor the error states to not immediately
+// exit the program to test more thoroughly.
+
+// Test with a valid Azure configuration.
+func TestNewOpenAIRetryClient_ValidAzureConfig(t *testing.T) {
+	cfg := &config.Config{
+		LLM: config.LLM{
+			OpenAIAPIKey:        "testKey",
+			AzureOpenAIEndpoint: "azureEndpoint",
+		},
+	}
+
+	client := NewOpenAIRetryClient(cfg)
+	assert.IsType(t, &openairetryclient.OpenAIRetryClient{}, client)
+	assert.IsType(t, time.Duration(0), client.Config.Timeout)
+	assert.Equal(t, uint(5), client.Config.MaxAttempts)
+}
+
+// Test with a valid configuration.
+func TestNewOpenAIRetryClient_ValidConfig(t *testing.T) {
+	cfg := &config.Config{
+		LLM: config.LLM{
+			OpenAIAPIKey: "testKey",
+		},
+	}
+
+	client := NewOpenAIRetryClient(cfg)
+	assert.IsType(t, &openairetryclient.OpenAIRetryClient{}, client)
+	assert.IsType(t, time.Duration(0), client.Config.Timeout)
+	assert.Equal(t, uint(5), client.Config.MaxAttempts)
+}
+
+// Test with a valid configuration.
+func TestNewOpenAIRetryClient_ValidConfigCustomEndpoint(t *testing.T) {
+	cfg := &config.Config{
+		LLM: config.LLM{
+			OpenAIAPIKey:   "testKey",
+			OpenAIEndpoint: "https://api.openai.com/v1",
+		},
+	}
+
+	client := NewOpenAIRetryClient(cfg)
+	assert.IsType(t, &openairetryclient.OpenAIRetryClient{}, client)
+	assert.IsType(t, time.Duration(0), client.Config.Timeout)
+	assert.Equal(t, uint(5), client.Config.MaxAttempts)
+}


### PR DESCRIPTION
## Description
This PR allows Zep to [pass a custom URL for OpenAI to the go-openai library](https://github.com/sashabaranov/go-openai/blob/619ad717353d8b9d5f4d9049b1ce1b168c5851b6/config.go#L30C4-L30C4).

This enables users to do things such as running their own open source LLMs through drop-in replacement APIs for OpenAI. I was motivated to create functionality to test out long term memory locally while developing a product and avoid racking up an OpenAI bill.

## How To Test

### 1) Set up a drop-in server

I was able to test this by running a local model via [llama-cpp-python's server functionality](https://llama-cpp-python.readthedocs.io/en/latest/).

### 2) Config Zep to connect to local LLM

1. Update `config.yaml` to specify the address for that server (e.g. `http://localhost:8888/v1`). 
2. Updated your config to also enable local embeddings as you will not be using OpenAI's. I ran Zep through docker to test this functionality, and I had to follow the instructions here: https://www.getzep.com/introducing-open-source-embeddings/
3. Create a `.env` file and add something like this: `ZEP_OPENAI_API_KEY=fakeaikey`
4. Build the docker image with `docker build -t zep .` 
5. Update the `docker-compose.yaml` and modify the following line:
```yaml
zep:
    image: zep:latest
```

### 3) Run Zep

Finally I ran `docker-compose up` and was able to connect to my locally running LLM server.

Note that if you choose to run an OpenAI drop-in server in a docker container you might consider connecting the networks together. To do this use a command like the following: `docker network connect zep_zep-network llama_server`. Then in your config you would use `openai_endpoint: "http://llama_server:8000/v1"`