### PR TITLE
BugFix: failure to acquire lock; nil pointer dereference

### DIFF
--- a/pkg/extractors/intent_extractor.go
+++ b/pkg/extractors/intent_extractor.go
@@ -100,6 +100,11 @@ func (ee *IntentExtractor) processMessage(
 	intentContent := resp.Choices[0].Message.Content
 	intentContent = strings.TrimPrefix(intentContent, "Intent: ")
 
+	// if we don't have an intent, just return
+	if intentContent == "" {
+		return
+	}
+
 	// Put the intent into the message metadata
 	intentResponse := []models.Message{
 		{

--- a/pkg/extractors/ner.go
+++ b/pkg/extractors/ner.go
@@ -52,6 +52,10 @@ func (ee *EntityExtractor) Extract(
 		}
 		entityList := extractEntities(r.Entities)
 
+		if len(entityList) == 0 {
+			continue
+		}
+
 		messages[i] = models.Message{
 			UUID: msgUUID,
 			Metadata: map[string]interface{}{

--- a/pkg/memorystore/postgres_message_metadata.go
+++ b/pkg/memorystore/postgres_message_metadata.go
@@ -45,11 +45,11 @@ func putMessageMetadata(
 
 	for i := range messages {
 		returnedMessage, err := putMessageMetadataTx(ctx, tx, sessionID, &messages[i])
-		messages[i] = *returnedMessage
 		if err != nil {
 			// defer will roll back the transaction
 			return nil, NewStorageError("failed to put message metadata", err)
 		}
+		messages[i] = *returnedMessage
 	}
 
 	// if the calling function passed in a transaction, don't commit here

--- a/pkg/memorystore/postgres_message_metadata.go
+++ b/pkg/memorystore/postgres_message_metadata.go
@@ -44,6 +44,9 @@ func putMessageMetadata(
 	}
 
 	for i := range messages {
+		if len(messages[i].Metadata) == 0 {
+			continue
+		}
 		returnedMessage, err := putMessageMetadataTx(ctx, tx, sessionID, &messages[i])
 		if err != nil {
 			// defer will roll back the transaction

--- a/pkg/memorystore/postgres_messages.go
+++ b/pkg/memorystore/postgres_messages.go
@@ -65,17 +65,17 @@ func putMessages(
 			messages[i].UUID = pgMessages[i].UUID
 		}
 
-		// insert/update message metadata. isPrivileged is false because we are
-		// most likely being called by the PutMemory handler.
-		messages, err = putMessageMetadata(ctx, tx, sessionID, messages, false)
-		if err != nil {
-			return err
-		}
-
 		return nil
 	})
 	if err != nil {
 		return nil, NewStorageError("failed to put messages", err)
+	}
+
+	// insert/update message metadata. isPrivileged is false because we are
+	// most likely being called by the PutMemory handler.
+	messages, err = putMessageMetadata(ctx, db, sessionID, messages, false)
+	if err != nil {
+		return nil, err
 	}
 
 	log.Debugf("putMessages completed for session %s with %d messages", sessionID, len(messages))

--- a/pkg/memorystore/postgres_session_test.go
+++ b/pkg/memorystore/postgres_session_test.go
@@ -192,7 +192,7 @@ func TestPutSessionMetadata(t *testing.T) {
 			sessionID:        sessionID,
 			metadata:         map[string]interface{}{},
 			privileged:       true,
-			expectedMetadata: map[string]interface{}{},
+			expectedMetadata: nil,
 		},
 		{
 			name:      "Update metadata",


### PR DESCRIPTION
Address metadata update deadlocks and an unfortunate placement of a func error check after a pointer dereference and not before.

- For PutMessage, move message metadata upsert out of message upsert TX
- only persist session metadata when metadata is present - in multiple places
- check for error before dereferencing after call to `putMessageMetadataTx`
