### PR TITLE
bugfix/embedder-panics

### DIFF
--- a/pkg/store/postgres/documentstore.go
+++ b/pkg/store/postgres/documentstore.go
@@ -385,7 +385,7 @@ func (ds *DocumentStore) documentEmbeddingUpdater(
 			docs := documentsFromEmbeddingUpdates(updates)
 			err := dbCollection.UpdateDocuments(ctx, docs)
 			if err != nil {
-				return fmt.Errorf("failed to update document embedding: %w", err)
+				log.Errorf("failed to update document embedding: %s", err)
 			}
 
 			log.Debugf("Document embedding updater updated %d documents", len(updates))

--- a/pkg/store/postgres/documentstore_test.go
+++ b/pkg/store/postgres/documentstore_test.go
@@ -1,0 +1,47 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/getzep/zep/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocumentsFromEmbeddingUpdates(t *testing.T) {
+	uuid1 := uuid.New()
+	uuid2 := uuid.New()
+
+	updates := []models.DocEmbeddingUpdate{
+		{
+			UUID:      uuid1,
+			Embedding: []float32{0.1, 0.2, 0.3},
+		},
+		{
+			UUID:      uuid2,
+			Embedding: []float32{0.4, 0.5, 0.6},
+		},
+	}
+
+	expectedDocs := []models.Document{
+		{
+			DocumentBase: models.DocumentBase{
+				UUID:       uuid1,
+				IsEmbedded: true,
+			},
+			Embedding: []float32{0.1, 0.2, 0.3},
+		},
+		{
+			DocumentBase: models.DocumentBase{
+				UUID:       uuid2,
+				IsEmbedded: true,
+			},
+			Embedding: []float32{0.4, 0.5, 0.6},
+		},
+	}
+
+	docs := documentsFromEmbeddingUpdates(updates)
+
+	assert.Equal(t, expectedDocs, docs)
+}


### PR DESCRIPTION
In documentEmbeddingUpdater, log DB write errors, don't return. Return closes the channel and results in panic for subsequent embedding updates.