### PR TITLE
fix/AuzreOpenAI embeddings and LLM deployment name

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,15 @@ llm:
   ## OpenAI-specific settings
   # Only used for Azure OpenAI API
   azure_openai_endpoint:
+  # for Azure OpenAI API deployment, the model may be deployed with custom deployment names
+  # set the deployment names if you encounter in logs HTTP 404 errors:
+  #   "The API deployment for this resource does not exist."
+  azure_openai:
+  # llm.model name is used as deployment name as reasonable default if not set
+  # assuming base model is deployed with deployment name matching model name
+  #   llm_deployment: "gpt-3.5-turbo-customname"
+  # embeddings deployment is required when Zep is configured to use OpenAI embeddings
+  #   embedding_deployment: "text-embedding-ada-002-customname"
   # Use only with an alternate OpenAI-compatible API endpoint
   openai_endpoint:
   openai_org_id:

--- a/config/models.go
+++ b/config/models.go
@@ -20,13 +20,19 @@ type StoreConfig struct {
 }
 
 type LLM struct {
-	Service             string `mapstructure:"service"`
-	Model               string `mapstructure:"model"`
-	AnthropicAPIKey     string `mapstructure:"anthropic_api_key"`
-	OpenAIAPIKey        string `mapstructure:"openai_api_key"`
-	AzureOpenAIEndpoint string `mapstructure:"azure_openai_endpoint"`
-	OpenAIEndpoint      string `mapstructure:"openai_endpoint"`
-	OpenAIOrgID         string `mapstructure:"openai_org_id"`
+	Service             string            `mapstructure:"service"`
+	Model               string            `mapstructure:"model"`
+	AnthropicAPIKey     string            `mapstructure:"anthropic_api_key"`
+	OpenAIAPIKey        string            `mapstructure:"openai_api_key"`
+	AzureOpenAIEndpoint string            `mapstructure:"azure_openai_endpoint"`
+	AzureOpenAIModel    AzureOpenAIConfig `mapstructure:"azure_openai"`
+	OpenAIEndpoint      string            `mapstructure:"openai_endpoint"`
+	OpenAIOrgID         string            `mapstructure:"openai_org_id"`
+}
+
+type AzureOpenAIConfig struct {
+	LLMDeployment       string `mapstructure:"llm_deployment"`
+	EmbeddingDeployment string `mapstructure:"embedding_deployment"`
 }
 
 type NLP struct {

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	gonum.org/v1/gonum v0.13.0
 )
 
-require github.com/tmc/langchaingo v0.0.0-20230811231558-fd8b7f099537 // indirect
+require github.com/tmc/langchaingo v0.0.0-20230823213549-ededff76a967 // indirect
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -306,6 +306,8 @@ github.com/swaggo/swag/v2 v2.0.0-rc3 h1:cIkbddJ9ftgRenDaDzyvg+2TUDLFCDffZ40yZE1r
 github.com/swaggo/swag/v2 v2.0.0-rc3/go.mod h1:mfTZJmxpXWA3JQ9V381+cRlutUCo7OXd/VyIRcMhByc=
 github.com/tmc/langchaingo v0.0.0-20230811231558-fd8b7f099537 h1:vkeNjlW+0Xiw2XizMHoQuLG8pg6AN1hU8zJuMV9GQBc=
 github.com/tmc/langchaingo v0.0.0-20230811231558-fd8b7f099537/go.mod h1:8T+nNIGBr3nYQEYFmF/YaT8t8YTKLvFYZBuVZOAYn5E=
+github.com/tmc/langchaingo v0.0.0-20230823213549-ededff76a967 h1:Zj1OLD2BYG8h0oQ40mlyyOGo9hNp21ebgy0HClbKK7w=
+github.com/tmc/langchaingo v0.0.0-20230823213549-ededff76a967/go.mod h1:jwblKo3Lqe8r7UU9G+iQv2T/k33bLptDK+EabbC0zqk=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
 github.com/uptrace/bun v0.3.9/go.mod h1:aL6D9vPw8DXaTQTwGrEPtUderBYXx7ShUmPfnxnqscw=

--- a/pkg/llms/llm_base.go
+++ b/pkg/llms/llm_base.go
@@ -22,6 +22,27 @@ var log = internal.GetLogger()
 func NewLLMClient(ctx context.Context, cfg *config.Config) (models.ZepLLM, error) {
 	switch cfg.LLM.Service {
 	case "openai":
+		// Azure OpenAI model names can't be validated by any hard-coded models
+		// list as it is configured by custom deployment name that may or may not match the model name.
+		// We will copy the Model name value down to AzureOpenAI LLM Deployment
+		// to assume user deployed base model with matching deployment name as
+		// advised, but still support custom models or otherwise-named base
+		// model.
+		if cfg.LLM.AzureOpenAIEndpoint != "" {
+			if cfg.LLM.AzureOpenAIModel.LLMDeployment != "" {
+				cfg.LLM.Model = cfg.LLM.AzureOpenAIModel.LLMDeployment
+			}
+			if cfg.LLM.Model == "" {
+				return nil, fmt.Errorf("invalid llm deployment for %s, deployment name is required", cfg.LLM.Service)
+			}
+
+			// EmbeddingsDeployment is only required if Zep is also configured to use
+			// OpenAI embeddings for document or message extractors
+			if cfg.LLM.AzureOpenAIModel.EmbeddingDeployment == "" && useOpenAIEmbeddings(cfg) {
+				return nil, fmt.Errorf("invalid embeddings deployment for %s, deployment name is required", cfg.LLM.Service)
+			}
+			return NewOpenAILLM(ctx, cfg)
+		}
 		if _, ok := ValidOpenAILLMs[cfg.LLM.Model]; !ok {
 			return nil, fmt.Errorf(
 				"invalid llm model \"%s\" for %s",
@@ -109,4 +130,16 @@ func NewRetryableHTTPClient() *retryablehttp.Client {
 	retryableHttpClient.Logger = log
 
 	return retryableHttpClient
+}
+
+// useOpenAIEmbeddings is true if OpenAI embeddings are enabled
+func useOpenAIEmbeddings(cfg *config.Config) bool {
+	switch {
+	case cfg.Extractors.Messages.Embeddings.Enabled:
+		return cfg.Extractors.Messages.Embeddings.Service == "openai"
+	case cfg.Extractors.Documents.Embeddings.Enabled:
+		return cfg.Extractors.Documents.Embeddings.Service == "openai"
+	}
+
+	return false
 }

--- a/pkg/llms/llm_openai.go
+++ b/pkg/llms/llm_openai.go
@@ -138,6 +138,12 @@ func (zllm *ZepOpenAILLM) configureClient(cfg *config.Config) ([]openai.Option, 
 			openai.WithAPIType(openai.APITypeAzure),
 			openai.WithBaseURL(cfg.LLM.AzureOpenAIEndpoint),
 		)
+		if cfg.LLM.AzureOpenAIModel.EmbeddingDeployment != "" {
+			options = append(
+				options,
+				openai.WithEmbeddingModel(cfg.LLM.AzureOpenAIModel.EmbeddingDeployment),
+			)
+		}
 	case cfg.LLM.OpenAIEndpoint != "":
 		// If an alternate OpenAI-compatible endpoint URL is set, use this as the base URL for requests
 		options = append(

--- a/pkg/llms/llm_openai_test.go
+++ b/pkg/llms/llm_openai_test.go
@@ -65,6 +65,27 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 		}
 	})
 
+	t.Run("Test with AzureOpenAIEmbeddingModel", func(t *testing.T) {
+		cfg := &config.Config{
+			LLM: config.LLM{
+				OpenAIAPIKey:        "test-key",
+				AzureOpenAIEndpoint: "https://azure.openai.com",
+				AzureOpenAIModel: config.AzureOpenAIConfig{
+					EmbeddingDeployment: "test-deployment",
+				},
+			},
+		}
+
+		options, err := zllm.configureClient(cfg)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if len(options) != 6 {
+			t.Errorf("Expected 6 options, got %d", len(options))
+		}
+	})
+
 	t.Run("Test with OpenAIEndpoint", func(t *testing.T) {
 		cfg := &config.Config{
 			LLM: config.LLM{


### PR DESCRIPTION
solves "The API deployment for this resource does not exist" for LLM and embedding models deployed in Azure OpenAI by deployment name supported in tmc/langchaingo#253

We can't Validate OpenAI LLM model names from hard-coded list in Azure because the model name parameter in API request is a deployment name, and while Microsoft advises us to use the model name as deployment name, we did not listen, and I didn't want to coordinate redeploying with a different name on a Friday.

This also permits use of customized models that can be deployed in Azure side-by-side base models as added benefit so I think it was worthwhile.