### PR TITLE
fix: Issue #176, overwriting session metadata with nil"

### DIFF
--- a/pkg/store/postgres/session.go
+++ b/pkg/store/postgres/session.go
@@ -149,11 +149,15 @@ func (dao *SessionDAO) updateSession(
 		Metadata:  session.Metadata,
 		DeletedAt: time.Time{}, // Intentionally overwrite soft-delete with zero value
 	}
+	var columns = []string{"deleted_at"}
+	if session.Metadata != nil {
+		columns = append(columns, "metadata")
+	}
 	r, err := dao.db.NewUpdate().
 		Model(&sessionDB).
 		// intentionally overwrite the deleted_at field, undeleting the session
 		// if the session exists and is deleted
-		Column("metadata", "deleted_at").
+		Column(columns...).
 		// use WhereAllWithDeleted to update soft-deleted sessions
 		WhereAllWithDeleted().
 		Where("session_id = ?", session.SessionID).

--- a/pkg/store/postgres/session_test.go
+++ b/pkg/store/postgres/session_test.go
@@ -155,6 +155,38 @@ func TestSessionDAO_Update(t *testing.T) {
 	assert.Equal(t, updateSession.Metadata, updatedSession.Metadata)
 }
 
+func TestSessionDAO_UpdateWithNilMetadata(t *testing.T) {
+	// Initialize SessionDAO
+	dao := NewSessionDAO(testDB)
+
+	// Create a test session
+	sessionID, err := testutils.GenerateRandomSessionID(16)
+	assert.NoError(t, err, "GenerateRandomSessionID should not return an error")
+
+	session := &models.CreateSessionRequest{
+		SessionID: sessionID,
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+	}
+	createdSession, err := dao.Create(testCtx, session)
+	assert.NoError(t, err)
+
+	// Update the session
+	updateSession := &models.UpdateSessionRequest{
+		SessionID: sessionID,
+	}
+	updatedSession, err := dao.Update(testCtx, updateSession, false)
+	assert.NoError(t, err)
+
+	// Verify the update hasn't nilled out the metadata
+	assert.Equal(t, createdSession.UUID, updatedSession.UUID)
+	assert.Equal(t, createdSession.ID, updatedSession.ID)
+	assert.Equal(t, createdSession.SessionID, updatedSession.SessionID)
+	assert.Equal(t, createdSession.UserID, updatedSession.UserID)
+	assert.Equal(t, session.Metadata, updatedSession.Metadata) // Metadata should not be nil
+}
+
 func TestSessionDAO_Delete(t *testing.T) {
 	// Initialize SessionDAO
 	dao := NewSessionDAO(testDB)


### PR DESCRIPTION
ref #176 

Changes to SessionDAO:
- metadata excluded from update column list if nil
- additional test for nil metadata on update