### PR TITLE
fix: index creation timeouts

### DIFF
--- a/pkg/store/postgres/document_search_test.go
+++ b/pkg/store/postgres/document_search_test.go
@@ -56,6 +56,8 @@ func TestDocumentSearchWithIndexEndToEnd(t *testing.T) {
 	err = vci.CreateIndex(context.Background(), true)
 	assert.NoError(t, err)
 
+	pollIndexCreation(documentStore, collectionName, ctx, t)
+
 	// Set Collection's IsIndexed flag to true
 	col, err := documentStore.GetCollection(ctx, vci.Collection.Name)
 	assert.NoError(t, err)


### PR DESCRIPTION
Index creation will sometimes timeout with large collections. This PR moves:
- index creation into a goroutine
- sets a 1 hour context timeout 
- logs start and stop index ops to INFO
- modifies unit tests as indexing is now async