### PR TITLE
improv: MaxRequestSize; Additional Document Collection tests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,8 @@ server:
   # Warning: The Web UI is not secured by authentication and should not be enabled if
   # Zep is exposed to the public internet.
   web_enabled: true
+  # The maximum size of a request body, in bytes. Defaults to 5MB.
+  max_request_size: 5242880
 auth:
   # Set to true to enable authentication
   required: false

--- a/config/models.go
+++ b/config/models.go
@@ -56,9 +56,10 @@ type AvailableIndexes struct {
 }
 
 type ServerConfig struct {
-	Host       string `mapstructure:"host"`
-	Port       int    `mapstructure:"port"`
-	WebEnabled bool   `mapstructure:"web_enabled"`
+	Host           string `mapstructure:"host"`
+	Port           int    `mapstructure:"port"`
+	WebEnabled     bool   `mapstructure:"web_enabled"`
+	MaxRequestSize int64  `mapstructure:"max_request_size"`
 }
 
 type LogConfig struct {

--- a/pkg/server/document_routes_test.go
+++ b/pkg/server/document_routes_test.go
@@ -1,0 +1,307 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/getzep/zep/pkg/models"
+	"github.com/getzep/zep/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO: Complete the tests
+
+func TestCreateCollectionRoute(t *testing.T) {
+	collectionName := testutils.GenerateRandomString(10)
+
+	autoEmbeded := false
+
+	// Create a collection
+	collection := &models.CreateDocumentCollectionRequest{
+		Name:        collectionName,
+		Description: "Test collection",
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+		EmbeddingDimensions: 128,
+		IsAutoEmbedded:      &autoEmbeded,
+	}
+
+	// Convert collection to JSON
+	collectionJSON, err := json.Marshal(collection)
+	assert.NoError(t, err)
+
+	// Create a request
+	req, err := http.NewRequest(
+		"POST",
+		testServer.URL+"/api/v1/collection/"+collectionName,
+		bytes.NewBuffer(collectionJSON),
+	)
+	assert.NoError(t, err)
+
+	// Create a client and do the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+
+	// Check the status code
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Get the newly created collection
+	rc, err := appState.DocumentStore.GetCollection(testCtx, collectionName)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, rc.UUID)
+	assert.Equal(t, rc.Name, strings.ToLower(collectionName))
+	assert.Equal(t, rc.Metadata["key"], "value")
+}
+
+func TestUpdateCollectionHandler(t *testing.T) {
+	collectionName := testutils.GenerateRandomString(10)
+
+	autoEmbeded := false
+	collectionCreateRequest := models.DocumentCollection{
+		Name:        collectionName,
+		Description: "Test collection",
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+		EmbeddingDimensions: 128,
+		IsAutoEmbedded:      autoEmbeded,
+	}
+
+	err := appState.DocumentStore.CreateCollection(testCtx, collectionCreateRequest)
+	assert.NoError(t, err)
+
+	// Update a collection
+	collection := &models.UpdateDocumentCollectionRequest{
+		Description: "Updated Test collection",
+		Metadata: map[string]interface{}{
+			"key": "updated value",
+		},
+	}
+
+	// Convert collection to JSON
+	collectionJSON, err := json.Marshal(collection)
+	assert.NoError(t, err)
+
+	// Create a request
+	req, err := http.NewRequest(
+		"PATCH",
+		testServer.URL+"/api/v1/collection/"+collectionName,
+		bytes.NewBuffer(collectionJSON),
+	)
+	assert.NoError(t, err)
+
+	// Create a client and do the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+
+	// Check the status code
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Get the updated collection
+	rc, err := appState.DocumentStore.GetCollection(testCtx, collectionName)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rc.Description, "Updated Test collection")
+	assert.Equal(t, rc.Metadata["key"], "updated value")
+}
+
+func TestDeleteCollectionHandler(t *testing.T) {
+	collectionName := testutils.GenerateRandomString(10)
+	// Create a collection
+	cr := models.DocumentCollection{
+		Name:        collectionName,
+		Description: "Test collection",
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+		EmbeddingDimensions: 128,
+		IsAutoEmbedded:      false,
+	}
+
+	err := appState.DocumentStore.CreateCollection(testCtx, cr)
+	assert.NoError(t, err)
+
+	// Delete the collection
+	req, err := http.NewRequest(
+		"DELETE",
+		testServer.URL+"/api/v1/collection/"+collectionName,
+		nil,
+	)
+	assert.NoError(t, err)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+
+	// Check the status code
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Try to get the deleted collection
+	_, err = appState.DocumentStore.GetCollection(testCtx, collectionName)
+	assert.ErrorAs(t, err, &models.ErrNotFound)
+}
+
+func TestGetCollectionHandler(t *testing.T) {
+	collectionName := testutils.GenerateRandomString(10)
+	// Create a collection
+	cr := models.DocumentCollection{
+		Name:        collectionName,
+		Description: "Test collection",
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+		EmbeddingDimensions: 128,
+		IsAutoEmbedded:      false,
+	}
+
+	err := appState.DocumentStore.CreateCollection(testCtx, cr)
+	assert.NoError(t, err)
+
+	// Get the collection
+	req, err := http.NewRequest(
+		"GET",
+		testServer.URL+"/api/v1/collection/"+collectionName,
+		nil,
+	)
+	assert.NoError(t, err)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+
+	// Check the status code
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Get the collection
+	rc, err := appState.DocumentStore.GetCollection(testCtx, collectionName)
+	assert.NoError(t, err)
+
+	assert.Equal(t, rc.Description, "Test collection")
+	assert.Equal(t, rc.Metadata["key"], "value")
+}
+
+func TestCreateDocumentsHandler(t *testing.T) {
+	collectionName := testutils.GenerateRandomString(10)
+	// Create a collection
+	cr := models.DocumentCollection{
+		Name:        collectionName,
+		Description: "Test collection",
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+		EmbeddingDimensions: 128,
+		IsAutoEmbedded:      true,
+	}
+
+	err := appState.DocumentStore.CreateCollection(testCtx, cr)
+	assert.NoError(t, err)
+
+	// Create documents
+	docs := []models.CreateDocumentRequest{
+		{
+			DocumentID: "doc1",
+			Content:    "This is a test document",
+			Metadata: map[string]interface{}{
+				"key": "value",
+			},
+		},
+		{
+			DocumentID: "doc2",
+			Content:    "This is another test document",
+			Metadata: map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+
+	j, err := json.Marshal(docs)
+	assert.NoError(t, err)
+
+	req, err := http.NewRequest(
+		"POST",
+		testServer.URL+"/api/v1/collection/"+collectionName+"/document",
+		bytes.NewBuffer(j),
+	)
+	assert.NoError(t, err)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+
+	// Check the status code
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Get the documents
+	for _, doc := range docs {
+		rd, err := appState.DocumentStore.GetDocuments(
+			testCtx,
+			collectionName,
+			nil,
+			[]string{doc.DocumentID},
+		)
+		assert.NoError(t, err)
+
+		assert.Equal(t, rd[0].Content, doc.Content)
+		assert.Equal(t, rd[0].Metadata["key"], doc.Metadata["key"])
+	}
+}
+
+// TestCreateDocumentsHandler with request body size greater than appState.Config.Server.MaxRequestSize
+func TestCreateDocumentsHandler_MaxRequestBodySize(t *testing.T) {
+	collectionName := testutils.GenerateRandomString(10)
+	// Create a collection
+	cr := models.DocumentCollection{
+		Name:        collectionName,
+		Description: "Test collection",
+		Metadata: map[string]interface{}{
+			"key": "value",
+		},
+		EmbeddingDimensions: 128,
+		IsAutoEmbedded:      true,
+	}
+
+	err := appState.DocumentStore.CreateCollection(testCtx, cr)
+	assert.NoError(t, err)
+
+	// Create a large document
+	largeDoc := strings.Repeat("a", int(appState.Config.Server.MaxRequestSize+1))
+
+	// Create a document request with the large document
+	docReq := []models.CreateDocumentRequest{
+		{
+			DocumentID: "largeDoc",
+			Content:    largeDoc,
+			Metadata: map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+
+	// Marshal the document request into JSON
+	j, err := json.Marshal(docReq)
+	assert.NoError(t, err)
+
+	// Create a new HTTP request
+	req, err := http.NewRequest(
+		"POST",
+		testServer.URL+"/api/v1/collection/"+collectionName+"/document",
+		bytes.NewBuffer(j),
+	)
+	assert.NoError(t, err)
+
+	// Send the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+
+	// Check the status code
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+	assert.Equal(t, "413 Request Entity Too Large", resp.Status)
+}

--- a/pkg/server/handlertools/tools.go
+++ b/pkg/server/handlertools/tools.go
@@ -68,13 +68,22 @@ func DecodeJSON(r *http.Request, data interface{}) error {
 
 // RenderError renders an error response.
 func RenderError(w http.ResponseWriter, err error, status int) {
+	if err.Error() == "http: request body too large" {
+		status = http.StatusRequestEntityTooLarge
+		err = fmt.Errorf(
+			"request body too large. if you're uploading documents, reduce the batch size or size of the document chunks",
+		)
+	}
+
 	if status != http.StatusNotFound {
 		// Don't log not found errors
 		log.Error(err)
 	}
+
 	if strings.Contains(err.Error(), "is deleted") || errors.Is(err, models.ErrBadRequest) {
 		status = http.StatusBadRequest
 	}
+
 	http.Error(w, err.Error(), status)
 }
 

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -48,8 +48,14 @@ func Create(appState *models.AppState) *http.Server {
 // @name						Authorization
 // @description				Type "Bearer" followed by a space and JWT token.
 func setupRouter(appState *models.AppState) *chi.Mux {
+	maxRequestSize := appState.Config.Server.MaxRequestSize
+	if maxRequestSize == 0 {
+		maxRequestSize = 5 << 20 // 5MB
+	}
+
 	router := chi.NewRouter()
 	router.Use(httpLogger.Logger("router", log))
+	router.Use(middleware.RequestSize(maxRequestSize))
 	router.Use(middleware.Recoverer)
 	router.Use(middleware.RequestID)
 	router.Use(middleware.RealIP)

--- a/pkg/server/routes_test.go
+++ b/pkg/server/routes_test.go
@@ -67,6 +67,22 @@ func setup() {
 	testUserStore = postgres.NewUserStoreDAO(testDB)
 	appState.UserStore = testUserStore
 
+	embeddingTaskChannel := make(
+		chan []models.DocEmbeddingTask,
+		10,
+	)
+	embeddingUpdateChannel := make(chan []models.DocEmbeddingUpdate, 500)
+	documentStore, err := postgres.NewDocumentStore(
+		appState,
+		testDB,
+		embeddingUpdateChannel,
+		embeddingTaskChannel,
+	)
+	if err != nil {
+		log.Fatalf("unable to create documentStore: %v", err)
+	}
+	appState.DocumentStore = documentStore
+
 	testServer = httptest.NewServer(
 		setupRouter(appState),
 	)

--- a/pkg/store/postgres/documentstore.go
+++ b/pkg/store/postgres/documentstore.go
@@ -208,7 +208,7 @@ func (ds *DocumentStore) CreateDocuments(
 		)
 	}
 	if !collection.IsAutoEmbedded && someEmpty {
-		return nil, errors.New(
+		return nil, models.NewBadRequestError(
 			"cannot create documents without embeddings in a non-auto-embedded collection",
 		)
 	}

--- a/pkg/store/postgres/search_utils.go
+++ b/pkg/store/postgres/search_utils.go
@@ -9,7 +9,12 @@ import (
 
 // parseJSONQuery recursively parses a JSONQuery and returns a bun.QueryBuilder.
 // TODO: fix the addition of extraneous parentheses in the query
-func parseJSONQuery(qb bun.QueryBuilder, jq *JSONQuery, isOr bool, tablePrefix string) bun.QueryBuilder {
+func parseJSONQuery(
+	qb bun.QueryBuilder,
+	jq *JSONQuery,
+	isOr bool,
+	tablePrefix string,
+) bun.QueryBuilder {
 	var tp string
 	if tablePrefix != "" {
 		tp = tablePrefix + "."

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -60,9 +60,10 @@ func testConfigDefaults() (*config.Config, error) {
 			},
 		},
 		Server: config.ServerConfig{
-			Host:       "0.0.0.0",
-			Port:       8000,
-			WebEnabled: true,
+			Host:           "0.0.0.0",
+			Port:           8000,
+			WebEnabled:     true,
+			MaxRequestSize: 1 << 20, // 10MB
 		},
 		Auth: config.AuthConfig{
 			Secret:   "do-not-use-this-secret-in-production",


### PR DESCRIPTION
- Limit Request body size using middleware
- Error suggesting reducing size of documents / batching of uploads
- Config option for max_request_size. Default to 5MB
- Additional Document Collection route tests