### PR TITLE
fix: upgrade go toolchain 1.21.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/getzep/zep
 
 go 1.21
 
-toolchain go1.21.2
+toolchain go1.21.3
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
- security fix to the net/http package