### PR TITLE
fix: More Messages returned fetchMessagesAfterSummaryPoint than memoryWindow

### DIFF
--- a/pkg/store/postgres/memorystore_test.go
+++ b/pkg/store/postgres/memorystore_test.go
@@ -242,10 +242,10 @@ func TestGetMessages(t *testing.T) {
 		withSummary    bool
 	}{
 		{
-			name:           "Get all messages",
+			name:           "Get all messages within messageWindow",
 			sessionID:      sessionID,
 			lastNMessages:  0,
-			expectedLength: len(messages),
+			expectedLength: messageWindow,
 			withSummary:    false,
 		},
 		{

--- a/pkg/store/postgres/messages.go
+++ b/pkg/store/postgres/messages.go
@@ -176,7 +176,7 @@ func getMessages(
 	if lastNMessages > 0 {
 		messages, err = fetchLastNMessages(ctx, db, sessionID, lastNMessages)
 	} else {
-		messages, err = fetchMessagesAfterSummaryPoint(ctx, db, sessionID, summary)
+		messages, err = fetchMessagesAfterSummaryPoint(ctx, db, sessionID, summary, memoryWindow)
 	}
 	if err != nil {
 		return nil, store.NewStorageError("failed to get messages", err)
@@ -201,6 +201,7 @@ func fetchMessagesAfterSummaryPoint(
 	db *bun.DB,
 	sessionID string,
 	summary *models.Summary,
+	memoryWindow int,
 ) ([]MessageStoreSchema, error) {
 	var summaryPointIndex int64
 	var err error
@@ -220,6 +221,9 @@ func fetchMessagesAfterSummaryPoint(
 	if summaryPointIndex > 0 {
 		query.Where("id > ?", summaryPointIndex)
 	}
+
+	// Always limit to the memory window
+	query.Limit(memoryWindow)
 
 	return messages, query.Scan(ctx)
 }


### PR DESCRIPTION
When Summaries are not created fast enough, fetchMessagesAfterSummaryPoint may return more messages than the memoryWindow. This modification always limits the number of returned messages to the memoryWindow.

Impacts:
- Ensures developers can more accurately manage prompt size
- There may be gaps in the conversations history if messageCount > memoryWindow and no summary has been created yet.