### PR TITLE
Feature: custom headers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,12 @@ server:
   web_enabled: true
   # The maximum size of a request body, in bytes. Defaults to 5MB.
   max_request_size: 5242880
+  # Custom Headers Configuration
+  # Allows customization of additional headers to be sent with requetss
+  # DO NOT STORE SECRETS HERE. Use environment variable ZEP_CUSTOM_HEADER_SECRET
+  custom_headers:
+    # Example format:
+    # header_name: header_value
 auth:
   # Set to true to enable authentication
   required: false

--- a/config.yaml
+++ b/config.yaml
@@ -67,6 +67,8 @@ server:
   custom_headers:
     # Example format:
     # header_name: header_value
+    x-zep-custom-header-1: 12345
+    x-zep-custom-header-2: abcde
 auth:
   # Set to true to enable authentication
   required: false

--- a/config.yaml
+++ b/config.yaml
@@ -62,7 +62,8 @@ server:
   max_request_size: 5242880
   # Custom Headers Configuration
   # Allows customization of additional headers to be sent with requetss
-  # DO NOT STORE SECRETS HERE. Use environment variable ZEP_CUSTOM_HEADER_SECRET
+  # Do not store secrets here in production. The ZEP_SECRET_CUSTOM_HEADER=header_name environment variables
+  # and ZEP_SECRET_CUSTOM_HEADER_VALUE=header_value used instead.
   custom_headers:
     # Example format:
     # header_name: header_value

--- a/config/config.go
+++ b/config/config.go
@@ -16,10 +16,11 @@ var log = logrus.New()
 
 // EnvVars is a set of secrets that should be stored in the environment, not config file
 var EnvVars = map[string]string{
-	"llm.anthropic_api_key": "ZEP_ANTHROPIC_API_KEY",
-	"llm.openai_api_key":    "ZEP_OPENAI_API_KEY",
-	"auth.secret":           "ZEP_AUTH_SECRET",
-	"development":           "ZEP_DEVELOPMENT",
+	"llm.anthropic_api_key":        "ZEP_ANTHROPIC_API_KEY",
+	"llm.openai_api_key":           "ZEP_OPENAI_API_KEY",
+	"auth.secret":                  "ZEP_AUTH_SECRET",
+	"development":                  "ZEP_DEVELOPMENT",
+	"server.secret_custom_headers": "ZEP_CUSTOM_HEADER_SECRET",
 }
 
 // LoadConfig loads the config file and ENV variables into a Config struct

--- a/config/config.go
+++ b/config/config.go
@@ -16,11 +16,12 @@ var log = logrus.New()
 
 // EnvVars is a set of secrets that should be stored in the environment, not config file
 var EnvVars = map[string]string{
-	"llm.anthropic_api_key":        "ZEP_ANTHROPIC_API_KEY",
-	"llm.openai_api_key":           "ZEP_OPENAI_API_KEY",
-	"auth.secret":                  "ZEP_AUTH_SECRET",
-	"development":                  "ZEP_DEVELOPMENT",
-	"server.secret_custom_headers": "ZEP_CUSTOM_HEADER_SECRET",
+	"llm.anthropic_api_key":             "ZEP_ANTHROPIC_API_KEY",
+	"llm.openai_api_key":                "ZEP_OPENAI_API_KEY",
+	"auth.secret":                       "ZEP_AUTH_SECRET",
+	"development":                       "ZEP_DEVELOPMENT",
+	"server.secret_custom_header":       "ZEP_SECRET_CUSTOM_HEADER",
+	"server.secret_custom_header_value": "ZEP_SECRET_CUSTOM_HEADER_VALUE",
 }
 
 // LoadConfig loads the config file and ENV variables into a Config struct

--- a/config/models.go
+++ b/config/models.go
@@ -56,10 +56,12 @@ type AvailableIndexes struct {
 }
 
 type ServerConfig struct {
-	Host           string `mapstructure:"host"`
-	Port           int    `mapstructure:"port"`
-	WebEnabled     bool   `mapstructure:"web_enabled"`
-	MaxRequestSize int64  `mapstructure:"max_request_size"`
+	Host                string            `mapstructure:"host"`
+	Port                int               `mapstructure:"port"`
+	WebEnabled          bool              `mapstructure:"web_enabled"`
+	MaxRequestSize      int64             `mapstructure:"max_request_size"`
+	CustomHeaders       map[string]string `mapstructure:"custom_headers"`
+	SecretCustomHeaders map[string]string `mapstructure:"secret_custom_headers"`
 }
 
 type LogConfig struct {

--- a/config/models.go
+++ b/config/models.go
@@ -56,12 +56,13 @@ type AvailableIndexes struct {
 }
 
 type ServerConfig struct {
-	Host                string            `mapstructure:"host"`
-	Port                int               `mapstructure:"port"`
-	WebEnabled          bool              `mapstructure:"web_enabled"`
-	MaxRequestSize      int64             `mapstructure:"max_request_size"`
-	CustomHeaders       map[string]string `mapstructure:"custom_headers"`
-	SecretCustomHeaders map[string]string `mapstructure:"secret_custom_headers"`
+	Host                    string            `mapstructure:"host"`
+	Port                    int               `mapstructure:"port"`
+	WebEnabled              bool              `mapstructure:"web_enabled"`
+	MaxRequestSize          int64             `mapstructure:"max_request_size"`
+	CustomHeaders           map[string]string `mapstructure:"custom_headers"`
+	SecretCustomHeader      string            `mapstructure:"secret_custom_header"`
+	SecretCustomHeaderValue string            `mapstructure:"secret_custom_header_value"`
 }
 
 type LogConfig struct {

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -9,20 +9,8 @@ import (
 
 const versionHeader = "X-Zep-Version"
 
-// ZepMiddleware implements any custom middlewares for Zep and allows the middlewares to access shared
-// resources, such as the models.AppState
-type zepCustomMiddleware struct {
-	appState *models.AppState
-}
-
-func newZepCustomMiddleware(appState *models.AppState) *zepCustomMiddleware {
-	return &zepCustomMiddleware{
-		appState: appState,
-	}
-}
-
 // SendVersion is a middleware that adds the current version to the response
-func (middleware *zepCustomMiddleware) SendVersion(next http.Handler) http.Handler {
+func SendVersion(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		if w.Header().Get(versionHeader) == "" {
@@ -36,23 +24,27 @@ func (middleware *zepCustomMiddleware) SendVersion(next http.Handler) http.Handl
 	return http.HandlerFunc(fn)
 }
 
-// CustomHeader will take any configured custom headers in the configuration file or 
+// CustomHeader will take any configured custom headers in the configuration file or
 // ZEP_SECRET_CUSTOM_HEADER and  ZEP_SECRET_CUSTOM_HEADER_VALUE environment variables and add them to requests
-func (middleware *zepCustomMiddleware)  CustomHeader(next http.Handler) http.Handler {
-	fn := func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		// Add each non-secret custom header
-		for header, value := range middleware.appState.Config.Server.CustomHeaders {
-			w.Header().Add(header, value)
+func CustomHeader(appState *models.AppState) func(http.Handler) http.Handler {
+	f := func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+			// Add each non-secret custom header
+			for header, value := range appState.Config.Server.CustomHeaders {
+				w.Header().Add(header, value)
+			}
+
+			// Add the secret custom header if provided
+			if appState.Config.Server.SecretCustomHeader != "" && appState.Config.Server.SecretCustomHeaderValue != "" {
+				w.Header().Add(
+					appState.Config.Server.SecretCustomHeader,
+					appState.Config.Server.SecretCustomHeaderValue,
+				)
+			}
+
+			next.ServeHTTP(w, r.WithContext(r.Context()))
 		}
-		// Add the secret custom header if provided
-		if zepMiddleware.appState.Config.Server.SecretCustomHeader != "" && zepMiddleware.appState.Config.Server.SecretCustomHeaderValue != "" {
-			w.Header().Add(
-				zepMiddleware.appState.Config.Server.SecretCustomHeader,
-				zepMiddleware.appState.Config.Server.SecretCustomHeaderValue,
-			)
-		}
-		next.ServeHTTP(w, r.WithContext(ctx))
+		return http.HandlerFunc(fn)
 	}
-	return http.HandlerFunc(fn)
+	return f
 }

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -37,7 +37,7 @@ func (middleware *zepCustomMiddleware) SendVersion(next http.Handler) http.Handl
 }
 
 // CustomHeader will take any configured custom headers in the configuration file or 
-// ZEP_CUSTOM_HEADER_SECRET environment variable and add them to requests
+// ZEP_SECRET_CUSTOM_HEADER and  ZEP_SECRET_CUSTOM_HEADER_VALUE environment variables and add them to requests
 func (middleware *zepCustomMiddleware)  CustomHeader(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -4,12 +4,25 @@ import (
 	"net/http"
 
 	"github.com/getzep/zep/config"
+	"github.com/getzep/zep/pkg/models"
 )
 
 const versionHeader = "X-Zep-Version"
 
+// ZepMiddleware implements any custom middlewares for Zep and allows the middlewares to access shared
+// resources, such as the models.AppState
+type zepCustomMiddleware struct {
+	appState *models.AppState
+}
+
+func newZepCustomMiddleware(appState *models.AppState) *zepCustomMiddleware {
+	return &zepCustomMiddleware{
+		appState: appState,
+	}
+}
+
 // SendVersion is a middleware that adds the current version to the response
-func SendVersion(next http.Handler) http.Handler {
+func (middleware *zepCustomMiddleware) SendVersion(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		if w.Header().Get(versionHeader) == "" {
@@ -17,6 +30,24 @@ func SendVersion(next http.Handler) http.Handler {
 				versionHeader,
 				config.VersionString,
 			)
+		}
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}
+	return http.HandlerFunc(fn)
+}
+
+// CustomHeader will take any configured custom headers in the configuration file or 
+// ZEP_CUSTOM_HEADER_SECRET environment variable and add them to requests
+func (middleware *zepCustomMiddleware)  CustomHeader(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		// Add each non-secret custom header
+		for header, value := range middleware.appState.Config.Server.CustomHeaders {
+			w.Header().Add(header, value)
+		}
+		// Add each secret custom header
+		for header, value := range middleware.appState.Config.Server.SecretCustomHeaders {
+			w.Header().Add(header, value)
 		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -45,9 +45,12 @@ func (middleware *zepCustomMiddleware)  CustomHeader(next http.Handler) http.Han
 		for header, value := range middleware.appState.Config.Server.CustomHeaders {
 			w.Header().Add(header, value)
 		}
-		// Add each secret custom header
-		for header, value := range middleware.appState.Config.Server.SecretCustomHeaders {
-			w.Header().Add(header, value)
+		// Add the secret custom header if provided
+		if zepMiddleware.appState.Config.Server.SecretCustomHeader != "" && zepMiddleware.appState.Config.Server.SecretCustomHeaderValue != "" {
+			w.Header().Add(
+				zepMiddleware.appState.Config.Server.SecretCustomHeader,
+				zepMiddleware.appState.Config.Server.SecretCustomHeaderValue,
+			)
 		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -23,14 +23,10 @@ import (
 
 const ReadHeaderTimeout = 5 * time.Second
 
-var (
-	log = internal.GetLogger()
-	zepMiddleware *zepCustomMiddleware
-)
+var log = internal.GetLogger()
 
 // Create creates a new HTTP server with the given app state
 func Create(appState *models.AppState) *http.Server {
-	zepMiddleware = newZepCustomMiddleware(appState)
 	host := appState.Config.Server.Host
 	port := appState.Config.Server.Port
 	router := setupRouter(appState)
@@ -41,16 +37,16 @@ func Create(appState *models.AppState) *http.Server {
 	}
 }
 
-//	@title						Zep REST-like API
-//	@version					0.x
-//	@license.name				Apache 2.0
-//	@license.url				http://www.apache.org/licenses/LICENSE-2.0.html
-//	@BasePath					/api/v1
-//	@schemes					http https
-//	@securityDefinitions.apikey	Bearer
-//	@in							header
-//	@name						Authorization
-//	@description				Type "Bearer" followed by a space and JWT token.
+// @title						Zep REST-like API
+// @version					0.x
+// @license.name				Apache 2.0
+// @license.url				http://www.apache.org/licenses/LICENSE-2.0.html
+// @BasePath					/api/v1
+// @schemes					http https
+// @securityDefinitions.apikey	Bearer
+// @in							header
+// @name						Authorization
+// @description				Type "Bearer" followed by a space and JWT token.
 func setupRouter(appState *models.AppState) *chi.Mux {
 	maxRequestSize := appState.Config.Server.MaxRequestSize
 	if maxRequestSize == 0 {
@@ -64,8 +60,8 @@ func setupRouter(appState *models.AppState) *chi.Mux {
 	router.Use(middleware.RequestID)
 	router.Use(middleware.RealIP)
 	router.Use(middleware.CleanPath)
-	router.Use(zepMiddleware.SendVersion)
-	router.Use(zepMiddleware.CustomHeader)
+	router.Use(SendVersion)
+	router.Use(CustomHeader(appState))
 	router.Use(middleware.Heartbeat("/healthz"))
 
 	// Only setup web routes if enabled

--- a/pkg/server/routes_test.go
+++ b/pkg/server/routes_test.go
@@ -141,9 +141,8 @@ func TestAuthMiddleware(t *testing.T) {
 
 func TestSendVersion(t *testing.T) {
 	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
-	zepMiddleware := newZepCustomMiddleware(nil) // SendVersion does not use the appState
 
-	handler := zepMiddleware.SendVersion(nextHandler)
+	handler := SendVersion(nextHandler)
 
 	req, err := http.NewRequest("GET", "/api", nil)
 	if err != nil {
@@ -173,9 +172,8 @@ func TestCustomHeader(t *testing.T) {
 			},
 		},
 	}
-	zepMiddleware := newZepCustomMiddleware(appState)
 
-	handler := zepMiddleware.CustomHeader(nextHandler)
+	handler := CustomHeader(appState)(nextHandler)
 
 	req, err := http.NewRequest("GET", "/api", nil)
 	if err != nil {
@@ -185,17 +183,17 @@ func TestCustomHeader(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	for header, value := range zepMiddleware.appState.Config.Server.CustomHeaders {
+	for header, value := range appState.Config.Server.CustomHeaders {
 		if rr.Header().Get(header) != value {
 			t.Errorf("handler returned wrong custom header: got %v want %v",
 				rr.Header().Get(header), value)
 		}
 	}
-	if rr.Header().Get(zepMiddleware.appState.Config.Server.SecretCustomHeader) != zepMiddleware.appState.Config.Server.SecretCustomHeaderValue {
+	if rr.Header().Get(appState.Config.Server.SecretCustomHeader) != appState.Config.Server.SecretCustomHeaderValue {
 		t.Errorf(
 			"handler returned wrong secret custom header: got %v want %v",
-			rr.Header().Get(zepMiddleware.appState.Config.Server.SecretCustomHeader),
-			zepMiddleware.appState.Config.Server.SecretCustomHeaderValue,
+			rr.Header().Get(appState.Config.Server.SecretCustomHeader),
+			appState.Config.Server.SecretCustomHeaderValue,
 		)
 	}
 }
@@ -211,9 +209,8 @@ func TestCustomHeader_NilCustomHeaders(t *testing.T) {
 			},
 		},
 	}
-	zepMiddleware := newZepCustomMiddleware(appState)
 
-	handler := zepMiddleware.CustomHeader(nextHandler)
+	handler := CustomHeader(appState)(nextHandler)
 
 	req, err := http.NewRequest("GET", "/api", nil)
 	if err != nil {
@@ -223,11 +220,11 @@ func TestCustomHeader_NilCustomHeaders(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if rr.Header().Get(zepMiddleware.appState.Config.Server.SecretCustomHeader) != zepMiddleware.appState.Config.Server.SecretCustomHeaderValue {
+	if rr.Header().Get(appState.Config.Server.SecretCustomHeader) != appState.Config.Server.SecretCustomHeaderValue {
 		t.Errorf(
 			"handler returned wrong secret custom header: got %v want %v",
-			rr.Header().Get(zepMiddleware.appState.Config.Server.SecretCustomHeader),
-			zepMiddleware.appState.Config.Server.SecretCustomHeaderValue,
+			rr.Header().Get(appState.Config.Server.SecretCustomHeader),
+			appState.Config.Server.SecretCustomHeaderValue,
 		)
 	}
 }


### PR DESCRIPTION
Addresses #169 by adding both a `map[string]string` to the config file and environment variables (`ZEP_SECRET_CUSTOM_HEADER` and `ZEP_SECRET_CUSTOM_HEADER_VALUE`) for a single secret header and value by mostly following @danielchalef's suggested implementation. I did deviate slightly from his suggestion because I thought it'd be nice to be flexible and support more than one custom header, just in case a user ever needs that. However, I'm not sure how we'd support more than one secret header provided from the environment.

~~I've also created a new `zepCustomMiddleware` struct in `./pkg/server/middleware.go` because I wasn't sure of a better way to give the new `CustomHeader` middleware access to the `appState`. I'm definitely open to changing this if this isn't acceptable.~~ 
I've changed this to be similar to how [middleware.RequestSize()](https://pkg.go.dev/github.com/go-chi/chi/v5/middleware#RequestSize) works; I feel it is a much cleaner implementation than my previous attempt.

I've written tests for this, but I haven't been able to fully test that it works yet; I'm still learning about Zep. I have been able to confirm that the new values are read from the config file and environment and show up in the `/admin/settings` page:
![image](https://github.com/getzep/zep/assets/14365919/4a47d952-5c75-4a16-a558-7ba7e91d027c)
