### PR TITLE
Enable separate Embeddings Client

### DIFF
--- a/cmd/zep/run.go
+++ b/cmd/zep/run.go
@@ -67,9 +67,20 @@ func NewAppState(cfg *config.Config) *models.AppState {
 		log.Fatal(err)
 	}
 
+	var embeddingsClient models.ZepEmbeddingsClient = nil
+
+	if cfg.EmbeddingsClient.Enabled {
+		embeddingsClient, err = llms.NewEmbeddingsClient(ctx, cfg)
+	}
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	appState := &models.AppState{
-		LLMClient: llmClient,
-		Config:    cfg,
+		LLMClient:        llmClient,
+		EmbeddingsClient: embeddingsClient,
+		Config:           cfg,
 	}
 
 	initializeStores(ctx, appState)

--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ embeddings_client:
   service: "openai"
   azure_openai_endpoint:
   azure_openai:
-  #embeddings deployment is required when using azure deployment for embeddings
+  # embeddings deployment is required when using azure deployment for embeddings
     embedding_deployment: "text-embedding-ada-002-customname"
   openai_endpoint:
   openai_org_id:

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,18 @@ llm:
   # Use only with an alternate OpenAI-compatible API endpoint
   openai_endpoint:
   openai_org_id:
+embeddings_client:
+  # Enable if, when not using local embeddings, you want to use distinct clients for your llm and embeddings.
+  # For now, only OpenAI embeddings are available as external embeddings client.
+  enabled: false
+  # When enabled, please make sure to have your ZEP_EMBEDDINGS_OPENAI_API_KEY environment variable set
+  service: "openai"
+  azure_openai_endpoint:
+  azure_openai:
+  #embeddings deployment is required when using azure deployment for embeddings
+    embedding_deployment: "text-embedding-ada-002-customname"
+  openai_endpoint:
+  openai_org_id:
 nlp:
   server_url: "http://localhost:5557"
 memory:
@@ -95,6 +107,9 @@ custom_prompts:
     #   <current_summary>{{.PrevSummary}}</current_summary>
     #   <new_lines>{{.MessagesJoined}}</new_lines>
     #   Response without preamble.
+    #
+    # For Open Source models compatible with the OpenAI client,
+    # follow the prompt guidelines provided by the model owners.
     #
     # If left empty, the default Anthropic summary prompt from zep/pkg/extractors/prompts.go will be used.
     anthropic: |

--- a/config.yaml
+++ b/config.yaml
@@ -108,9 +108,6 @@ custom_prompts:
     #   <new_lines>{{.MessagesJoined}}</new_lines>
     #   Response without preamble.
     #
-    # For Open Source models compatible with the OpenAI client,
-    # follow the prompt guidelines provided by the model owners.
-    #
     # If left empty, the default Anthropic summary prompt from zep/pkg/extractors/prompts.go will be used.
     anthropic: |
 
@@ -127,6 +124,9 @@ custom_prompts:
     #   Current summary: {{.PrevSummary}}
     #   New lines of conversation: {{.MessagesJoined}}
     #   New summary:`
+    # 
+    # For Open Source models compatible with the OpenAI client,
+    # follow the prompt guidelines provided by the model owners.
     #
     # If left empty, the default OpenAI summary prompt from zep/pkg/extractors/prompts.go will be used.
     openai: |

--- a/config/config.go
+++ b/config/config.go
@@ -16,10 +16,11 @@ var log = logrus.New()
 
 // EnvVars is a set of secrets that should be stored in the environment, not config file
 var EnvVars = map[string]string{
-	"llm.anthropic_api_key": "ZEP_ANTHROPIC_API_KEY",
-	"llm.openai_api_key":    "ZEP_OPENAI_API_KEY",
-	"auth.secret":           "ZEP_AUTH_SECRET",
-	"development":           "ZEP_DEVELOPMENT",
+	"llm.anthropic_api_key":            "ZEP_ANTHROPIC_API_KEY",
+	"llm.openai_api_key":               "ZEP_OPENAI_API_KEY",
+	"embeddings_client.openai_api_key": "ZEP_EMBEDDINGS_OPENAI_API_KEY",
+	"auth.secret":                      "ZEP_AUTH_SECRET",
+	"development":                      "ZEP_DEVELOPMENT",
 }
 
 // LoadConfig loads the config file and ENV variables into a Config struct

--- a/config/models.go
+++ b/config/models.go
@@ -3,17 +3,18 @@ package config
 // Config holds the configuration of the application
 // Use cmd.NewConfig to create a new instance
 type Config struct {
-	LLM           LLM                 `mapstructure:"llm"`
-	NLP           NLP                 `mapstructure:"nlp"`
-	Memory        MemoryConfig        `mapstructure:"memory"`
-	Extractors    ExtractorsConfig    `mapstructure:"extractors"`
-	Store         StoreConfig         `mapstructure:"store"`
-	Server        ServerConfig        `mapstructure:"server"`
-	Log           LogConfig           `mapstructure:"log"`
-	Auth          AuthConfig          `mapstructure:"auth"`
-	DataConfig    DataConfig          `mapstructure:"data"`
-	Development   bool                `mapstructure:"development"`
-	CustomPrompts CustomPromptsConfig `mapstructure:"custom_prompts"`
+	LLM              LLM                 `mapstructure:"llm"`
+	EmbeddingsClient EmbeddingsClient    `mapstructure:"embeddings_client"`
+	NLP              NLP                 `mapstructure:"nlp"`
+	Memory           MemoryConfig        `mapstructure:"memory"`
+	Extractors       ExtractorsConfig    `mapstructure:"extractors"`
+	Store            StoreConfig         `mapstructure:"store"`
+	Server           ServerConfig        `mapstructure:"server"`
+	Log              LogConfig           `mapstructure:"log"`
+	Auth             AuthConfig          `mapstructure:"auth"`
+	DataConfig       DataConfig          `mapstructure:"data"`
+	Development      bool                `mapstructure:"development"`
+	CustomPrompts    CustomPromptsConfig `mapstructure:"custom_prompts"`
 }
 
 type StoreConfig struct {
@@ -25,6 +26,16 @@ type LLM struct {
 	Service             string            `mapstructure:"service"`
 	Model               string            `mapstructure:"model"`
 	AnthropicAPIKey     string            `mapstructure:"anthropic_api_key"`
+	OpenAIAPIKey        string            `mapstructure:"openai_api_key"`
+	AzureOpenAIEndpoint string            `mapstructure:"azure_openai_endpoint"`
+	AzureOpenAIModel    AzureOpenAIConfig `mapstructure:"azure_openai"`
+	OpenAIEndpoint      string            `mapstructure:"openai_endpoint"`
+	OpenAIOrgID         string            `mapstructure:"openai_org_id"`
+}
+
+type EmbeddingsClient struct {
+	Enabled             bool              `mapstructure:"enabled"`
+	Service             string            `mapstructure:"service"`
 	OpenAIAPIKey        string            `mapstructure:"openai_api_key"`
 	AzureOpenAIEndpoint string            `mapstructure:"azure_openai_endpoint"`
 	AzureOpenAIModel    AzureOpenAIConfig `mapstructure:"azure_openai"`

--- a/pkg/llms/embeddings.go
+++ b/pkg/llms/embeddings.go
@@ -20,14 +20,23 @@ func EmbedTexts(
 		return nil, errors.New("no text to embed")
 	}
 
-	if appState.LLMClient == nil {
+	llmClient := appState.LLMClient
+
+	if llmClient == nil {
 		return nil, errors.New(InvalidLLMModelError)
 	}
 
 	if model.Service == "local" {
 		return embedTextsLocal(ctx, appState, documentType, text)
 	}
-	return appState.LLMClient.EmbedTexts(ctx, text)
+
+	embeddingsClient := appState.EmbeddingsClient
+
+	if embeddingsClient != nil {
+		return embeddingsClient.EmbedTexts(ctx, text)
+	}
+
+	return llmClient.EmbedTexts(ctx, text)
 }
 
 func GetEmbeddingModel(

--- a/pkg/llms/embeddings_base.go
+++ b/pkg/llms/embeddings_base.go
@@ -1,0 +1,42 @@
+package llms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getzep/zep/pkg/models"
+
+	"github.com/getzep/zep/config"
+)
+
+const InvalidEmbeddingsClientError = "embeddings client is not set or is invalid"
+
+type EmbeddingsClientError struct {
+	message       string
+	originalError error
+}
+
+func (e *EmbeddingsClientError) Error() string {
+	return fmt.Sprintf("embeddings client error: %s (original error: %v)", e.message, e.originalError)
+}
+
+func NewEmbeddingsClientError(message string, originalError error) *EmbeddingsClientError {
+	return &EmbeddingsClientError{message: message, originalError: originalError}
+}
+
+func NewEmbeddingsClient(ctx context.Context, cfg *config.Config) (models.ZepEmbeddingsClient, error) {
+	switch cfg.EmbeddingsClient.Service {
+	// For now we only support OpenAI embeddings
+	case "openai":
+		// EmbeddingsDeployment is required if using external embeddings with AzureOpenAI
+		if cfg.EmbeddingsClient.AzureOpenAIEndpoint != "" && cfg.EmbeddingsClient.AzureOpenAIModel.EmbeddingDeployment == "" {
+			err := InvalidEmbeddingsDeploymentError(cfg.EmbeddingsClient.Service)
+			return nil, err
+		}
+		// The logic is the same if custom OpenAI Endpoint is set or not
+		// since the model name will be set automatically in this case
+		return NewOpenAIEmbeddingsClient(ctx, cfg)
+	default:
+		return nil, fmt.Errorf("invalid embeddings service: %s", cfg.EmbeddingsClient.Service)
+	}
+}

--- a/pkg/llms/embeddings_openai.go
+++ b/pkg/llms/embeddings_openai.go
@@ -1,0 +1,88 @@
+package llms
+
+import (
+	"context"
+
+	"github.com/getzep/zep/config"
+	"github.com/getzep/zep/pkg/models"
+	"github.com/tmc/langchaingo/llms/openai"
+)
+
+const EmbeddingsOpenAIAPIKeyNotSetError = "ZEP_EMBEDDINGS_OPENAI_API_KEY is not set" //nolint:gosec
+
+var _ models.ZepEmbeddingsClient = &ZepOpenAIEmbeddingsClient{}
+
+func NewOpenAIEmbeddingsClient(ctx context.Context, cfg *config.Config) (*ZepOpenAIEmbeddingsClient, error) {
+	zembeddings := &ZepOpenAIEmbeddingsClient{}
+	err := zembeddings.Init(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return zembeddings, nil
+}
+
+type ZepOpenAIEmbeddingsClient struct {
+	client *openai.Chat
+}
+
+func (zembeddings *ZepOpenAIEmbeddingsClient) Init(_ context.Context, cfg *config.Config) error {
+
+	options, err := zembeddings.configureClient(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Create a new client instance with options.
+	// Even if it will just used for embeddings,
+	// it uses the same langchain openai chat client builder
+	client, err := NewOpenAIChatClient(options...)
+	zembeddings.client = client
+
+	return nil
+}
+
+func (zembeddings *ZepOpenAIEmbeddingsClient) EmbedTexts(ctx context.Context, texts []string) ([][]float32, error) {
+	return EmbedTextsWithOpenAIClient(ctx, texts, zembeddings.client)
+}
+
+func getValidOpenAIModel() string {
+	for k := range ValidOpenAILLMs {
+		return k
+	}
+	return "gpt-3.5-turbo"
+}
+
+func (zembeddings *ZepOpenAIEmbeddingsClient) configureClient(cfg *config.Config) ([]openai.Option, error) {
+	// Retrieve the OpenAIAPIKey from configuration
+	apiKey := GetOpenAIAPIKey(cfg, "embeddings")
+
+	if cfg.EmbeddingsClient.AzureOpenAIEndpoint != "" && cfg.EmbeddingsClient.OpenAIEndpoint != "" {
+		log.Fatal("only one of AzureOpenAIEndpoint or OpenAIEndpoint can be set")
+	}
+
+	// Even if it will only be used for embeddings, we should pass a valid openai llm model
+	// to avoid any errors
+	validOpenaiLLMModel := getValidOpenAIModel()
+
+	options := GetBaseOpenAIClientOptions(apiKey, validOpenaiLLMModel)
+
+	switch {
+	case cfg.EmbeddingsClient.AzureOpenAIEndpoint != "":
+		options = append(
+			options,
+			openai.WithAPIType(openai.APITypeAzure),
+			openai.WithBaseURL(cfg.EmbeddingsClient.AzureOpenAIEndpoint),
+			openai.WithEmbeddingModel(cfg.EmbeddingsClient.AzureOpenAIModel.EmbeddingDeployment),
+		)
+	case cfg.EmbeddingsClient.OpenAIEndpoint != "":
+		// If an alternate OpenAI-compatible endpoint Path is set, use this as the base Path for requests
+		options = append(
+			options,
+			openai.WithBaseURL(cfg.EmbeddingsClient.OpenAIEndpoint),
+		)
+	case cfg.EmbeddingsClient.OpenAIOrgID != "":
+		options = append(options, openai.WithOrganization(cfg.EmbeddingsClient.OpenAIOrgID))
+	}
+
+	return options, nil
+}

--- a/pkg/llms/embeddings_openai.go
+++ b/pkg/llms/embeddings_openai.go
@@ -55,7 +55,7 @@ func (zembeddings *ZepOpenAIEmbeddingsClient) configureClient(cfg *config.Config
 	// Retrieve the OpenAIAPIKey from configuration
 	apiKey := GetOpenAIAPIKey(cfg, EmbeddingsClientType)
 
-	validateOpenAIConfig(cfg, EmbeddingsClientType)
+	ValidateOpenAIConfig(cfg, EmbeddingsClientType)
 
 	// Even if it will only be used for embeddings, we should pass a valid openai llm model
 	// to avoid any errors

--- a/pkg/llms/embeddings_openai_test.go
+++ b/pkg/llms/embeddings_openai_test.go
@@ -21,8 +21,7 @@ func TestZepOpenAIEmbeddings_Init(t *testing.T) {
 	zembeddings := &ZepOpenAIEmbeddingsClient{}
 
 	err := zembeddings.Init(context.Background(), cfg)
-	assert.NoError(t, err, "Expected no error from Init")
-	assert.NotNil(t, zembeddings.client, "Expected client to be initialized")
+	TestOpenAIClient_Init(t, err, zembeddings.client, EmbeddingsClientType)
 }
 
 func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
@@ -36,13 +35,7 @@ func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zembeddings.configureClient(cfg)
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-
-		if len(options) != 3 {
-			t.Errorf("Expected 2 options, got %d", len(options))
-		}
+		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIAPIKeyTestCase)
 	})
 
 	t.Run("Test with AzureOpenAIEmbeddingModel", func(t *testing.T) {
@@ -57,13 +50,7 @@ func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zembeddings.configureClient(cfg)
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-
-		if len(options) != 6 {
-			t.Errorf("Expected 6 options, got %d", len(options))
-		}
+		TestOpenAIClient_ConfigureClient(t, options, err, AzureOpenAIEmbeddingModelTestCase)
 	})
 
 	t.Run("Test with OpenAIEndpoint", func(t *testing.T) {
@@ -75,13 +62,7 @@ func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zembeddings.configureClient(cfg)
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-
-		if len(options) != 4 {
-			t.Errorf("Expected 3 options, got %d", len(options))
-		}
+		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIEndpointTestCase)
 	})
 
 	t.Run("Test with OpenAIOrgID", func(t *testing.T) {
@@ -93,13 +74,7 @@ func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zembeddings.configureClient(cfg)
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-
-		if len(options) != 4 {
-			t.Errorf("Expected 3 options, got %d", len(options))
-		}
+		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIOrgIDTestCase)
 	})
 }
 
@@ -109,10 +84,6 @@ func TestZepOpenAIEmbeddings_EmbedTexts(t *testing.T) {
 	zembeddings, err := NewOpenAIEmbeddingsClient(context.Background(), cfg)
 	assert.NoError(t, err, "Expected no error from NewOpenAIEmbeddingsClient")
 
-	texts := []string{"Hello, world!", "Another text"}
-	embeddings, err := zembeddings.EmbedTexts(context.Background(), texts)
-	assert.NoError(t, err, "Expected no error from EmbedTexts")
-	assert.Equal(t, len(texts), len(embeddings), "Expected embeddings to have same length as texts")
-	assert.NotZero(t, embeddings[0], "Expected embeddings to be non-zero")
-	assert.NotZero(t, embeddings[1], "Expected embeddings to be non-zero")
+	embeddings, err := zembeddings.EmbedTexts(context.Background(), EmbeddingsTestTexts)
+	TestOpenAIClient_EmbedText(t, embeddings, err)
 }

--- a/pkg/llms/embeddings_openai_test.go
+++ b/pkg/llms/embeddings_openai_test.go
@@ -21,7 +21,7 @@ func TestZepOpenAIEmbeddings_Init(t *testing.T) {
 	zembeddings := &ZepOpenAIEmbeddingsClient{}
 
 	err := zembeddings.Init(context.Background(), cfg)
-	TestOpenAIClient_Init(t, err, zembeddings.client, EmbeddingsClientType)
+	assertInit(t, err, zembeddings.client, EmbeddingsClientType)
 }
 
 func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
@@ -35,7 +35,7 @@ func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zembeddings.configureClient(cfg)
-		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIAPIKeyTestCase)
+		assertConfigureClient(t, options, err, OpenAIAPIKeyTestCase)
 	})
 
 	t.Run("Test with AzureOpenAIEmbeddingModel", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zembeddings.configureClient(cfg)
-		TestOpenAIClient_ConfigureClient(t, options, err, AzureOpenAIEmbeddingModelTestCase)
+		assertConfigureClient(t, options, err, AzureOpenAIEmbeddingModelTestCase)
 	})
 
 	t.Run("Test with OpenAIEndpoint", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zembeddings.configureClient(cfg)
-		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIEndpointTestCase)
+		assertConfigureClient(t, options, err, OpenAIEndpointTestCase)
 	})
 
 	t.Run("Test with OpenAIOrgID", func(t *testing.T) {
@@ -74,7 +74,7 @@ func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zembeddings.configureClient(cfg)
-		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIOrgIDTestCase)
+		assertConfigureClient(t, options, err, OpenAIOrgIDTestCase)
 	})
 }
 
@@ -85,5 +85,5 @@ func TestZepOpenAIEmbeddings_EmbedTexts(t *testing.T) {
 	assert.NoError(t, err, "Expected no error from NewOpenAIEmbeddingsClient")
 
 	embeddings, err := zembeddings.EmbedTexts(context.Background(), EmbeddingsTestTexts)
-	TestOpenAIClient_EmbedText(t, embeddings, err)
+	assertEmbeddings(t, embeddings, err)
 }

--- a/pkg/llms/embeddings_openai_test.go
+++ b/pkg/llms/embeddings_openai_test.go
@@ -1,0 +1,118 @@
+package llms
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getzep/zep/pkg/testutils"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/getzep/zep/config"
+)
+
+func TestZepOpenAIEmbeddings_Init(t *testing.T) {
+	cfg := &config.Config{
+		EmbeddingsClient: config.EmbeddingsClient{
+			OpenAIAPIKey: "test-key",
+		},
+	}
+
+	zembeddings := &ZepOpenAIEmbeddingsClient{}
+
+	err := zembeddings.Init(context.Background(), cfg)
+	assert.NoError(t, err, "Expected no error from Init")
+	assert.NotNil(t, zembeddings.client, "Expected client to be initialized")
+}
+
+func TestZepOpenAIEmbeddings_TestConfigureClient(t *testing.T) {
+	zembeddings := &ZepOpenAIEmbeddingsClient{}
+
+	t.Run("Test with OpenAIAPIKey", func(t *testing.T) {
+		cfg := &config.Config{
+			EmbeddingsClient: config.EmbeddingsClient{
+				OpenAIAPIKey: "test-key",
+			},
+		}
+
+		options, err := zembeddings.configureClient(cfg)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if len(options) != 3 {
+			t.Errorf("Expected 2 options, got %d", len(options))
+		}
+	})
+
+	t.Run("Test with AzureOpenAIEmbeddingModel", func(t *testing.T) {
+		cfg := &config.Config{
+			EmbeddingsClient: config.EmbeddingsClient{
+				OpenAIAPIKey:        "test-key",
+				AzureOpenAIEndpoint: "https://azure.openai.com",
+				AzureOpenAIModel: config.AzureOpenAIConfig{
+					EmbeddingDeployment: "test-embedding-deployment",
+				},
+			},
+		}
+
+		options, err := zembeddings.configureClient(cfg)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if len(options) != 6 {
+			t.Errorf("Expected 6 options, got %d", len(options))
+		}
+	})
+
+	t.Run("Test with OpenAIEndpoint", func(t *testing.T) {
+		cfg := &config.Config{
+			EmbeddingsClient: config.EmbeddingsClient{
+				OpenAIAPIKey:   "test-key",
+				OpenAIEndpoint: "https://openai.com",
+			},
+		}
+
+		options, err := zembeddings.configureClient(cfg)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if len(options) != 4 {
+			t.Errorf("Expected 3 options, got %d", len(options))
+		}
+	})
+
+	t.Run("Test with OpenAIOrgID", func(t *testing.T) {
+		cfg := &config.Config{
+			EmbeddingsClient: config.EmbeddingsClient{
+				OpenAIAPIKey: "test-key",
+				OpenAIOrgID:  "org-id",
+			},
+		}
+
+		options, err := zembeddings.configureClient(cfg)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		if len(options) != 4 {
+			t.Errorf("Expected 3 options, got %d", len(options))
+		}
+	})
+}
+
+func TestZepOpenAIEmbeddings_EmbedTexts(t *testing.T) {
+	cfg := testutils.NewTestConfig()
+
+	zembeddings, err := NewOpenAIEmbeddingsClient(context.Background(), cfg)
+	assert.NoError(t, err, "Expected no error from NewOpenAIEmbeddingsClient")
+
+	texts := []string{"Hello, world!", "Another text"}
+	embeddings, err := zembeddings.EmbedTexts(context.Background(), texts)
+	assert.NoError(t, err, "Expected no error from EmbedTexts")
+	assert.Equal(t, len(texts), len(embeddings), "Expected embeddings to have same length as texts")
+	assert.NotZero(t, embeddings[0], "Expected embeddings to be non-zero")
+	assert.NotZero(t, embeddings[1], "Expected embeddings to be non-zero")
+}

--- a/pkg/llms/llm_base.go
+++ b/pkg/llms/llm_base.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/getzep/zep/pkg/models"
+	"github.com/tmc/langchaingo/llms/openai"
 
 	"github.com/hashicorp/go-retryablehttp"
 
@@ -17,6 +18,11 @@ import (
 
 const DefaultTemperature = 0.0
 const InvalidLLMModelError = "llm model is not set or is invalid"
+const InvalidEmbeddingsClientError = "embeddings client is not set or is invalid"
+
+var InvalidEmbeddingsDeploymentError = func(service string) error {
+	return fmt.Errorf("invalid embeddings deployment for %s, deployment name is required", service)
+}
 
 var log = internal.GetLogger()
 
@@ -43,10 +49,8 @@ func NewLLMClient(ctx context.Context, cfg *config.Config) (models.ZepLLM, error
 			// EmbeddingsDeployment is only required if Zep is also configured to use
 			// OpenAI embeddings for document or message extractors
 			if cfg.LLM.AzureOpenAIModel.EmbeddingDeployment == "" && useOpenAIEmbeddings(cfg) {
-				return nil, fmt.Errorf(
-					"invalid embeddings deployment for %s, deployment name is required",
-					cfg.LLM.Service,
-				)
+				err := InvalidEmbeddingsDeploymentError(cfg.EmbeddingsClient.Service)
+				return nil, err
 			}
 			return NewOpenAILLM(ctx, cfg)
 		}
@@ -77,6 +81,25 @@ func NewLLMClient(ctx context.Context, cfg *config.Config) (models.ZepLLM, error
 		return NewOpenAILLM(ctx, cfg)
 	default:
 		return nil, fmt.Errorf("invalid LLM service: %s", cfg.LLM.Service)
+	}
+}
+
+func NewEmbeddingsClient(ctx context.Context, cfg *config.Config) (models.ZepEmbeddingsClient, error) {
+	switch cfg.EmbeddingsClient.Service {
+	// For now we only support OpenAI embeddings
+	case "openai":
+		// EmbeddingsDeployment is required if using external embeddings with AzureOpenAI
+		if cfg.EmbeddingsClient.AzureOpenAIEndpoint != "" && cfg.EmbeddingsClient.AzureOpenAIModel.EmbeddingDeployment == "" {
+			err := InvalidEmbeddingsDeploymentError(cfg.EmbeddingsClient.Service)
+			return nil, err
+		}
+		// The logic is the same if custom OpenAI Endpoint is set or not
+		// since the model name will be set automatically in this case
+		return NewOpenAIEmbeddingsClient(ctx, cfg)
+	case "":
+		return NewOpenAIEmbeddingsClient(ctx, cfg)
+	default:
+		return nil, fmt.Errorf("invalid embeddings service: %s", cfg.EmbeddingsClient.Service)
 	}
 }
 
@@ -179,4 +202,61 @@ func useOpenAIEmbeddings(cfg *config.Config) bool {
 	}
 
 	return false
+}
+
+func NewOpenAIChatClient(options ...openai.Option) (*openai.Chat, error) {
+	client, err := openai.NewChat(options...)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func GetOpenAIAPIKey(cfg *config.Config, clientType string) string {
+	var apiKey string
+
+	if clientType == "embeddings" {
+		apiKey = cfg.EmbeddingsClient.OpenAIAPIKey
+		// If the key is not set, log a fatal error and exit
+		if apiKey == "" {
+			log.Fatal(EmbeddingsOpenAIAPIKeyNotSetError)
+		}
+	} else {
+		apiKey = cfg.LLM.OpenAIAPIKey
+		if apiKey == "" {
+			log.Fatal(EmbeddingsOpenAIAPIKeyNotSetError)
+		}
+	}
+	return apiKey
+}
+
+func EmbedTextsWithOpenAIClient(ctx context.Context, texts []string, openAIClient *openai.Chat) ([][]float32, error) {
+	// If the LLM is not initialized, return an error
+	if openAIClient == nil {
+		return nil, NewLLMError(InvalidLLMModelError, nil)
+	}
+
+	thisCtx, cancel := context.WithTimeout(ctx, OpenAIAPITimeout)
+	defer cancel()
+
+	embeddings, err := openAIClient.CreateEmbedding(thisCtx, texts)
+	if err != nil {
+		return nil, NewLLMError("error while creating embedding", err)
+	}
+
+	return embeddings, nil
+}
+
+func GetBaseOpenAIClientOptions(apiKey, validModel string) []openai.Option {
+	retryableHTTPClient := NewRetryableHTTPClient(MaxOpenAIAPIRequestAttempts, OpenAIAPITimeout)
+
+	options := make([]openai.Option, 0)
+	options = append(
+		options,
+		openai.WithHTTPClient(retryableHTTPClient.StandardClient()),
+		openai.WithModel(validModel),
+		openai.WithToken(apiKey),
+	)
+
+	return options
 }

--- a/pkg/llms/llm_openai.go
+++ b/pkg/llms/llm_openai.go
@@ -91,7 +91,7 @@ func (zllm *ZepOpenAILLM) configureClient(cfg *config.Config) ([]openai.Option, 
 	// Retrieve the OpenAIAPIKey from configuration
 	apiKey := GetOpenAIAPIKey(cfg, LLMClientType)
 
-	validateOpenAIConfig(cfg, LLMClientType)
+	ValidateOpenAIConfig(cfg, LLMClientType)
 
 	options := GetBaseOpenAIClientOptions(apiKey, cfg.LLM.Model)
 

--- a/pkg/llms/llm_openai_test.go
+++ b/pkg/llms/llm_openai_test.go
@@ -22,8 +22,7 @@ func TestZepOpenAILLM_Init(t *testing.T) {
 	zllm := &ZepOpenAILLM{}
 
 	err := zllm.Init(context.Background(), cfg)
-	assert.NoError(t, err, "Expected no error from Init")
-	assert.NotNil(t, zllm.llm, "Expected llm to be initialized")
+	TestOpenAIClient_Init(t, err, zllm.llm, LLMClientType)
 	assert.NotNil(t, zllm.tkm, "Expected tkm to be initialized")
 }
 
@@ -38,13 +37,7 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zllm.configureClient(cfg)
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-
-		if len(options) != 3 {
-			t.Errorf("Expected 2 options, got %d", len(options))
-		}
+		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIAPIKeyTestCase)
 	})
 
 	t.Run("Test with AzureOpenAIEndpoint", func(t *testing.T) {
@@ -79,13 +72,7 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zllm.configureClient(cfg)
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-
-		if len(options) != 6 {
-			t.Errorf("Expected 6 options, got %d", len(options))
-		}
+		TestOpenAIClient_ConfigureClient(t, options, err, AzureOpenAIEmbeddingModelTestCase)
 	})
 
 	t.Run("Test with OpenAIEndpointAndCustomModelName", func(t *testing.T) {
@@ -98,13 +85,7 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zllm.configureClient(cfg)
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-
-		if len(options) != 4 {
-			t.Errorf("Expected 3 options, got %d", len(options))
-		}
+		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIEndpointTestCase)
 	})
 
 	t.Run("Test with OpenAIOrgID", func(t *testing.T) {
@@ -116,13 +97,7 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zllm.configureClient(cfg)
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-
-		if len(options) != 4 {
-			t.Errorf("Expected 3 options, got %d", len(options))
-		}
+		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIOrgIDTestCase)
 	})
 }
 
@@ -146,12 +121,8 @@ func TestZepOpenAILLM_EmbedTexts(t *testing.T) {
 	zllm, err := NewOpenAILLM(context.Background(), cfg)
 	assert.NoError(t, err, "Expected no error from NewOpenAILLM")
 
-	texts := []string{"Hello, world!", "Another text"}
-	embeddings, err := zllm.EmbedTexts(context.Background(), texts)
-	assert.NoError(t, err, "Expected no error from EmbedTexts")
-	assert.Equal(t, len(texts), len(embeddings), "Expected embeddings to have same length as texts")
-	assert.NotZero(t, embeddings[0], "Expected embeddings to be non-zero")
-	assert.NotZero(t, embeddings[1], "Expected embeddings to be non-zero")
+	embeddings, err := zllm.EmbedTexts(context.Background(), EmbeddingsTestTexts)
+	TestOpenAIClient_EmbedText(t, embeddings, err)
 }
 
 func TestZepOpenAILLM_GetTokenCount(t *testing.T) {

--- a/pkg/llms/llm_openai_test.go
+++ b/pkg/llms/llm_openai_test.go
@@ -22,7 +22,7 @@ func TestZepOpenAILLM_Init(t *testing.T) {
 	zllm := &ZepOpenAILLM{}
 
 	err := zllm.Init(context.Background(), cfg)
-	TestOpenAIClient_Init(t, err, zllm.llm, LLMClientType)
+	assertInit(t, err, zllm.llm, LLMClientType)
 	assert.NotNil(t, zllm.tkm, "Expected tkm to be initialized")
 }
 
@@ -37,7 +37,7 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zllm.configureClient(cfg)
-		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIAPIKeyTestCase)
+		assertConfigureClient(t, options, err, OpenAIAPIKeyTestCase)
 	})
 
 	t.Run("Test with AzureOpenAIEndpoint", func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zllm.configureClient(cfg)
-		TestOpenAIClient_ConfigureClient(t, options, err, AzureOpenAIEmbeddingModelTestCase)
+		assertConfigureClient(t, options, err, AzureOpenAIEmbeddingModelTestCase)
 	})
 
 	t.Run("Test with OpenAIEndpointAndCustomModelName", func(t *testing.T) {
@@ -85,7 +85,7 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zllm.configureClient(cfg)
-		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIEndpointTestCase)
+		assertConfigureClient(t, options, err, OpenAIEndpointTestCase)
 	})
 
 	t.Run("Test with OpenAIOrgID", func(t *testing.T) {
@@ -97,7 +97,7 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 		}
 
 		options, err := zllm.configureClient(cfg)
-		TestOpenAIClient_ConfigureClient(t, options, err, OpenAIOrgIDTestCase)
+		assertConfigureClient(t, options, err, OpenAIOrgIDTestCase)
 	})
 }
 
@@ -122,7 +122,7 @@ func TestZepOpenAILLM_EmbedTexts(t *testing.T) {
 	assert.NoError(t, err, "Expected no error from NewOpenAILLM")
 
 	embeddings, err := zllm.EmbedTexts(context.Background(), EmbeddingsTestTexts)
-	TestOpenAIClient_EmbedText(t, embeddings, err)
+	assertEmbeddings(t, embeddings, err)
 }
 
 func TestZepOpenAILLM_GetTokenCount(t *testing.T) {

--- a/pkg/llms/openai_base.go
+++ b/pkg/llms/openai_base.go
@@ -1,0 +1,153 @@
+package llms
+
+import (
+	"context"
+	"time"
+
+	"github.com/getzep/zep/config"
+	"github.com/tmc/langchaingo/llms/openai"
+)
+
+const OpenAIAPITimeout = 90 * time.Second
+const MaxOpenAIAPIRequestAttempts = 5
+
+type ClientType string
+
+const (
+	EmbeddingsClientType ClientType = "embeddings"
+	LLMClientType        ClientType = "llm"
+)
+
+func NewOpenAIChatClient(options ...openai.Option) (*openai.Chat, error) {
+	client, err := openai.NewChat(options...)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func GetOpenAIAPIKey(cfg *config.Config, clientType ClientType) string {
+	var apiKey string
+
+	if clientType == EmbeddingsClientType {
+		apiKey = cfg.EmbeddingsClient.OpenAIAPIKey
+		// If the key is not set, log a fatal error and exit
+		if apiKey == "" {
+			log.Fatal(EmbeddingsOpenAIAPIKeyNotSetError)
+		}
+	} else {
+		apiKey = cfg.LLM.OpenAIAPIKey
+		if apiKey == "" {
+			log.Fatal(OpenAIAPIKeyNotSetError)
+		}
+	}
+	return apiKey
+}
+
+func validateOpenAIConfig(cfg *config.Config, clientType ClientType) {
+
+	var azureEndpoint string
+	var openAIEndpoint string
+
+	if clientType == EmbeddingsClientType {
+		azureEndpoint = cfg.EmbeddingsClient.AzureOpenAIEndpoint
+		openAIEndpoint = cfg.EmbeddingsClient.OpenAIEndpoint
+	} else {
+		azureEndpoint = cfg.LLM.AzureOpenAIEndpoint
+		openAIEndpoint = cfg.LLM.OpenAIEndpoint
+	}
+
+	if azureEndpoint != "" && openAIEndpoint != "" {
+		log.Fatal("only one of AzureOpenAIEndpoint or OpenAIEndpoint can be set")
+	}
+}
+
+func EmbedTextsWithOpenAIClient(ctx context.Context, texts []string, openAIClient *openai.Chat, clientType ClientType) ([][]float32, error) {
+	// If the Client is not initialized, return an error
+	if openAIClient == nil {
+		if clientType == EmbeddingsClientType {
+			return nil, NewEmbeddingsClientError(InvalidEmbeddingsClientError, nil)
+		}
+		return nil, NewLLMError(InvalidLLMModelError, nil)
+	}
+
+	thisCtx, cancel := context.WithTimeout(ctx, OpenAIAPITimeout)
+	defer cancel()
+
+	embeddings, err := openAIClient.CreateEmbedding(thisCtx, texts)
+	if err != nil {
+		message := "error while creating embedding"
+		if clientType == EmbeddingsClientType {
+			return nil, NewEmbeddingsClientError(message, nil)
+		}
+		return nil, NewLLMError(message, err)
+	}
+
+	return embeddings, nil
+}
+
+func GetBaseOpenAIClientOptions(apiKey, validModel string) []openai.Option {
+	retryableHTTPClient := NewRetryableHTTPClient(MaxOpenAIAPIRequestAttempts, OpenAIAPITimeout)
+
+	options := make([]openai.Option, 0)
+	options = append(
+		options,
+		openai.WithHTTPClient(retryableHTTPClient.StandardClient()),
+		openai.WithModel(validModel),
+		openai.WithToken(apiKey),
+	)
+
+	return options
+}
+
+func ConfigureOpenAIClientOptions(options []openai.Option, cfg *config.Config, clientType ClientType) []openai.Option {
+	applyOption := func(cond bool, opts ...openai.Option) []openai.Option {
+		if cond {
+			return append(options, opts...)
+		}
+		return options
+	}
+
+	var openAIEndpoint string
+	var openAIOrgID string
+
+	if clientType == EmbeddingsClientType {
+		openAIEndpoint = cfg.EmbeddingsClient.OpenAIEndpoint
+		openAIOrgID = cfg.EmbeddingsClient.OpenAIOrgID
+
+		// Check configuration for AzureOpenAIEndpoint; if it's set, use the DefaultAzureConfig
+		// and provided endpoint Path.
+		// WithEmbeddings is always required in case of embeddings client
+		options = applyOption(cfg.EmbeddingsClient.AzureOpenAIEndpoint != "",
+			openai.WithAPIType(openai.APITypeAzure),
+			openai.WithBaseURL(cfg.EmbeddingsClient.AzureOpenAIEndpoint),
+			openai.WithEmbeddingModel(cfg.EmbeddingsClient.AzureOpenAIModel.EmbeddingDeployment),
+		)
+	} else {
+		openAIEndpoint = cfg.LLM.OpenAIEndpoint
+		openAIOrgID = cfg.LLM.OpenAIOrgID
+
+		options = append(
+			options,
+			openai.WithAPIType(openai.APITypeAzure),
+			openai.WithBaseURL(cfg.LLM.AzureOpenAIEndpoint),
+		)
+		if cfg.LLM.AzureOpenAIModel.EmbeddingDeployment != "" {
+			options = append(
+				options,
+				openai.WithEmbeddingModel(cfg.LLM.AzureOpenAIModel.EmbeddingDeployment),
+			)
+		}
+
+	}
+
+	options = applyOption(openAIEndpoint != "",
+		openai.WithBaseURL(openAIEndpoint),
+	)
+
+	options = applyOption(openAIOrgID != "",
+		openai.WithOrganization(openAIOrgID),
+	)
+
+	return options
+}

--- a/pkg/llms/openai_base.go
+++ b/pkg/llms/openai_base.go
@@ -44,7 +44,7 @@ func GetOpenAIAPIKey(cfg *config.Config, clientType ClientType) string {
 	return apiKey
 }
 
-func validateOpenAIConfig(cfg *config.Config, clientType ClientType) {
+func ValidateOpenAIConfig(cfg *config.Config, clientType ClientType) {
 
 	var azureEndpoint string
 	var openAIEndpoint string

--- a/pkg/llms/openai_base.go
+++ b/pkg/llms/openai_base.go
@@ -127,18 +127,13 @@ func ConfigureOpenAIClientOptions(options []openai.Option, cfg *config.Config, c
 		openAIEndpoint = cfg.LLM.OpenAIEndpoint
 		openAIOrgID = cfg.LLM.OpenAIOrgID
 
-		options = append(
-			options,
+		options = applyOption(cfg.LLM.AzureOpenAIEndpoint != "",
 			openai.WithAPIType(openai.APITypeAzure),
 			openai.WithBaseURL(cfg.LLM.AzureOpenAIEndpoint),
 		)
-		if cfg.LLM.AzureOpenAIModel.EmbeddingDeployment != "" {
-			options = append(
-				options,
-				openai.WithEmbeddingModel(cfg.LLM.AzureOpenAIModel.EmbeddingDeployment),
-			)
-		}
-
+		options = applyOption(cfg.LLM.AzureOpenAIModel.EmbeddingDeployment != "",
+			openai.WithEmbeddingModel(cfg.LLM.AzureOpenAIModel.EmbeddingDeployment),
+		)
 	}
 
 	options = applyOption(openAIEndpoint != "",

--- a/pkg/llms/openai_base_test.go
+++ b/pkg/llms/openai_base_test.go
@@ -1,0 +1,57 @@
+package llms
+
+import (
+	"testing"
+
+	"github.com/tmc/langchaingo/llms/openai"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestCaseType string
+
+const (
+	OpenAIAPIKeyTestCase              TestCaseType = "OpenAIAPIKeyTestCase"
+	AzureOpenAIEmbeddingModelTestCase TestCaseType = "AzureOpenAIEmbeddingModelTestCase"
+	OpenAIEndpointTestCase            TestCaseType = "OpenAIEndpointTestCase"
+	OpenAIOrgIDTestCase               TestCaseType = "OpenAIOrgIDTestCase"
+)
+
+var EmbeddingsTestTexts = []string{"Hello, world!", "Another text"}
+
+func TestOpenAIClient_Init(t *testing.T, err error, openAIClient *openai.Chat, clientType ClientType) {
+	assert.NoError(t, err, "Expected no error from Init")
+	switch clientType {
+	case EmbeddingsClientType:
+		assert.NotNil(t, openAIClient, "Expected client to be initialized")
+	default:
+		assert.NotNil(t, openAIClient, "Expected llm to be initialized")
+	}
+}
+
+func TestOpenAIClient_ConfigureClient(t *testing.T, options []openai.Option, err error, testCase TestCaseType) {
+	assert.NoError(t, err, "Unexpected error")
+	expectedOptions := map[TestCaseType]int{
+		OpenAIAPIKeyTestCase:              3,
+		AzureOpenAIEmbeddingModelTestCase: 6,
+		OpenAIEndpointTestCase:            4,
+		OpenAIOrgIDTestCase:               4,
+	}
+	expected, ok := expectedOptions[testCase]
+	if !ok {
+		t.Errorf("Unexpected test case: %s", testCase)
+		return
+	}
+	//? assert.Len(t, options, expected, "Unexpected number of options")
+	if len(options) != expected {
+		t.Errorf("Expected %e options, got %d", expected, len(options))
+	}
+}
+
+func TestOpenAIClient_EmbedText(t *testing.T, embeddings [][]float32, err error) {
+	assert.NoError(t, err, "Expected no error from EmbedTexts")
+	assert.Equal(t, len(EmbeddingsTestTexts), len(embeddings), "Expected embeddings to have same length as texts")
+	assert.NotZero(t, embeddings[0], "Expected embeddings to be non-zero")
+	assert.NotZero(t, embeddings[1], "Expected embeddings to be non-zero")
+	assert.NoError(t, err, "Unexpected error")
+}

--- a/pkg/llms/openai_base_test.go
+++ b/pkg/llms/openai_base_test.go
@@ -19,7 +19,8 @@ const (
 
 var EmbeddingsTestTexts = []string{"Hello, world!", "Another text"}
 
-func TestOpenAIClient_Init(t *testing.T, err error, openAIClient *openai.Chat, clientType ClientType) {
+func assertInit(t *testing.T, err error, openAIClient *openai.Chat, clientType ClientType) {
+	t.Helper()
 	assert.NoError(t, err, "Expected no error from Init")
 	switch clientType {
 	case EmbeddingsClientType:
@@ -29,7 +30,8 @@ func TestOpenAIClient_Init(t *testing.T, err error, openAIClient *openai.Chat, c
 	}
 }
 
-func TestOpenAIClient_ConfigureClient(t *testing.T, options []openai.Option, err error, testCase TestCaseType) {
+func assertConfigureClient(t *testing.T, options []openai.Option, err error, testCase TestCaseType) {
+	t.Helper()
 	assert.NoError(t, err, "Unexpected error")
 	expectedOptions := map[TestCaseType]int{
 		OpenAIAPIKeyTestCase:              3,
@@ -44,11 +46,12 @@ func TestOpenAIClient_ConfigureClient(t *testing.T, options []openai.Option, err
 	}
 	//? assert.Len(t, options, expected, "Unexpected number of options")
 	if len(options) != expected {
-		t.Errorf("Expected %e options, got %d", expected, len(options))
+		t.Errorf("Expected %d options, got %d", expected, len(options))
 	}
 }
 
-func TestOpenAIClient_EmbedText(t *testing.T, embeddings [][]float32, err error) {
+func assertEmbeddings(t *testing.T, embeddings [][]float32, err error) {
+	t.Helper()
 	assert.NoError(t, err, "Expected no error from EmbedTexts")
 	assert.Equal(t, len(EmbeddingsTestTexts), len(embeddings), "Expected embeddings to have same length as texts")
 	assert.NotZero(t, embeddings[0], "Expected embeddings to be non-zero")

--- a/pkg/models/appstate.go
+++ b/pkg/models/appstate.go
@@ -7,11 +7,12 @@ import (
 // AppState is a struct that holds the state of the application
 // Use cmd.NewAppState to create a new instance
 type AppState struct {
-	LLMClient     ZepLLM
-	MemoryStore   MemoryStore[any]
-	DocumentStore DocumentStore[any]
-	UserStore     UserStore
-	TaskRouter    TaskRouter
-	TaskPublisher TaskPublisher
-	Config        *config.Config
+	LLMClient        ZepLLM
+	EmbeddingsClient ZepEmbeddingsClient
+	MemoryStore      MemoryStore[any]
+	DocumentStore    DocumentStore[any]
+	UserStore        UserStore
+	TaskRouter       TaskRouter
+	TaskPublisher    TaskPublisher
+	Config           *config.Config
 }

--- a/pkg/models/zembeddings.go
+++ b/pkg/models/zembeddings.go
@@ -1,0 +1,14 @@
+package models
+
+import (
+	"context"
+
+	"github.com/getzep/zep/config"
+)
+
+type ZepEmbeddingsClient interface {
+	// EmbedTexts embeds the given texts
+	EmbedTexts(ctx context.Context, texts []string) ([][]float32, error)
+	// Init initializes the Client
+	Init(ctx context.Context, cfg *config.Config) error
+}

--- a/pkg/server/webhandlers/settings.go
+++ b/pkg/server/webhandlers/settings.go
@@ -23,6 +23,7 @@ func redactHTMLEncodeConfig(cfg *config.Config) (*config.Config, error) {
 	redactedConfig := *cfg
 	redactedConfig.LLM.AnthropicAPIKey = "**redacted**"
 	redactedConfig.LLM.OpenAIAPIKey = "**redacted**"
+	redactedConfig.EmbeddingsClient.OpenAIAPIKey = "**redacted**"
 	redactedConfig.Auth.Secret = "**redacted**"
 
 	re := regexp.MustCompile(`(?i:postgres://[^:]+:)([^@]+)`)

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -100,6 +100,8 @@ func testConfigDefaults() (*config.Config, error) {
 			testConfig.LLM.AnthropicAPIKey = os.Getenv(envVar)
 		case "llm.openai_api_key":
 			testConfig.LLM.OpenAIAPIKey = os.Getenv(envVar)
+		case "embeddings_client.openai_api_key":
+			testConfig.EmbeddingsClient.OpenAIAPIKey = os.Getenv(envVar)
 		case "auth.secret":
 			testConfig.Auth.Secret = os.Getenv(envVar)
 		case "development":


### PR DESCRIPTION
Hi @danielchalef, I'm proposing this PR since I'm currently using this feature on my own project and it may be useful to users using open source models, or users using Anthropic llm and that would like to use OpenAI embeddings.

The goal is to give the option to create a separate embeddings client. For example in my case, I use the Llama 2 70B Chat through a compatible OpenAI endpoint, but those endpoints just have the llm part enabled, not the embeddings part (in my case I use Anyscale Endpoints, but it would be the same problem for users hosting their own open source model using compatible OpenAI endpoints with vLLM for example).

With this PR, if the embeddings client is disabled (false by default), it will use the llm endpoint for embeddings as it is currently the case.
If you enable embeddings client, you can configure this endpoint that will be specifically used for embeddings (when not using local embeddings), only with the OpenAI service option for the moment. This allows me for example to use the open source model for intents and summaries, and the OpenAI api for embeddings.

The tests are passing locally (except for the Anthropic ones since I don't have a key) and I added some new tests for this use case also. It's also working on Render with embeddings client disabled or enabled

Tell me if you think it would be interesting to merge this feature on the main repo (this is the second time I write with go so please also tell me if I need to rework/rewrite some parts). 
I can also make a separate PR to be able to customise the intent prompt when using open source models if you think it would be interesting