### PR TITLE
fix: memstore refactor issue + others

### DIFF
--- a/pkg/server/apihandlers/memory_handlers.go
+++ b/pkg/server/apihandlers/memory_handlers.go
@@ -35,10 +35,6 @@ func GetMemoryHandler(appState *models.AppState) http.HandlerFunc {
 			handlertools.RenderError(w, err, http.StatusBadRequest)
 			return
 		}
-		if lastN == 0 {
-			handlertools.RenderError(w, fmt.Errorf("lastn must be greater than 0"), http.StatusBadRequest)
-			return
-		}
 
 		sessionMemory, err := appState.MemoryStore.GetMemory(r.Context(), sessionID, lastN)
 		if err != nil {

--- a/pkg/tasks/message_ner.go
+++ b/pkg/tasks/message_ner.go
@@ -69,10 +69,6 @@ func (n *MessageNERTask) Execute(
 		}
 		entityList := extractEntities(r.Entities)
 
-		if len(entityList) == 0 {
-			continue
-		}
-
 		nerMessages[i] = models.Message{
 			UUID: msgUUID,
 			Metadata: map[string]interface{}{


### PR DESCRIPTION
Fix issue introduced during memstore refactor. Fix NER issue that had been hanging around for a while. When no named entities were found, we skipped adding a record to the slice we persisted back to the DB, however the slice was initialized with the size of the source slice.

- lastn is optional and can be 0
- don't drop ner msg update if no ner result
