### PR TITLE
fix(summaries): Don't summarize empty messages

### DIFF
--- a/pkg/tasks/message_summarizer.go
+++ b/pkg/tasks/message_summarizer.go
@@ -76,6 +76,10 @@ func (t *MessageSummaryTask) Execute(
 		log.Warningf("SummaryTask GetMemory returned no messages for session %s", sessionID)
 		return nil
 	}
+
+	// drop empty messages
+	messages = dropEmptyMessages(messages)
+
 	// If we're still under the message window, we don't need to summarize.
 	if len(messages) < t.appState.Config.Memory.MessageWindow {
 		return nil

--- a/pkg/tasks/message_utils.go
+++ b/pkg/tasks/message_utils.go
@@ -4,11 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/getzep/zep/pkg/models"
 	"github.com/google/uuid"
 )
+
+func dropEmptyMessages(messages []models.Message) []models.Message {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if strings.TrimSpace(messages[i].Content) == "" {
+			messages = append(messages[:i], messages[i+1:]...)
+		}
+	}
+	return messages
+}
 
 func summaryTaskPayloadToSummary(
 	ctx context.Context,

--- a/pkg/tasks/message_utils_test.go
+++ b/pkg/tasks/message_utils_test.go
@@ -1,0 +1,23 @@
+package tasks
+
+import (
+	"github.com/getzep/zep/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDropEmptyMessages(t *testing.T) {
+	messages := []models.Message{
+		{Content: "Hello"},
+		{Content: " "},
+		{Content: "\n"},
+		{Content: "World"},
+		{Content: ""},
+	}
+
+	result := dropEmptyMessages(messages)
+
+	assert.Equal(t, 2, len(result), "Expected 2 messages")
+	assert.Equal(t, "Hello", result[0].Content, "Expected first message to be 'Hello'")
+	assert.Equal(t, "World", result[1].Content, "Expected second message to be 'World'")
+}


### PR DESCRIPTION
ref: #285 

Problem: Summarizer attempted to summarize empty messages, which resulted in broken responses from the  LLM.

Fix: Drop messages where Content is empty (nil string, whitespace characters)