### PR TITLE
Feature/custom headers (issue #169)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -66,13 +66,10 @@ server:
   max_request_size: 5242880
   # Custom headers to be included in the server responses. Define each header as a key-value pair.
   # This feature allows you to specify additional headers for compliance, security, or other purposes.
-  # DO NOT hard-code secrets in this file.
+  # For sensitive headers, use a placeholder and fetch the value from an environment variable in your application logic.
   # custom_headers:
-  #   X-Frame-Options: "DENY"
-  #   X-XSS-Protection: "1; mode=block"
-  # use_custom_auth: true
-  # Indicates whether to use custom authentication. If true, the application expects a custom auth header.
-  # The actual header should be provided through the ZEP_CUSTOM_AUTH_HEADER environment variable.
+  #   Example-Header: "Value"
+  #   Sensitive-Header: "env:MY_SENSITIVE_HEADER"
 auth:
   # Set to true to enable authentication
   required: false

--- a/config.yaml
+++ b/config.yaml
@@ -64,6 +64,12 @@ server:
   web_enabled: true
   # The maximum size of a request body, in bytes. Defaults to 5MB.
   max_request_size: 5242880
+  # Custom headers to be included in the server responses. Define each header as a key-value pair.
+  # This feature allows you to specify additional headers for compliance, security, or other purposes.
+  # DO NOT hard-code secrets in this file: use the ZEP_CUSTOM_AUTH_HEADER environment variable instead.
+  # custom_headers:
+  #   X-Frame-Options: "DENY"
+  #   X-XSS-Protection: "1; mode=block"
 auth:
   # Set to true to enable authentication
   required: false

--- a/config.yaml
+++ b/config.yaml
@@ -66,10 +66,13 @@ server:
   max_request_size: 5242880
   # Custom headers to be included in the server responses. Define each header as a key-value pair.
   # This feature allows you to specify additional headers for compliance, security, or other purposes.
-  # DO NOT hard-code secrets in this file: use the ZEP_CUSTOM_AUTH_HEADER environment variable instead.
+  # DO NOT hard-code secrets in this file.
   # custom_headers:
   #   X-Frame-Options: "DENY"
   #   X-XSS-Protection: "1; mode=block"
+  # use_custom_auth: true
+  # Indicates whether to use custom authentication. If true, the application expects a custom auth header.
+  # The actual header should be provided through the ZEP_CUSTOM_AUTH_HEADER environment variable.
 auth:
   # Set to true to enable authentication
   required: false

--- a/config/config.go
+++ b/config/config.go
@@ -16,11 +16,10 @@ var log = logrus.New()
 
 // EnvVars is a set of secrets that should be stored in the environment, not config file
 var EnvVars = map[string]string{
-	"llm.anthropic_api_key":     "ZEP_ANTHROPIC_API_KEY",
-	"llm.openai_api_key":        "ZEP_OPENAI_API_KEY",
-	"auth.secret":               "ZEP_AUTH_SECRET",
-	"development":               "ZEP_DEVELOPMENT",
-	"server.custom_auth_header": "ZEP_CUSTOM_AUTH_HEADER",
+	"llm.anthropic_api_key": "ZEP_ANTHROPIC_API_KEY",
+	"llm.openai_api_key":    "ZEP_OPENAI_API_KEY",
+	"auth.secret":           "ZEP_AUTH_SECRET",
+	"development":           "ZEP_DEVELOPMENT",
 }
 
 // LoadConfig loads the config file and ENV variables into a Config struct

--- a/config/config.go
+++ b/config/config.go
@@ -16,10 +16,11 @@ var log = logrus.New()
 
 // EnvVars is a set of secrets that should be stored in the environment, not config file
 var EnvVars = map[string]string{
-	"llm.anthropic_api_key": "ZEP_ANTHROPIC_API_KEY",
-	"llm.openai_api_key":    "ZEP_OPENAI_API_KEY",
-	"auth.secret":           "ZEP_AUTH_SECRET",
-	"development":           "ZEP_DEVELOPMENT",
+	"llm.anthropic_api_key":     "ZEP_ANTHROPIC_API_KEY",
+	"llm.openai_api_key":        "ZEP_OPENAI_API_KEY",
+	"auth.secret":               "ZEP_AUTH_SECRET",
+	"development":               "ZEP_DEVELOPMENT",
+	"server.custom_auth_header": "ZEP_CUSTOM_AUTH_HEADER",
 }
 
 // LoadConfig loads the config file and ENV variables into a Config struct

--- a/config/models.go
+++ b/config/models.go
@@ -62,6 +62,7 @@ type ServerConfig struct {
 	WebEnabled     bool              `mapstructure:"web_enabled"`
 	MaxRequestSize int64             `mapstructure:"max_request_size"`
 	CustomHeaders  map[string]string `mapstructure:"custom_headers"`
+	UseCustomAuth  bool              `mapstructure:"use_custom_auth"`
 }
 
 type LogConfig struct {

--- a/config/models.go
+++ b/config/models.go
@@ -57,10 +57,11 @@ type AvailableIndexes struct {
 }
 
 type ServerConfig struct {
-	Host           string `mapstructure:"host"`
-	Port           int    `mapstructure:"port"`
-	WebEnabled     bool   `mapstructure:"web_enabled"`
-	MaxRequestSize int64  `mapstructure:"max_request_size"`
+	Host           string            `mapstructure:"host"`
+	Port           int               `mapstructure:"port"`
+	WebEnabled     bool              `mapstructure:"web_enabled"`
+	MaxRequestSize int64             `mapstructure:"max_request_size"`
+	CustomHeaders  map[string]string `mapstructure:"custom_headers"`
 }
 
 type LogConfig struct {

--- a/config/models.go
+++ b/config/models.go
@@ -62,7 +62,6 @@ type ServerConfig struct {
 	WebEnabled     bool              `mapstructure:"web_enabled"`
 	MaxRequestSize int64             `mapstructure:"max_request_size"`
 	CustomHeaders  map[string]string `mapstructure:"custom_headers"`
-	UseCustomAuth  bool              `mapstructure:"use_custom_auth"`
 }
 
 type LogConfig struct {

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/getzep/zep/config"
 )
@@ -23,12 +25,20 @@ func SendVersion(next http.Handler) http.Handler {
 	return http.HandlerFunc(fn)
 }
 
+// ApplyCustomHeaders is a middleware that adds custom headers to the response
 func ApplyCustomHeaders(customHeaders map[string]string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			for key, value := range customHeaders {
+				actualValue := value
+				// Detect and handle sensitive header values originating from environment variables
+				if strings.HasPrefix(value, "env:") {
+					actualValue = os.Getenv(value[4:])
+				}
+
+				// Only add the header if it's not already set, allowing for route-specific overrides
 				if w.Header().Get(key) == "" {
-					w.Header().Add(key, value)
+					w.Header().Add(key, actualValue)
 				}
 			}
 			next.ServeHTTP(w, r)

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -22,3 +22,16 @@ func SendVersion(next http.Handler) http.Handler {
 	}
 	return http.HandlerFunc(fn)
 }
+
+func ApplyCustomHeaders(customHeaders map[string]string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for key, value := range customHeaders {
+				if w.Header().Get(key) == "" {
+					w.Header().Add(key, value)
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -69,6 +69,7 @@ func setupRouter(appState *models.AppState) *chi.Mux {
 		middleware.RealIP,
 		middleware.CleanPath,
 		SendVersion,
+		ApplyCustomHeaders(appState.Config.Server.CustomHeaders),
 		middleware.Heartbeat("/healthz"),
 	)
 


### PR DESCRIPTION
This PR implements the ability to add custom headers to responses. It follows the steps outlined in #169 except it does not use `var EnvVars = map[string]string{ ` and instead references the .env variable in the `config.yaml`, because custom headers need a custom key ('apiKey' for example) and this seemed the most straightforward and user-friendly solution. All tests passed and the lint passed.

I'm not sure how to best implement `ApplyCustomHeaders` in `routes.go`. Right now the custom headers attach to every response, which does not seem right. Any direction and help finalizing would be much appreciated!

<!--
ELLIPSIS_HIDDEN
-->


----

> :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 135b0ddb998d9396c6e5843a3c06521eb5520346.

### Summary:
This PR adds the ability to include custom headers in server responses, defined in `config.yaml`, and applies them to every response via a new middleware function `ApplyCustomHeaders`.

**Key points**:
- Added `CustomHeaders` field in `ServerConfig` struct in `config/models.go`
- Defined custom headers in `config.yaml`
- Implemented `ApplyCustomHeaders` function in `pkg/server/middleware.go` to add custom headers to responses
- Added `ApplyCustomHeaders` to middleware stack in `pkg/server/routes.go`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
