### PR TITLE
Adding new openai 4o-mini model

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 llm:
   # openai or anthropic
   service: "openai"
-  # OpenAI: gpt-3.5-turbo, gpt-4, gpt-3.5-turbo-1106, gpt-3.5-turbo-16k, gpt-4-32k; Anthropic: claude-instant-1 or claude-2
+  # OpenAI: gpt-3.5-turbo, gpt-4, gpt-3.5-turbo-1106, gpt-3.5-turbo-16k, gpt-4-32k, gpt-4o-mini, gpt-4o-mini-2024-07-18; Anthropic: claude-instant-1 or claude-2
   model: "gpt-3.5-turbo-1106"
   ## OpenAI-specific settings
   # Only used for Azure OpenAI API

--- a/pkg/llms/llm_base.go
+++ b/pkg/llms/llm_base.go
@@ -152,14 +152,16 @@ func NewLLMError(message string, originalError error) *LLMError {
 }
 
 var ValidOpenAILLMs = map[string]bool{
-	"gpt-3.5-turbo":      true,
-	"gpt-4":              true,
-	"gpt-3.5-turbo-16k":  true,
-	"gpt-3.5-turbo-1106": true,
-	"gpt-4-32k":          true,
-	"gpt-4-1106-preview": true,
-	"gpt-4-turbo":        true,
-	"gpt-4o":             true,
+	"gpt-3.5-turbo":          true,
+	"gpt-4":                  true,
+	"gpt-3.5-turbo-16k":      true,
+	"gpt-3.5-turbo-1106":     true,
+	"gpt-4-32k":              true,
+	"gpt-4-1106-preview":     true,
+	"gpt-4-turbo":            true,
+	"gpt-4o":                 true,
+	"gto-4o-mini":            true,
+	"gpt-4o-mini-2024-07-18": true,
 }
 
 var ValidAnthropicLLMs = map[string]bool{

--- a/pkg/llms/llm_base.go
+++ b/pkg/llms/llm_base.go
@@ -160,7 +160,7 @@ var ValidOpenAILLMs = map[string]bool{
 	"gpt-4-1106-preview":     true,
 	"gpt-4-turbo":            true,
 	"gpt-4o":                 true,
-	"gto-4o-mini":            true,
+	"gpt-4o-mini":            true,
 	"gpt-4o-mini-2024-07-18": true,
 }
 


### PR DESCRIPTION
openai 4o-mini is smarter and cheaper than openai 3.5-turbo.
Adding openai 4o-mini and gpt-4o-mini-2024-07-18 to the list of valid open ai llm models
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit de1842dc9b8d4100b175062684a833afbd4a9189  | 
|--------|--------|

### Summary:
Added `gto-4o-mini` and `gpt-4o-mini-2024-07-18` to the valid OpenAI LLM models in `pkg/llms/llm_base.go`.

**Key points**:
- Added `gto-4o-mini` and `gpt-4o-mini-2024-07-18` to `ValidOpenAILLMs` map in `pkg/llms/llm_base.go`.
- These models are now recognized as valid OpenAI LLM models.
- No other changes were made to the codebase.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->