### PR TITLE
Updating default open ai model in config and tests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ llm:
   azure_openai:
   # llm.model name is used as deployment name as reasonable default if not set
   # assuming base model is deployed with deployment name matching model name
-  #   llm_deployment: "gpt-4.0-mini-customname"
+  #   llm_deployment: "gpt-4o-mini-customname"
   # embeddings deployment is required when Zep is configured to use OpenAI embeddings
   #   embedding_deployment: "text-embedding-ada-002-customname"
   # Use only with an alternate OpenAI-compatible API endpoint

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 llm:
   # openai or anthropic
   service: "openai"
-  # OpenAI: gpt-3.5-turbo, gpt-4, gpt-3.5-turbo-1106, gpt-3.5-turbo-16k, gpt-4-32k, gpt-4o, gpt-4o-2024-08-06, gpt-4o-mini, gpt-4o-mini-2024-07-18; Anthropic: claude-instant-1 or claude-2
+  # OpenAI: gpt-3.5-turbo, gpt-4, gpt-3.5-turbo-1106, gpt-3.5-turbo-16k, gpt-4-32k, gpt-4o-mini, gpt-4o-mini-2024-07-18; Anthropic: claude-instant-1 or claude-2
   model: "gpt-3.5-turbo-1106"
   ## OpenAI-specific settings
   # Only used for Azure OpenAI API

--- a/config.yaml
+++ b/config.yaml
@@ -2,7 +2,7 @@ llm:
   # openai or anthropic
   service: "openai"
   # OpenAI: gpt-3.5-turbo, gpt-4, gpt-3.5-turbo-1106, gpt-3.5-turbo-16k, gpt-4-32k, gpt-4o-mini, gpt-4o-mini-2024-07-18; Anthropic: claude-instant-1 or claude-2
-  model: "gpt-3.5-turbo-1106"
+  model: "gpt-4o-mini"
   ## OpenAI-specific settings
   # Only used for Azure OpenAI API
   azure_openai_endpoint:

--- a/config.yaml
+++ b/config.yaml
@@ -12,7 +12,7 @@ llm:
   azure_openai:
   # llm.model name is used as deployment name as reasonable default if not set
   # assuming base model is deployed with deployment name matching model name
-  #   llm_deployment: "gpt-3.5-turbo-customname"
+  #   llm_deployment: "gpt-4.0-mini-customname"
   # embeddings deployment is required when Zep is configured to use OpenAI embeddings
   #   embedding_deployment: "text-embedding-ada-002-customname"
   # Use only with an alternate OpenAI-compatible API endpoint

--- a/pkg/llms/llm_openai_test.go
+++ b/pkg/llms/llm_openai_test.go
@@ -14,7 +14,7 @@ import (
 func TestZepOpenAILLM_Init(t *testing.T) {
 	cfg := &config.Config{
 		LLM: config.LLM{
-			Model:        "gpt-3.5-turbo",
+			Model:        "gpt-4o-mini",
 			OpenAIAPIKey: "test-key",
 		},
 	}
@@ -137,7 +137,7 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 
 func TestZepOpenAILLM_Call(t *testing.T) {
 	cfg := testutils.NewTestConfig()
-	cfg.LLM.Model = "gpt-3.5-turbo"
+	cfg.LLM.Model = "gpt-4o-mini"
 
 	zllm, err := NewOpenAILLM(context.Background(), cfg)
 	assert.NoError(t, err, "Expected no error from NewOpenAILLM")

--- a/pkg/tasks/message_intent_analysis_test.go
+++ b/pkg/tasks/message_intent_analysis_test.go
@@ -55,7 +55,7 @@ func runTestIntentExtractor(t *testing.T, testAppState *models.AppState) {
 }
 
 func TestIntentExtractor_Extract_OpenAI(t *testing.T) {
-	appState.Config.LLM.Model = "gpt-3.5-turbo"
+	appState.Config.LLM.Model = "gpt-4o-mini"
 	llmClient, err := llms.NewOpenAILLM(testCtx, appState.Config)
 	assert.NoError(t, err)
 	appState.LLMClient = llmClient

--- a/pkg/tasks/message_summarizer_test.go
+++ b/pkg/tasks/message_summarizer_test.go
@@ -68,7 +68,7 @@ func runTestSummarize(t *testing.T, llmClient models.ZepLLM) {
 
 func TestSummarize_OpenAI(t *testing.T) {
 	appState.Config.LLM.Service = "openai"
-	appState.Config.LLM.Model = "gpt-3.5-turbo"
+	appState.Config.LLM.Model = "gpt-4o-mini"
 	llmClient, err := llms.NewOpenAILLM(testCtx, appState.Config)
 	assert.NoError(t, err)
 	runTestSummarize(t, llmClient)

--- a/pkg/tasks/message_token_counter_test.go
+++ b/pkg/tasks/message_token_counter_test.go
@@ -66,7 +66,7 @@ func runTestTokenCountExtractor(
 
 func TestTokenCountExtractor_OpenAI(t *testing.T) {
 	appState.Config.LLM.Service = "openai"
-	appState.Config.LLM.Model = "gpt-3.5-turbo"
+	appState.Config.LLM.Model = "gpt-4o-mini"
 	llmClient, err := llms.NewOpenAILLM(testCtx, appState.Config)
 	assert.NoError(t, err)
 	appState.LLMClient = llmClient

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -24,7 +24,7 @@ func testConfigDefaults() (*config.Config, error) {
 	testConfig := &config.Config{
 		LLM: config.LLM{
 			Service: "openai",
-			Model:   "gpt-3.5-turbo-1106",
+			Model:   "gpt-4o-mini",
 		},
 		NLP: config.NLP{
 			ServerURL: "http://localhost:5557",


### PR DESCRIPTION
changing default openai model in config an tests from 3.5-turbo to 4o-mini
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 05d4ef48ce47fe33106bd329ac541978729aff59  | 
|--------|--------|

### Summary:
The PR updates the default OpenAI model to `gpt-4o-mini` in configuration and test files, affecting various tests and configurations.

**Key points**:
- Updated `model` in `config.yaml` from `gpt-3.5-turbo-1106` to `gpt-4o-mini`.
- Modified `pkg/llms/llm_openai_test.go` to use `gpt-4o-mini` in `TestZepOpenAILLM_Init`, `TestZepOpenAILLM_Call`.
- Changed `pkg/tasks/message_intent_analysis_test.go` to use `gpt-4o-mini` in `TestIntentExtractor_Extract_OpenAI`.
- Updated `pkg/tasks/message_summarizer_test.go` to use `gpt-4o-mini` in `TestSummarize_OpenAI`.
- Modified `pkg/tasks/message_token_counter_test.go` to use `gpt-4o-mini` in `TestTokenCountExtractor_OpenAI`.
- Updated `pkg/testutils/utils.go` to set default model to `gpt-4o-mini` in `testConfigDefaults`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->