### PR TITLE
feat: add OpenAI embedding configuration option in LLM settings

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,6 +20,8 @@ llm:
     embedding_deployment:
   openai_endpoint:
   openai_org_id:
+  # text-embedding-3-small, text-embedding-3-large, text-embedding-ada-002 (default)
+  openai_embedding:
 nlp:
   server_url: "http://localhost:5557"
 memory:

--- a/config/models.go
+++ b/config/models.go
@@ -31,6 +31,7 @@ type LLM struct {
 	AzureOpenAIModel    AzureOpenAIConfig `mapstructure:"azure_openai"`
 	OpenAIEndpoint      string            `mapstructure:"openai_endpoint"`
 	OpenAIOrgID         string            `mapstructure:"openai_org_id"`
+	OpenAIEmbedding     string            `mapstructure:"openai_embedding"`
 }
 
 type AzureOpenAIConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -144,3 +144,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	mellium.im/sasl v0.3.1 // indirect
 )
+
+replace github.com/tmc/langchaingo => github.com/ArnoChenFx/langchaingo v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/ArnoChenFx/langchaingo v0.0.2 h1:KsYt4ZHBgCDE17+IzZD8FgLX8jdRXHXW24safJdioCo=
+github.com/ArnoChenFx/langchaingo v0.0.2/go.mod h1:R+a8fqt6nmKyYj7KSpr/m9oxqE6OJLbLyO9pxeHpjLU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
@@ -397,8 +399,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/swaggo/swag v1.16.2 h1:28Pp+8DkQoV+HLzLx8RGJZXNGKbFqnuvSbAAtoxiY04=
 github.com/swaggo/swag v1.16.2/go.mod h1:6YzXnDcpr0767iOejs318CwYkCQqyGer6BizOg03f+E=
-github.com/tmc/langchaingo v0.0.0-20230929160525-e16b77704b8d h1:i4+wYULVM2/3Yb/aDE7Z4s2v7vqtQERQWh5lopBEuig=
-github.com/tmc/langchaingo v0.0.0-20230929160525-e16b77704b8d/go.mod h1:R+a8fqt6nmKyYj7KSpr/m9oxqE6OJLbLyO9pxeHpjLU=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc h1:9lRDQMhESg+zvGYmW5DyG0UqvY96Bu5QYsTLvCHdrgo=
 github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc/go.mod h1:bciPuU6GHm1iF1pBvUfxfsH0Wmnc2VbpgvbI9ZWuIRs=
 github.com/uptrace/bun v0.3.9/go.mod h1:aL6D9vPw8DXaTQTwGrEPtUderBYXx7ShUmPfnxnqscw=

--- a/pkg/llms/llm_openai.go
+++ b/pkg/llms/llm_openai.go
@@ -122,6 +122,9 @@ func (zllm *ZepOpenAILLM) configureClient(cfg *config.Config) ([]openai.Option, 
 	if cfg.LLM.AzureOpenAIEndpoint != "" && cfg.LLM.OpenAIEndpoint != "" {
 		log.Fatal("only one of AzureOpenAIEndpoint or OpenAIEndpoint can be set")
 	}
+	if cfg.LLM.AzureOpenAIModel.EmbeddingDeployment != "" && cfg.LLM.OpenAIEmbedding != "" {
+		log.Fatal("only one of AzureOpenAIModel.EmbeddingDeployment or OpenAIEmbedding can be set")
+	}
 
 	// Set up the HTTP client and config OpenTelemetry wrapper
 	httpClient := NewRetryableHTTPClient(MaxOpenAIAPIRequestAttempts, OpenAIAPITimeout)
@@ -133,6 +136,13 @@ func (zllm *ZepOpenAILLM) configureClient(cfg *config.Config) ([]openai.Option, 
 		openai.WithModel(cfg.LLM.Model),
 		openai.WithToken(apiKey),
 	)
+
+	if cfg.LLM.OpenAIEmbedding != "" {
+		options = append(
+			options,
+			openai.WithEmbeddingModel(cfg.LLM.OpenAIEmbedding),
+		)
+	}
 
 	switch {
 	case cfg.LLM.AzureOpenAIEndpoint != "":

--- a/pkg/llms/llm_openai_test.go
+++ b/pkg/llms/llm_openai_test.go
@@ -100,9 +100,10 @@ func TestZepOpenAILLM_TestConfigureClient(t *testing.T) {
 	t.Run("Test with OpenAIEndpointAndCustomModelName", func(t *testing.T) {
 		cfg := &config.Config{
 			LLM: config.LLM{
-				OpenAIAPIKey:   "test-key",
-				OpenAIEndpoint: "https://openai.com",
-				Model:          "some-model",
+				OpenAIAPIKey:    "test-key",
+				OpenAIEndpoint:  "https://openai.com",
+				Model:           "some-model",
+				OpenAIEmbedding: "text-embedding-3-small",
 			},
 		}
 


### PR DESCRIPTION
In order to achieve this, I have to make some modifications to langchaingo:
https://github.com/ArnoChenFx/langchaingo/commit/3e1b201db5b9bb515d4fef862a019b9bf33533ea
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `openai_embedding` configuration option for OpenAI embeddings and update `langchaingo` dependency.
> 
>   - **Configuration**:
>     - Add `openai_embedding` option in `config.yaml` and `config/models.go` for specifying OpenAI embedding models.
>   - **Client Configuration**:
>     - Update `configureClient()` in `llm_openai.go` to handle `OpenAIEmbedding` setting, ensuring only one embedding option is set.
>   - **Dependency**:
>     - Replace `github.com/tmc/langchaingo` with `github.com/ArnoChenFx/langchaingo` in `go.mod` and `go.sum`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fzep&utm_source=github&utm_medium=referral)<sup> for 4a61f506e7f3f5ff1ebd286087a285da4c60a59f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->