### PR TITLE
revert: Publish image action changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,15 +4,6 @@ on:
   push:
    # Publish semver tags as releases.
    tags: [ 'v*.*.*' ]
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to build and publish'
-        required: true
-      push_as_latest:
-        description: 'Also push as latest?'
-        type: boolean
-        default: false
 
 env:
   REGISTRY: docker.io
@@ -24,15 +15,10 @@ jobs:
       name: release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo for tag push
-        if: github.event_name == 'push'
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }}
-
-      - name: Checkout repo for manual trigger
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+          ref: ${{ github.event.inputs.tag || github.ref  }}
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -43,33 +29,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract version from tag
-        id: get_version
-        run: |
-          VERSION=${{ github.event.inputs.tag || github.ref_name }}
-          VERSION=${VERSION#v}  # Remove leading 'v' if present
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "major_minor=${VERSION%.*}" >> $GITHUB_OUTPUT
-          echo "major=${VERSION%%.*}" >> $GITHUB_OUTPUT
-
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4.4.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable=${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.push_as_latest == 'true') }}
-            type=raw,value=${{ steps.get_version.outputs.version }}
-            type=raw,value=${{ steps.get_version.outputs.major_minor }}
-            type=raw,value=${{ steps.get_version.outputs.major }}
-      - name: Set up Depot CLI
-        uses: depot/setup-action@v1
-      - name: Build and push
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=match,pattern=v(.*-beta),group=1
+            type=match,pattern=v.*-(beta),group=1
+
+      - name: Depot build and push image
         uses: depot/build-push-action@v1
         with:
-          context: ${{ github.workspace }}
-          push: true
+          project: v9jv1mlpwc
+          context: .
           platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags || env.TAGS }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,7 +62,8 @@ jobs:
             type=raw,value=${{ steps.get_version.outputs.version }}
             type=raw,value=${{ steps.get_version.outputs.major_minor }}
             type=raw,value=${{ steps.get_version.outputs.major }}
-
+      - name: Set up Depot CLI
+        uses: depot/setup-action@v1
       - name: Build and push
         uses: depot/build-push-action@v1
         with:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds Depot CLI setup to GitHub Actions workflow in `docker-publish.yml`, updating checkout and build steps.
> 
>   - **Workflow Changes**:
>     - Adds Depot CLI setup step using `depot/setup-action@v1` in `docker-publish.yml`.
>     - Updates checkout action to `actions/checkout@v3` and modifies ref handling.
>     - Simplifies Docker metadata extraction and build steps, removing manual version extraction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fzep&utm_source=github&utm_medium=referral)<sup> for fe2e2efe639e86e8fcca23538d658ea35477d096. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->