### PR TITLE
chore: Fix permissions on release runner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,9 @@ jobs:
     environment:
       name: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `contents: read` and `id-token: write` permissions to `docker-image` job in `docker-publish.yml`.
> 
>   - **Permissions**:
>     - Added `contents: read` and `id-token: write` permissions to the `docker-image` job in `.github/workflows/docker-publish.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fzep&utm_source=github&utm_medium=referral)<sup> for f3f561107dd84da50b066f6d0b93c0f87e00b10d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->