### PR TITLE
chore: Add healthcheck to neo4j service

### DIFF
--- a/docker-compose.ce.yaml
+++ b/docker-compose.ce.yaml
@@ -50,7 +50,8 @@ services:
       timeout: 5s
       retries: 3
     depends_on:
-      - neo4j
+      neo4j:
+        condition: service_healthy
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - MODEL_NAME=gpt-4o-mini
@@ -62,6 +63,12 @@ services:
     image: neo4j:5.22.0
     networks:
       - zep-network
+    healthcheck:
+      test: wget http://localhost:7474 || exit 1
+      interval: 1s
+      timeout: 10s
+      retries: 20
+      start_period: 3s
     ports:
       - "7474:7474"  # HTTP
       - "${NEO4J_PORT}:${NEO4J_PORT}"  # Bolt


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a health check to the Neo4j service in `docker-compose.ce.yaml` and updates `zep` service dependencies to wait for Neo4j to be healthy.
> 
>   - **Health Check**:
>     - Adds health check to `neo4j` service in `docker-compose.ce.yaml` using `wget` to check HTTP availability on port 7474.
>     - Configures health check with `interval: 1s`, `timeout: 10s`, `retries: 20`, and `start_period: 3s`.
>   - **Dependencies**:
>     - Updates `depends_on` for `zep` service to wait for `neo4j` to be healthy before starting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fzep&utm_source=github&utm_medium=referral)<sup> for 99e14da087f7368780f6011431df7015ff7739de. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->