### PR TITLE
fix NEO4J_URI and port mapping in docker-compose file

### DIFF
--- a/docker-compose.ce.yaml
+++ b/docker-compose.ce.yaml
@@ -55,7 +55,7 @@ services:
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - MODEL_NAME=gpt-4o-mini
-      - NEO4J_URI=bolt://neo4j:${NEO4J_PORT}
+      - NEO4J_URI=bolt://neo4j:7687
       - NEO4J_USER=${NEO4J_USER}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD}
       - PORT=8003
@@ -71,7 +71,7 @@ services:
       start_period: 3s
     ports:
       - "7474:7474"  # HTTP
-      - "${NEO4J_PORT}:${NEO4J_PORT}"  # Bolt
+      - "${NEO4J_PORT}:7687"  # Bolt
     volumes:
       - neo4j_data:/data
     environment:

--- a/docker-compose.ce.yaml
+++ b/docker-compose.ce.yaml
@@ -1,3 +1,5 @@
+name: zep-ce
+
 services:
   zep:
     image: zepai/zep:latest
@@ -45,7 +47,13 @@ services:
     networks:
       - zep-network
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8003/healthcheck')"]
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8003/healthcheck')",
+        ]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -56,26 +64,26 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - MODEL_NAME=gpt-4o-mini
       - NEO4J_URI=bolt://neo4j:7687
-      - NEO4J_USER=${NEO4J_USER}
-      - NEO4J_PASSWORD=${NEO4J_PASSWORD}
+      - NEO4J_USER=neo4j
+      - NEO4J_PASSWORD=zepzepzep
       - PORT=8003
   neo4j:
     image: neo4j:5.22.0
     networks:
       - zep-network
     healthcheck:
-      test: wget http://localhost:7474 || exit 1
+      test: wget http://localhost:7687 || exit 1
       interval: 1s
       timeout: 10s
       retries: 20
       start_period: 3s
     ports:
-      - "7474:7474"  # HTTP
-      - "${NEO4J_PORT}:7687"  # Bolt
+      - "7474:7474" # HTTP
+      - "7687:7687" # Bolt
     volumes:
       - neo4j_data:/data
     environment:
-      - NEO4J_AUTH=${NEO4J_USER}/${NEO4J_PASSWORD}
+      - NEO4J_AUTH=neo4j/zepzepzep
 volumes:
   neo4j_data:
   zep-db:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix Neo4j URI and port mapping in `docker-compose.ce.yaml` to use hardcoded port 7687.
> 
>   - **Environment Variables**:
>     - Fix `NEO4J_URI` in `docker-compose.ce.yaml` to use hardcoded port `7687` instead of `${NEO4J_PORT}`.
>   - **Port Mapping**:
>     - Update Neo4j Bolt port mapping in `docker-compose.ce.yaml` from `${NEO4J_PORT}:${NEO4J_PORT}` to `${NEO4J_PORT}:7687`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fzep&utm_source=github&utm_medium=referral)<sup> for 86cccb42cd6615dce1f2b95a8f3512b78e257876. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->