### PR TITLE
feature(config): allow enable postgres ssl

### DIFF
--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -31,7 +31,7 @@ var defaultConfig = Config{
 		Carbon: carbonConfig{
 			Locale: "en",
 		},
-        Postgres: postgresConfig{
+		Postgres: postgresConfig{
 		    SSLMode: "disable",
 		},
 	},

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -31,6 +31,9 @@ var defaultConfig = Config{
 		Carbon: carbonConfig{
 			Locale: "en",
 		},
+        Postgres: postgresConfig{
+		    SSLMode: "disable",
+		},
 	},
 }
 
@@ -58,6 +61,7 @@ type postgresConfigCommon struct {
 	Host               string `yaml:"host"`
 	Port               int    `yaml:"port"`
 	Database           string `yaml:"database"`
+	SSLMode            string `yaml:"ssl_mode"`
 	ReadTimeout        int    `yaml:"read_timeout"`
 	WriteTimeout       int    `yaml:"write_timeout"`
 	MaxOpenConnections int    `yaml:"max_open_connections"`
@@ -65,12 +69,13 @@ type postgresConfigCommon struct {
 
 func (c postgresConfigCommon) DSN() string {
 	return fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?sslmode=disable",
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
         	url.QueryEscape(c.User),
         	url.QueryEscape(c.Password),
         	c.Host,
         	c.Port,
         	url.QueryEscape(c.Database),
+        	url.QueryEscape(c.SSLMode),
     	)
 }
 

--- a/src/lib/config/config.go
+++ b/src/lib/config/config.go
@@ -61,13 +61,12 @@ type postgresConfigCommon struct {
 	Host               string `yaml:"host"`
 	Port               int    `yaml:"port"`
 	Database           string `yaml:"database"`
-	SSLMode            string `yaml:"ssl_mode"`
 	ReadTimeout        int    `yaml:"read_timeout"`
 	WriteTimeout       int    `yaml:"write_timeout"`
 	MaxOpenConnections int    `yaml:"max_open_connections"`
 }
 
-func (c postgresConfigCommon) DSN() string {
+func (c postgresConfig) DSN() string {
 	return fmt.Sprintf(
 		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
         	url.QueryEscape(c.User),

--- a/src/lib/config/models_ce.go
+++ b/src/lib/config/models_ce.go
@@ -14,6 +14,7 @@ type Config struct {
 type postgresConfig struct {
 	postgresConfigCommon `yaml:",inline"`
 
+	SSLMode string `yaml:"ssl_mode"`
 	SchemaName string `yaml:"schema_name"`
 }
 

--- a/zep.yaml
+++ b/zep.yaml
@@ -17,7 +17,7 @@ postgres:
   port: 5432
   database: postgres
   schema_name: public
-  ssl_mode: require
+  ssl_mode: disable
   read_timeout: 30
   write_timeout: 30
   max_open_connections: 10

--- a/zep.yaml
+++ b/zep.yaml
@@ -17,6 +17,7 @@ postgres:
   port: 5432
   database: postgres
   schema_name: public
+  ssl_mode: require
   read_timeout: 30
   write_timeout: 30
   max_open_connections: 10


### PR DESCRIPTION
With this PR SSL can be enabled on demand, it defaults to the configuration it was previously there `ssl_mode: disable`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add SSL configuration option for Postgres connections, defaulting to 'disable'.
> 
>   - **Configuration**:
>     - Adds `SSLMode` to `postgresConfig` in `config.go` with default `disable`.
>     - Updates `zep.yaml` to include `ssl_mode` under `postgres`.
>   - **DSN Construction**:
>     - Modifies `DSN()` in `config.go` to use `SSLMode` for Postgres connection string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=getzep%2Fzep&utm_source=github&utm_medium=referral)<sup> for 0f19eaf7460f6f0dbffbb5789af7f3154e6ee920. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->