### PR TITLE
Update LiveKit example: fix title casing and upgrade model

### DIFF
--- a/integrations/python/zep_livekit/examples/full-example/README.md
+++ b/integrations/python/zep_livekit/examples/full-example/README.md
@@ -1,4 +1,4 @@
-# Zep Livekit Integration Full Working Example
+# Zep LiveKit Integration Full Working Example
 
 Voice agent that demonstrates LiveKit + Zep integration with persistent memory.
 

--- a/integrations/python/zep_livekit/examples/full-example/zep_graph_voice_agent.py
+++ b/integrations/python/zep_livekit/examples/full-example/zep_graph_voice_agent.py
@@ -66,7 +66,7 @@ async def entrypoint(ctx: agents.JobContext):
     # Step 5: Create agent session with OpenAI components
     session = agents.AgentSession(
         stt=openai.STT(),
-        llm=openai.LLM(model="gpt-4o-mini"),
+        llm=openai.LLM(model="gpt-5-nano-2025-08-07"),
         tts=openai.TTS(voice="alloy"),
         vad=silero.VAD.load(),
     )

--- a/integrations/python/zep_livekit/examples/full-example/zep_voice_agent.py
+++ b/integrations/python/zep_livekit/examples/full-example/zep_voice_agent.py
@@ -46,7 +46,7 @@ async def entrypoint(ctx: agents.JobContext):
     # Step 5: Create agent session with OpenAI components
     session = agents.AgentSession(
         stt=openai.STT(),
-        llm=openai.LLM(model="gpt-4o-mini"),
+        llm=openai.LLM(model="gpt-5-nano-2025-08-07"),
         tts=openai.TTS(voice="alloy"),
         vad=silero.VAD.load(),
     )


### PR DESCRIPTION
## Summary
- Fix README title casing: "Livekit" → "LiveKit"
- Update OpenAI model from gpt-4o-mini to gpt-5-nano-2025-08-07 in both voice agents

## Test plan
- [ ] Verify README displays correct "LiveKit" casing
- [ ] Test both voice agents work with new model
- [ ] Confirm no breaking changes in agent functionality

🤖 Generated with [Claude Code](https://claude.ai/code)