### PR TITLE
Upgrade eval harness to GPT-5-mini with minimal reasoning

### DIFF
--- a/zep-eval-harness/README.md
+++ b/zep-eval-harness/README.md
@@ -1,4 +1,4 @@
-# Zep Test Harness
+# Zep Eval Harness
 
 An end-to-end evaluation framework for testing Zep's memory retrieval and question-answering capabilities using dummy datasets.
 

--- a/zep-eval-harness/zep_evaluate.py
+++ b/zep-eval-harness/zep_evaluate.py
@@ -22,8 +22,8 @@ USER_ID = "zep_eval_test_user_001"
 SEARCH_LIMIT = 10  # Number of results per scope
 
 # LLM Model configuration
-LLM_RESPONSE_MODEL = "gpt-4.1-mini-2025-04-14"  # Model used for generating responses
-LLM_JUDGE_MODEL = "gpt-4.1-mini-2025-04-14"      # Model used for grading responses
+LLM_RESPONSE_MODEL = "gpt-5-mini"  # Model used for generating responses
+LLM_JUDGE_MODEL = "gpt-5-mini"      # Model used for grading responses
 
 
 # ============================================================================
@@ -227,7 +227,7 @@ Answer:
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": prompt}
         ],
-        temperature=0,
+        reasoning_effort="minimal",
     )
 
     return response.choices[0].message.content or ''
@@ -293,7 +293,7 @@ Please provide your evaluation:
             {"role": "user", "content": grading_prompt}
         ],
         response_format=Grade,
-        temperature=0,
+        reasoning_effort="minimal",
     )
 
     result = response.choices[0].message.parsed


### PR DESCRIPTION
## Summary

- Upgrade Zep eval harness models from gpt-4.1-mini to gpt-5-mini
- Configure minimal reasoning effort for optimal performance and reduced latency
- Replace temperature parameter with reasoning_effort parameter (incompatible with reasoning models)
- Update README title from "Zep Test Harness" to "Zep Eval Harness"

## Changes

- **zep_evaluate.py**: Updated model configuration and reasoning parameters
  - Both LLM_RESPONSE_MODEL and LLM_JUDGE_MODEL now use gpt-5-mini
  - Replaced temperature=0 with reasoning_effort="minimal" in both generate_ai_response and grade_ai_response functions
  
- **README.md**: Updated title for clarity

## Why GPT-5-mini with Minimal Reasoning?

- GPT-5-mini provides superior model capabilities over GPT-4.1-mini
- Minimal reasoning effort minimizes reasoning tokens for faster responses while maintaining accuracy
- Ideal for deterministic evaluation tasks like response generation and grading
- Removes unnecessary latency for tasks that don't require deep chain-of-thought reasoning

## Test Plan

- [x] Verify model strings are correctly updated
- [x] Verify reasoning_effort parameter is set to minimal
- [x] Verify temperature parameter is removed from both API calls
- [x] README title updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)