### PR TITLE
Fix agent-memory-full-example dependencies and default display mode

### DIFF
--- a/examples/python/agent-memory-full-example/requirements.txt
+++ b/examples/python/agent-memory-full-example/requirements.txt
@@ -20,6 +20,7 @@ jsonschema==4.25.1
 jsonschema-specifications==2025.9.1
 MarkupSafe==3.0.2
 narwhals==2.5.0
+nest_asyncio==1.6.0
 numpy==2.3.3
 openai==1.109.1
 packaging==25.0

--- a/examples/python/agent-memory-full-example/ui.py
+++ b/examples/python/agent-memory-full-example/ui.py
@@ -204,7 +204,7 @@ if "no_zep_responses" not in st.session_state:
     st.session_state.no_zep_responses = {}  # {thread_id: [{"role": "assistant", "content": "...", "timestamp": ...}, ...]}
 
 if "display_mode" not in st.session_state:
-    st.session_state.display_mode = "both"  # Options: "both", "zep_only", "no_zep_only"
+    st.session_state.display_mode = "zep_only"  # Options: "both", "zep_only", "no_zep_only"
 
 if "generating_responses" not in st.session_state:
     st.session_state.generating_responses = False


### PR DESCRIPTION
## Summary
- Add missing `nest_asyncio` dependency to requirements.txt (fixes ModuleNotFoundError when running the app)
- Change default display mode from "both" to "zep_only" for a better initial user experience

## Test plan
- [ ] Run the agent-memory-full-example with the new requirements
- [ ] Verify the app starts without the nest_asyncio import error
- [ ] Confirm the app defaults to "With Zep" display mode on first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)