### PR TITLE
Add real estate ontology and update quickstart dashboard

### DIFF
--- a/examples/python/zep-quickstart-dashboard/agents.py
+++ b/examples/python/zep-quickstart-dashboard/agents.py
@@ -102,8 +102,7 @@ class ChatAgent:
             # Retrieve user context from Zep and track timing
             zep_start = time.perf_counter()
             results = await self.zep_client.thread.get_user_context(
-                thread_id=thread_id,
-                mode="basic"
+                thread_id=thread_id
             )
             context_block = results.context
             zep_end = time.perf_counter()

--- a/examples/python/zep-quickstart-dashboard/data/conversations.json
+++ b/examples/python/zep-quickstart-dashboard/data/conversations.json
@@ -1,16 +1,76 @@
 [
   {
     "messages": [
-      {"role": "user", "content": "Can you schedule a meeting with Sarah for tomorrow at 2pm?"},
-      {"role": "assistant", "content": "I've scheduled a meeting with Sarah for tomorrow at 2pm. You'll receive a calendar invite shortly."}
+      {"role": "user", "content": "Hi! My husband and I are looking to buy a house. We have two kids, ages 7 and 10."},
+      {"role": "assistant", "content": "Welcome! I'd love to help you find the perfect home for your family. Let me ask a few questions to understand what you're looking for."},
+      {"role": "user", "content": "Great! We're looking for something with at least 3 bedrooms, ideally 4 if we can find it, since we need space for both kids and a home office."},
+      {"role": "assistant", "content": "That makes sense. What's your budget range for this purchase?"},
+      {"role": "user", "content": "We're looking to stay between $200,000 and $400,000. We can stretch up to maybe $420,000 for the right place."},
+      {"role": "assistant", "content": "Perfect. That gives us good options in several neighborhoods. What areas are you interested in?"},
+      {"role": "user", "content": "We'd prefer to stay in the Westside or near good schools. Our oldest starts middle school next year."},
+      {"role": "assistant", "content": "Excellent. Schools are definitely a priority. What about outdoor space? Do you need a backyard?"},
+      {"role": "user", "content": "Yes, a backyard is essential. The kids need space to play, and we love to host family barbecues in the summer."},
+      {"role": "assistant", "content": "Got it! I'll start looking for 3-4 bedroom homes with good yards in family-friendly neighborhoods with top-rated schools. I'll send you some listings this week."}
     ]
   },
   {
     "messages": [
-      {"role": "user", "content": "Can you order me some coffee?"},
-      {"role": "assistant", "content": "Of course! Where would you like me to order from, and how do you like your coffee?"},
-      {"role": "user", "content": "I prefer my coffee from Starbucks. And I like my coffee with milk and two pumps of mocha syrup."},
-      {"role": "assistant", "content": "Got it! I've ordered your coffee with milk and two pumps of mocha syrup from Starbucks. It should be ready for pickup in about 10 minutes."}
+      {"role": "user", "content": "I looked at those listings you sent. The one on Maple Street looks interesting!"},
+      {"role": "assistant", "content": "The Maple Street property is lovely! It has 4 bedrooms, 2.5 baths, and a great backyard. Would you like to schedule a showing?"},
+      {"role": "user", "content": "Yes, please! Can we see it this Saturday? My husband will be available then."},
+      {"role": "assistant", "content": "Saturday works perfectly. I've scheduled a showing for 10am. The house also has an updated kitchen which I think you'll love."},
+      {"role": "user", "content": "That's great! One thing though - is there parking? We have two cars."},
+      {"role": "assistant", "content": "Yes, it has a 2-car garage plus driveway space. Plenty of room for both vehicles."},
+      {"role": "user", "content": "Perfect. Are there any other similar properties we should look at while we're out?"},
+      {"role": "assistant", "content": "I found two more in your price range nearby. One on Oak Drive with 5 bedrooms, and another on Pine Avenue with a larger lot."},
+      {"role": "user", "content": "The 4-bedroom sounds interesting. We could use the extra room for guests since my parents visit often."},
+      {"role": "assistant", "content": "I'll add the Oak Drive property to your Saturday tour. It's listed at $385,000 and has been on the market for just two weeks."}
+    ]
+  },
+  {
+    "messages": [
+      {"role": "user", "content": "We saw both houses yesterday. The Maple Street one was nice but felt a bit cramped, and honestly it only has 2 bathrooms which might not be enough."},
+      {"role": "assistant", "content": "I understand. What did you think of the Oak Drive property with 4 bedrooms?"},
+      {"role": "user", "content": "We loved the space! But honestly, it needs too much work. The kitchen is really outdated and we don't want a major renovation."},
+      {"role": "assistant", "content": "That's valuable feedback. So move-in ready or recently updated is important to you?"},
+      {"role": "user", "content": "Exactly. We want something we can move into without major projects. Maybe cosmetic updates are fine, but no gut renovations."},
+      {"role": "assistant", "content": "Got it. Let me focus on homes that have been updated in the last 5-10 years. Any other must-haves we should add to the criteria?"},
+      {"role": "user", "content": "A good-sized master bedroom would be great. And if it has hardwood floors, even better!"},
+      {"role": "assistant", "content": "Noted! Hardwood floors are popular in this area. What about a home office space - still important?"},
+      {"role": "user", "content": "Yes, very important. My husband works from home three days a week, so we need a dedicated office with a door. Also, I'm thinking at least 2.5 bathrooms would be ideal with the kids getting older."},
+      {"role": "assistant", "content": "Perfect. I'll search for move-in ready, 3-4 bedroom homes with at least 2.5 baths, hardwood floors, updated features, good yards, and space for a home office. I'll have new options for you by Wednesday."}
+    ]
+  },
+  {
+    "messages": [
+      {"role": "user", "content": "The listings you sent look great! Especially the one on Birch Lane. Can we see it this week?"},
+      {"role": "assistant", "content": "The Birch Lane house is stunning! It's listed at $365,000, has beautiful hardwood floors throughout, and was renovated in 2021. I can get you in Thursday at 5pm."},
+      {"role": "user", "content": "Thursday works! What's the school district for that property?"},
+      {"role": "assistant", "content": "It's in the Riverside School District - highly rated. The elementary school is actually walkable, just 3 blocks away."},
+      {"role": "user", "content": "That's perfect! Our daughter could walk to school. What about the backyard size?"},
+      {"role": "assistant", "content": "The lot is 0.3 acres with a fully fenced backyard. There's a patio area and plenty of grass for the kids to play."},
+      {"role": "user", "content": "Sounds ideal. Is there central AC? That's something we realized we need after looking at the Oak Drive house."},
+      {"role": "assistant", "content": "Yes, it has central air and heat, both updated in 2021 during the renovation. Very energy efficient."},
+      {"role": "user", "content": "Great. And the garage situation?"},
+      {"role": "assistant", "content": "2-car attached garage with additional storage space. There's also a workshop area that your husband might appreciate."},
+      {"role": "user", "content": "He'll love that! We're really excited to see this one. It checks all our boxes."},
+      {"role": "assistant", "content": "I have a good feeling about this property for you! See you Thursday at 5pm."}
+    ]
+  },
+  {
+    "messages": [
+      {"role": "user", "content": "We absolutely loved the Birch Lane house! We want to make an offer."},
+      {"role": "assistant", "content": "I'm so glad to hear that! It really is perfect for your family. The market is competitive right now, so we should move quickly."},
+      {"role": "user", "content": "What do you think we should offer? It's listed at $365,000."},
+      {"role": "assistant", "content": "Based on recent comps in the area, I'd recommend offering $375,000. It's a strong offer that shows you're serious without going too high."},
+      {"role": "user", "content": "That's a bit of a stretch but within our budget. Should we include any contingencies?"},
+      {"role": "assistant", "content": "Definitely include a home inspection contingency. I'd also recommend a financing contingency since you're getting a mortgage."},
+      {"role": "user", "content": "Good idea. We're pre-approved up to $420,000, so financing shouldn't be an issue."},
+      {"role": "assistant", "content": "Perfect. That strengthens your position. How about the closing timeline - do you have flexibility?"},
+      {"role": "user", "content": "Our lease ends in 60 days, so we could close anytime in the next 45-60 days."},
+      {"role": "assistant", "content": "That's ideal. Most sellers appreciate a flexible buyer. Let me draft the offer with $375,000, standard contingencies, and a 45-day close. We can present it this evening."},
+      {"role": "user", "content": "Let's do it! My husband and I are both so excited. This house has everything we wanted - the yard, the office, the updated kitchen, the school district, and 2.5 bathrooms."},
+      {"role": "assistant", "content": "It really does check every box! I'll get the paperwork ready and call you within the hour. Fingers crossed!"}
     ]
   }
 ]

--- a/examples/python/zep-quickstart-dashboard/data/user.json
+++ b/examples/python/zep-quickstart-dashboard/data/user.json
@@ -1,6 +1,6 @@
 {
-  "user_id_prefix": "John-Doe",
-  "email": "john@example.com",
-  "first_name": "John",
+  "user_id_prefix": "Jane",
+  "email": "jane.doe@example.com",
+  "first_name": "Jane",
   "last_name": "Doe"
 }

--- a/examples/python/zep-quickstart-dashboard/data/user_data.json
+++ b/examples/python/zep-quickstart-dashboard/data/user_data.json
@@ -1,17 +1,176 @@
 [
     {
-        "user_preferences": {
-            "smoothie_order": "green protein smoothie with almond butter",
-            "preferred_smoothie_shop": "Juice Press",
-            "music_genres": ["jazz", "classical", "indie_pop"]
+        "house_search": {
+            "search_query": "4 bedroom family homes westside",
+            "filters": {
+                "bedrooms": 4,
+                "price_min": 200000,
+                "price_max": 400000,
+                "property_type": "single_family",
+                "location": "Westside"
+            },
+            "timestamp": "2025-10-01T14:23:00Z",
+            "results_viewed": 12
         }
     },
     {
-        "favorite_restaurant": {
-            "name": "Canlis",
-            "location": "Seattle",
-            "cuisine_type": "fine_dining",
-            "user_notes": "loved this restaurant"
+        "house_search": {
+            "search_query": "homes near good schools 4+ bedrooms",
+            "filters": {
+                "bedrooms_min": 4,
+                "bathrooms_min": 2,
+                "price_min": 220000,
+                "price_max": 380000,
+                "has_backyard": true,
+                "school_rating_min": 8
+            },
+            "timestamp": "2025-10-03T09:45:00Z",
+            "results_viewed": 18
+        }
+    },
+    {
+        "house_search": {
+            "search_query": "single family home 2 car garage updated kitchen",
+            "filters": {
+                "bedrooms": 4,
+                "bathrooms_min": 2.5,
+                "price_min": 250000,
+                "price_max": 400000,
+                "has_garage": true,
+                "garage_spaces": 2,
+                "keywords": ["updated kitchen", "renovated"]
+            },
+            "timestamp": "2025-10-08T16:30:00Z",
+            "results_viewed": 15
+        }
+    },
+    {
+        "house_search": {
+            "search_query": "5 bedroom homes with office space",
+            "filters": {
+                "bedrooms": 5,
+                "bathrooms_min": 2,
+                "price_min": 280000,
+                "price_max": 420000,
+                "has_office": true,
+                "has_backyard": true,
+                "lot_size_min": 0.2
+            },
+            "timestamp": "2025-10-12T11:15:00Z",
+            "results_viewed": 9
+        }
+    },
+    {
+        "house_search": {
+            "search_query": "move-in ready homes hardwood floors",
+            "filters": {
+                "bedrooms_min": 3,
+                "bathrooms_min": 2,
+                "price_min": 200000,
+                "price_max": 380000,
+                "year_built_min": 2010,
+                "condition": "excellent",
+                "flooring_type": "hardwood"
+            },
+            "timestamp": "2025-10-16T13:50:00Z",
+            "results_viewed": 14
+        }
+    },
+    {
+        "house_search": {
+            "search_query": "updated homes central AC large master bedroom",
+            "filters": {
+                "bedrooms_min": 4,
+                "bathrooms_min": 2.5,
+                "price_min": 240000,
+                "price_max": 400000,
+                "has_central_ac": true,
+                "master_bedroom_size": "large",
+                "year_renovated_min": 2015
+            },
+            "timestamp": "2025-10-19T10:20:00Z",
+            "results_viewed": 11
+        }
+    },
+    {
+        "house_search": {
+            "search_query": "family homes walkable to school fenced yard",
+            "filters": {
+                "bedrooms_min": 3,
+                "bathrooms_min": 2,
+                "price_min": 220000,
+                "price_max": 390000,
+                "school_distance_max": 0.5,
+                "has_fenced_yard": true,
+                "lot_size_min": 0.25
+            },
+            "timestamp": "2025-10-22T15:40:00Z",
+            "results_viewed": 16
+        }
+    },
+    {
+        "house_search": {
+            "search_query": "riverside school district 4 bedroom homes",
+            "filters": {
+                "bedrooms": 4,
+                "bathrooms_min": 2,
+                "price_min": 300000,
+                "price_max": 410000,
+                "school_district": "Riverside",
+                "has_garage": true,
+                "has_backyard": true
+            },
+            "timestamp": "2025-10-25T14:10:00Z",
+            "results_viewed": 8
+        }
+    },
+    {
+        "house_search": {
+            "search_query": "homes with home office space for remote work",
+            "filters": {
+                "bedrooms_min": 3,
+                "bathrooms_min": 2,
+                "price_min": 230000,
+                "price_max": 390000,
+                "has_office": true,
+                "has_garage": true,
+                "garage_spaces": 2
+            },
+            "timestamp": "2025-10-28T09:30:00Z",
+            "results_viewed": 13
+        }
+    },
+    {
+        "house_search": {
+            "search_query": "family friendly homes with large backyard for entertaining",
+            "filters": {
+                "bedrooms_min": 3,
+                "bathrooms_min": 2,
+                "price_min": 210000,
+                "price_max": 400000,
+                "has_backyard": true,
+                "has_fenced_yard": true,
+                "lot_size_min": 0.25,
+                "outdoor_features": ["patio", "deck"]
+            },
+            "timestamp": "2025-10-29T14:55:00Z",
+            "results_viewed": 20
+        }
+    },
+    {
+        "house_search": {
+            "search_query": "energy efficient homes under 420k",
+            "filters": {
+                "bedrooms_min": 3,
+                "bathrooms_min": 2,
+                "price_min": 200000,
+                "price_max": 420000,
+                "has_central_ac": true,
+                "year_built_min": 2010,
+                "condition": "excellent"
+            },
+            "timestamp": "2025-10-30T11:45:00Z",
+            "results_viewed": 10
         }
     }
 ]

--- a/examples/python/zep-quickstart-dashboard/ontology.py
+++ b/examples/python/zep-quickstart-dashboard/ontology.py
@@ -1,0 +1,290 @@
+"""
+Real Estate Agent Ontology
+
+This module defines custom entity and edge types for a real estate agent assistant.
+The ontology captures properties, neighborhoods, schools, amenities, and the relationships
+between users and these entities during the home buying process.
+"""
+
+from zep_cloud.external_clients.ontology import EntityModel, EntityText, EdgeModel, EntityInt, EntityFloat, EntityBoolean
+from pydantic import Field
+
+
+# ============================================================================
+# Entity Types (Nouns)
+# ============================================================================
+
+class Property(EntityModel):
+    """
+    Represents a specific house or real estate property that is available for sale or has been viewed.
+    This includes single-family homes, condos, townhouses, etc.
+    """
+    address: EntityText = Field(
+        description="The street address of the property, for example: '123 Maple Street' or '456 Oak Drive'",
+        default=None
+    )
+    price: EntityInt = Field(
+        description="The listing price of the property in dollars, for example: 365000 or 420000",
+        default=None
+    )
+    bedrooms: EntityInt = Field(
+        description="The number of bedrooms in the property, for example: 3, 4, or 5",
+        default=None
+    )
+    bathrooms: EntityFloat = Field(
+        description="The number of bathrooms in the property, for example: 2, 2.5, or 3",
+        default=None
+    )
+
+
+class Neighborhood(EntityModel):
+    """
+    Represents a geographic area, neighborhood, or school district where properties are located.
+    Examples include 'Westside', 'Riverside School District', or specific area names.
+    """
+    area_name: EntityText = Field(
+        description="The name of the neighborhood, area, or school district, for example: 'Westside', 'Riverside School District', 'Downtown'",
+        default=None
+    )
+    desirability: EntityText = Field(
+        description="Why this neighborhood is desirable or notable, for example: 'highly rated schools', 'family-friendly', 'walkable'",
+        default=None
+    )
+
+
+class School(EntityModel):
+    """
+    Represents an educational institution (elementary, middle, or high school) near a property.
+    Schools are an important factor in family home buying decisions.
+    """
+    school_name: EntityText = Field(
+        description="The name of the school, for example: 'Riverside Elementary School' or 'Lincoln Middle School'",
+        default=None
+    )
+    school_type: EntityText = Field(
+        description="The type of school, for example: 'elementary', 'middle', 'high'",
+        default=None
+    )
+    rating: EntityText = Field(
+        description="The quality or rating of the school, for example: 'highly rated', 'top-rated', or a numeric rating",
+        default=None
+    )
+
+
+class Amenity(EntityModel):
+    """
+    Represents a specific feature, amenity, or characteristic of a property.
+    Examples include 'hardwood floors', 'updated kitchen', 'central AC', 'backyard', 'garage', '2-car garage', 'home office'.
+    """
+    feature_name: EntityText = Field(
+        description="The name of the feature or amenity, for example: 'hardwood floors', 'updated kitchen', 'central AC', 'backyard', '2-car garage', 'home office'",
+        default=None
+    )
+    importance: EntityText = Field(
+        description="How important this amenity is to the user, for example: 'essential', 'must-have', 'nice to have', 'preferred'",
+        default=None
+    )
+
+
+class FamilyMember(EntityModel):
+    """
+    Represents a member of the user's household or family.
+    This includes spouse/partner, children, parents, or other relatives that influence housing decisions.
+    """
+    relationship: EntityText = Field(
+        description="The relationship to the user, for example: 'husband', 'wife', 'child', 'daughter', 'son', 'parent', 'mother', 'father'",
+        default=None
+    )
+    age: EntityInt = Field(
+        description="The age of the family member if mentioned, for example: 7, 10, 35",
+        default=None
+    )
+    relevance: EntityText = Field(
+        description="How this family member influences the home search, for example: 'starting middle school', 'works from home', 'visits often', 'needs play space'",
+        default=None
+    )
+
+
+class Room(EntityModel):
+    """
+    Represents a specific room or space within a property that the user has requirements or preferences about.
+    Examples include kitchen, master bedroom, home office, guest room, or other specific spaces.
+    """
+    room_type: EntityText = Field(
+        description="The type of room, for example: 'kitchen', 'master bedroom', 'home office', 'guest room', 'bedroom', 'bathroom'",
+        default=None
+    )
+    desired_features: EntityText = Field(
+        description="Specific features desired for this room, for example: 'updated', 'large', 'with door', 'good-sized', 'renovated'",
+        default=None
+    )
+
+
+class Showing(EntityModel):
+    """
+    Represents a scheduled property showing or tour appointment.
+    This tracks when users are viewing properties.
+    """
+    property_address: EntityText = Field(
+        description="The address of the property being shown, for example: 'Maple Street', 'Birch Lane', 'Oak Drive'",
+        default=None
+    )
+    showing_time: EntityText = Field(
+        description="When the showing is scheduled, for example: 'Saturday at 10am', 'Thursday at 5pm', 'this weekend'",
+        default=None
+    )
+    status: EntityText = Field(
+        description="The status of the showing, for example: 'scheduled', 'completed', 'cancelled'",
+        default=None
+    )
+
+
+class FinancingDetail(EntityModel):
+    """
+    Represents financial and mortgage information related to the home purchase.
+    This includes pre-approval amounts, mortgage details, and financing contingencies.
+    """
+    financing_type: EntityText = Field(
+        description="The type of financing detail, for example: 'pre-approval', 'mortgage', 'financing contingency', 'down payment'",
+        default=None
+    )
+    amount: EntityInt = Field(
+        description="The dollar amount if applicable, for example: 420000 for pre-approval amount",
+        default=None
+    )
+    details: EntityText = Field(
+        description="Additional details about the financing, for example: 'pre-approved up to', 'getting a mortgage', 'financing shouldn't be an issue'",
+        default=None
+    )
+
+
+# ============================================================================
+# Edge Types (Relationships/Verbs)
+# ============================================================================
+
+class InterestedInProperty(EdgeModel):
+    """
+    Represents the fact that the user expressed interest in a specific property.
+    This could be from reviewing listings, saving favorites, or asking to see a property.
+    """
+    property_address: EntityText = Field(
+        description="The address of the property the user is interested in, for example: 'Maple Street' or 'Birch Lane'",
+        default=None
+    )
+    interest_level: EntityText = Field(
+        description="The level of interest, for example: 'high', 'moderate', 'considering', 'very interested'",
+        default=None
+    )
+
+
+class ViewedProperty(EdgeModel):
+    """
+    Represents the fact that the user physically toured or viewed a property.
+    This is a concrete action where the user visited the property for a showing.
+    """
+    property_address: EntityText = Field(
+        description="The address of the property that was viewed, for example: 'Maple Street' or 'Oak Drive'",
+        default=None
+    )
+    viewing_date: EntityText = Field(
+        description="When the property was viewed, for example: 'Saturday', 'yesterday', 'this week', or a specific date",
+        default=None
+    )
+
+
+class RejectedProperty(EdgeModel):
+    """
+    Represents the fact that the user rejected or decided against a property.
+    Includes the reason for rejection, which helps refine future searches.
+    """
+    property_address: EntityText = Field(
+        description="The address of the property that was rejected, for example: 'Maple Street' or 'Oak Drive'",
+        default=None
+    )
+    rejection_reason: EntityText = Field(
+        description="Why the property was rejected, for example: 'too cramped', 'needs too much work', 'outdated kitchen', 'not enough bathrooms'",
+        default=None
+    )
+
+
+class MadeOffer(EdgeModel):
+    """
+    Represents the fact that the user made a purchase offer on a property.
+    This is a significant action in the home buying process.
+    """
+    property_address: EntityText = Field(
+        description="The address of the property where an offer was made, for example: 'Birch Lane'",
+        default=None
+    )
+    offer_amount: EntityInt = Field(
+        description="The dollar amount of the offer, for example: 375000 or 400000",
+        default=None
+    )
+
+
+class HasRequirement(EdgeModel):
+    """
+    Represents a specific requirement, must-have, or criteria that the user needs in a property.
+    Examples include number of bedrooms, bathrooms, features, or condition requirements.
+    """
+    requirement_type: EntityText = Field(
+        description="The category of requirement, for example: 'bedrooms', 'bathrooms', 'condition', 'features', 'space'",
+        default=None
+    )
+    requirement_details: EntityText = Field(
+        description="Specific details about the requirement, for example: 'at least 3 bedrooms', 'move-in ready', 'home office with door', '2.5 bathrooms minimum'",
+        default=None
+    )
+    priority: EntityText = Field(
+        description="How important this requirement is, for example: 'essential', 'must-have', 'important', 'preferred', 'flexible'",
+        default=None
+    )
+
+
+class PrefersNeighborhood(EdgeModel):
+    """
+    Represents the fact that the user prefers or wants to live in a specific neighborhood or area.
+    This helps narrow down the property search to desired locations.
+    """
+    neighborhood_name: EntityText = Field(
+        description="The name of the preferred neighborhood or area, for example: 'Westside', 'Riverside School District', 'near good schools'",
+        default=None
+    )
+    reason: EntityText = Field(
+        description="Why the user prefers this neighborhood, for example: 'good schools', 'family-friendly', 'convenient location', 'safe area'",
+        default=None
+    )
+
+
+class NeedsAmenity(EdgeModel):
+    """
+    Represents the fact that the user needs or wants a specific amenity or feature in their property.
+    This includes both essential features and nice-to-have amenities.
+    """
+    amenity_name: EntityText = Field(
+        description="The specific amenity or feature needed, for example: 'backyard', 'home office', 'hardwood floors', 'updated kitchen', 'central AC', '2-car garage'",
+        default=None
+    )
+    necessity_level: EntityText = Field(
+        description="How necessary this amenity is, for example: 'essential', 'must-have', 'important', 'would be great', 'nice to have'",
+        default=None
+    )
+
+
+class HasBudgetConstraint(EdgeModel):
+    """
+    Represents the user's budget limitations and financial constraints for purchasing a property.
+    This includes price ranges, maximum prices, and flexibility in the budget.
+    """
+    min_price: EntityInt = Field(
+        description="The minimum price the user is considering in dollars, for example: 200000 or 250000",
+        default=None
+    )
+    max_price: EntityInt = Field(
+        description="The maximum price the user can afford in dollars, for example: 400000 or 420000",
+        default=None
+    )
+    flexibility: EntityText = Field(
+        description="How flexible the budget is, for example: 'firm', 'can stretch for the right place', 'flexible', 'negotiable'",
+        default=None
+    )


### PR DESCRIPTION
## Summary
- Remove deprecated `mode` parameter from `get_user_context()` call in agents.py
- Create new `ontology.py` with 8 custom entity types and 8 edge types for real estate domain
- Update ingestion script to set custom ontology for specific user with default ontology disabled
- Replace generic examples with real estate agent use case showcasing family home buying

The custom ontology is designed specifically for the Zep quickstart dashboard, capturing properties, neighborhoods, schools, amenities, family members, rooms, showings, and financing details with appropriate relationships.