### PR TITLE
Upgrade zep-mcp-server SDK and Docker setup

### DIFF
--- a/mcp/zep-mcp-server/.env.example
+++ b/mcp/zep-mcp-server/.env.example
@@ -10,3 +10,7 @@ ZEP_API_KEY=
 # Optional: Logging level (debug, info, warn, error)
 # Default: info
 LOG_LEVEL=info
+
+# Optional: Host port published by docker compose
+# Change this if 8080 is already in use on your machine
+ZEP_MCP_HOST_PORT=8080

--- a/mcp/zep-mcp-server/.env.example
+++ b/mcp/zep-mcp-server/.env.example
@@ -1,5 +1,7 @@
 # Zep MCP Server Configuration
-# Copy this file to .env and fill in your values
+# Copy this file to .env and fill in your values.
+# docker compose reads this file via docker-compose.yml:env_file.
+# docker run can use it via --env-file .env.
 
 # Required: Your Zep Cloud API key
 # Get your API key from https://app.getzep.com

--- a/mcp/zep-mcp-server/.env.example
+++ b/mcp/zep-mcp-server/.env.example
@@ -12,5 +12,5 @@ ZEP_API_KEY=
 LOG_LEVEL=info
 
 # Optional: Host port published by docker compose
-# Change this if 8080 is already in use on your machine
-ZEP_MCP_HOST_PORT=8080
+# Default: 8081
+ZEP_MCP_HOST_PORT=8081

--- a/mcp/zep-mcp-server/Dockerfile
+++ b/mcp/zep-mcp-server/Dockerfile
@@ -1,55 +1,24 @@
-# Multi-stage Dockerfile for Zep MCP Server
-# Stage 1: Build
-FROM golang:1.23.0-alpine3.19 AS builder
+FROM golang:1.23-alpine AS builder
 
-# Install build dependencies
-RUN apk add --no-cache git ca-certificates tzdata
+WORKDIR /src
 
-WORKDIR /build
-
-# Copy go mod files first for better caching
 COPY go.mod go.sum ./
 RUN go mod download
 
-# Copy source code
 COPY . .
 
-# Build static binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -ldflags="-s -w -X main.Version=${VERSION:-0.1.0}" \
-    -o zep-mcp-server \
+    -trimpath \
+    -ldflags="-s -w" \
+    -o /out/zep-mcp-server \
     ./cmd/server
 
-# Stage 2: Runtime
-FROM alpine:3.19
-
-# Install runtime dependencies
-RUN apk add --no-cache ca-certificates curl
-
-# Create non-root user
-RUN addgroup -g 1001 -S zep && \
-    adduser -u 1001 -S zep -G zep
+FROM gcr.io/distroless/static-debian12:nonroot
 
 WORKDIR /app
 
-# Copy binary from builder
-COPY --from=builder /build/zep-mcp-server .
+COPY --from=builder /out/zep-mcp-server /app/zep-mcp-server
 
-# Copy timezone data
-COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
-
-# Set ownership
-RUN chown -R zep:zep /app
-
-# Switch to non-root user
-USER zep
-
-# Health check for HTTP mode (port 8080)
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/ || exit 1
-
-# Expose HTTP port
 EXPOSE 8080
 
-# Run the server (default to HTTP mode)
 ENTRYPOINT ["/app/zep-mcp-server"]

--- a/mcp/zep-mcp-server/Makefile
+++ b/mcp/zep-mcp-server/Makefile
@@ -47,8 +47,8 @@ help:
 	@echo ""
 	@echo "Docker targets:"
 	@echo "  make docker-build  - Build Docker image"
-	@echo "  make docker-run    - Run server with docker-compose"
-	@echo "  make docker-down   - Stop docker-compose"
+	@echo "  make docker-run    - Run server with docker compose"
+	@echo "  make docker-down   - Stop docker compose"
 	@echo "  make docker-clean  - Remove Docker images and containers"
 	@echo ""
 
@@ -137,30 +137,30 @@ docker-build:
 	docker build -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
 	@echo "✓ Docker image built: $(DOCKER_IMAGE):$(DOCKER_TAG)"
 
-## docker-run: Run server with docker-compose
+## docker-run: Run server with docker compose
 docker-run:
-	@echo "Starting server with docker-compose..."
-	docker-compose up
+	@echo "Starting server with docker compose..."
+	docker compose up
 
-## docker-run-detached: Run server with docker-compose in background
+## docker-run-detached: Run server with docker compose in background
 docker-run-detached:
-	@echo "Starting server with docker-compose (detached)..."
-	docker-compose up -d
+	@echo "Starting server with docker compose (detached)..."
+	docker compose up -d
 	@echo "✓ Server started in background"
 
-## docker-down: Stop docker-compose
+## docker-down: Stop docker compose
 docker-down:
-	@echo "Stopping docker-compose..."
-	docker-compose down
+	@echo "Stopping docker compose..."
+	docker compose down
 	@echo "✓ Stopped"
 
-## docker-logs: View docker-compose logs
+## docker-logs: View docker compose logs
 docker-logs:
-	docker-compose logs -f
+	docker compose logs -f
 
 ## docker-clean: Remove Docker images and containers
 docker-clean:
 	@echo "Cleaning Docker resources..."
-	@docker-compose down -v 2>/dev/null || true
+	@docker compose down -v 2>/dev/null || true
 	@docker rmi $(DOCKER_IMAGE):$(DOCKER_TAG) 2>/dev/null || true
 	@echo "✓ Docker resources cleaned"

--- a/mcp/zep-mcp-server/README.md
+++ b/mcp/zep-mcp-server/README.md
@@ -4,7 +4,7 @@ A Model Context Protocol (MCP) server for [Zep Cloud](https://www.getzep.com/), 
 
 ## Features
 
-- **🔍 Search & Retrieval**: Search the knowledge graph, retrieve context, and access conversation history
+- **🔍 Search & Retrieval**: Search the knowledge graph, detect structural patterns, retrieve context, and access conversation history
 - **📊 Graph Exploration**: Query nodes, edges, and episodes from the temporal knowledge graph
 - **🔒 Read-Only**: Safe, non-destructive operations for AI assistants
 - **⚡ Fast**: Built with Go for optimal performance
@@ -12,29 +12,30 @@ A Model Context Protocol (MCP) server for [Zep Cloud](https://www.getzep.com/), 
 
 ## Tools
 
-The server provides 13 read-only tools:
+The server provides 14 read-only tools:
 
 ### Core Search & Retrieval
 
 1. **`search_graph`** - Search the knowledge graph with filters, reranking, and scoped search
-2. **`get_user_context`** - Retrieve formatted context for a thread (supports custom templates)
-3. **`get_user`** - Get user information and metadata
-4. **`list_threads`** - List conversation threads for a user
+2. **`detect_patterns`** - Detect recurring structural patterns in a user or named graph
+3. **`get_user_context`** - Retrieve formatted context for a thread (supports custom templates)
+4. **`get_user`** - Get user information and metadata
+5. **`list_threads`** - List conversation threads for a user
 
 ### Graph Query
 
-5. **`get_user_nodes`** - Retrieve entity nodes from a user's knowledge graph
-6. **`get_user_edges`** - Retrieve relationship edges from a user's knowledge graph
-7. **`get_episodes`** - Get episode nodes (temporal data ingestion events)
+6. **`get_user_nodes`** - Retrieve entity nodes from a user's knowledge graph
+7. **`get_user_edges`** - Retrieve relationship edges from a user's knowledge graph
+8. **`get_episodes`** - Get episode nodes (temporal data ingestion events)
 
 ### Detail Retrieval
 
-8. **`get_thread_messages`** - Retrieve messages from a conversation thread
-9. **`get_node`** - Get a specific node by UUID
-10. **`get_edge`** - Get a specific edge by UUID
-11. **`get_episode`** - Get a specific episode by UUID
-12. **`get_node_edges`** - Get all edges connected to a specific node
-13. **`get_episode_mentions`** - Get nodes and edges mentioned in an episode
+9. **`get_thread_messages`** - Retrieve messages from a conversation thread
+10. **`get_node`** - Get a specific node by UUID
+11. **`get_edge`** - Get a specific edge by UUID
+12. **`get_episode`** - Get a specific episode by UUID
+13. **`get_node_edges`** - Get all edges connected to a specific node
+14. **`get_episode_mentions`** - Get nodes and edges mentioned in an episode
 
 ## Installation
 
@@ -121,14 +122,15 @@ See [Docker Deployment Guide](docs/DOCKER.md) for full Docker documentation.
 # Build the image
 make docker-build
 
-# Run with docker-compose
+# Run with docker compose (loads .env)
 make docker-run
 ```
 
 Or manually:
 ```bash
+cp .env.example .env
 docker build -t zep-mcp-server:latest .
-docker run -e ZEP_API_KEY=your-key -p 8080:8080 zep-mcp-server:latest
+docker run --env-file .env -p 8080:8080 zep-mcp-server:latest
 ```
 
 ### MCP Client Configuration
@@ -193,7 +195,7 @@ Claude Code uses HTTP transport to connect to MCP servers. Configure it using th
 **Using Docker:**
 ```bash
 # Edit .env file with your ZEP_API_KEY
-docker-compose up -d
+docker compose up -d
 
 # Add to Claude Code
 claude mcp add --transport http zep http://localhost:8080
@@ -212,6 +214,20 @@ tools.search_graph({
   query: "What are their preferences?",
   scope: "edges",  // edges, nodes, or episodes
   limit: 10
+})
+```
+
+### Detect Graph Patterns
+
+```javascript
+// Detect recurring graph patterns around decision nodes
+tools.detect_patterns({
+  user_id: "user_123",
+  seeds: {
+    node_labels: ["Decision"]
+  },
+  recency_weight: "30_days",
+  include_examples: true
 })
 ```
 

--- a/mcp/zep-mcp-server/README.md
+++ b/mcp/zep-mcp-server/README.md
@@ -129,7 +129,9 @@ make docker-run
 Or manually:
 ```bash
 cp .env.example .env
+# Optional: change ZEP_MCP_HOST_PORT in .env if 8080 is taken
 docker build -t zep-mcp-server:latest .
+# If you changed ZEP_MCP_HOST_PORT, use the same host port here
 docker run --env-file .env -p 8080:8080 zep-mcp-server:latest
 ```
 
@@ -195,6 +197,7 @@ Claude Code uses HTTP transport to connect to MCP servers. Configure it using th
 **Using Docker:**
 ```bash
 # Edit .env file with your ZEP_API_KEY
+# Optional: set ZEP_MCP_HOST_PORT=8081 if 8080 is already in use
 docker compose up -d
 
 # Add to Claude Code

--- a/mcp/zep-mcp-server/README.md
+++ b/mcp/zep-mcp-server/README.md
@@ -129,10 +129,10 @@ make docker-run
 Or manually:
 ```bash
 cp .env.example .env
-# Optional: change ZEP_MCP_HOST_PORT in .env if 8080 is taken
+# Optional: change ZEP_MCP_HOST_PORT in .env if you do not want the default 8081
 docker build -t zep-mcp-server:latest .
 # If you changed ZEP_MCP_HOST_PORT, use the same host port here
-docker run --env-file .env -p 8080:8080 zep-mcp-server:latest
+docker run --env-file .env -p 8081:8080 zep-mcp-server:latest
 ```
 
 ### MCP Client Configuration
@@ -197,11 +197,11 @@ Claude Code uses HTTP transport to connect to MCP servers. Configure it using th
 **Using Docker:**
 ```bash
 # Edit .env file with your ZEP_API_KEY
-# Optional: set ZEP_MCP_HOST_PORT=8081 if 8080 is already in use
+# Optional: set ZEP_MCP_HOST_PORT if you do not want the default 8081
 docker compose up -d
 
 # Add to Claude Code
-claude mcp add --transport http zep http://localhost:8080
+claude mcp add --transport http zep http://localhost:8081
 ```
 
 The HTTP transport supports both stateless JSON requests and streaming responses, allowing Claude Code and other HTTP-based MCP clients to interact with the Zep knowledge graph.

--- a/mcp/zep-mcp-server/docker-compose.yml
+++ b/mcp/zep-mcp-server/docker-compose.yml
@@ -1,51 +1,9 @@
-version: '3.8'
-
 services:
   zep-mcp-server:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    build: .
     image: zep-mcp-server:latest
-    container_name: zep-mcp-server
     restart: unless-stopped
-
-    environment:
-      # Zep API Configuration
-      - ZEP_API_KEY=${ZEP_API_KEY}
-      # Optional: Override default log level
-      - LOG_LEVEL=${LOG_LEVEL:-info}
-
+    env_file:
+      - .env
     ports:
       - "8080:8080"
-
-    # Health check
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
-      interval: 30s
-      timeout: 3s
-      retries: 3
-      start_period: 5s
-
-    # Resource limits
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 128M
-        reservations:
-          cpus: '0.5'
-          memory: 64M
-
-    # Security
-    security_opt:
-      - no-new-privileges:true
-    read_only: true
-    tmpfs:
-      - /tmp
-
-    # Logging
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"

--- a/mcp/zep-mcp-server/docker-compose.yml
+++ b/mcp/zep-mcp-server/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     env_file:
       - .env
     ports:
-      - "${ZEP_MCP_HOST_PORT:-8080}:8080"
+      - "${ZEP_MCP_HOST_PORT:-8081}:8080"

--- a/mcp/zep-mcp-server/docker-compose.yml
+++ b/mcp/zep-mcp-server/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     env_file:
       - .env
     ports:
-      - "8080:8080"
+      - "${ZEP_MCP_HOST_PORT:-8080}:8080"

--- a/mcp/zep-mcp-server/docs/DOCKER.md
+++ b/mcp/zep-mcp-server/docs/DOCKER.md
@@ -17,6 +17,7 @@ cp .env.example .env
 ```
 
 2. Set `ZEP_API_KEY` in `.env`.
+   If port `8080` is already in use, also change `ZEP_MCP_HOST_PORT` in `.env`.
 
 3. Start the server:
 
@@ -24,7 +25,7 @@ cp .env.example .env
 docker compose up --build
 ```
 
-The server listens on `http://localhost:8080`.
+By default the server listens on `http://localhost:8080`.
 
 ## Compose Environment Loading
 
@@ -35,7 +36,7 @@ env_file:
   - .env
 ```
 
-That means `docker compose` loads `ZEP_API_KEY` and `LOG_LEVEL` from the local `.env` file and passes them into the container environment.
+That means `docker compose` loads `ZEP_API_KEY` and `LOG_LEVEL` from the local `.env` file and passes them into the container environment. The same `.env` file also provides `ZEP_MCP_HOST_PORT` for the host-side port mapping.
 
 ## Build and Run Manually
 
@@ -48,6 +49,7 @@ docker build -t zep-mcp-server:latest .
 Run it with the same `.env` file:
 
 ```bash
+# If you changed ZEP_MCP_HOST_PORT in .env, use the same host port here
 docker run --rm \
   --env-file .env \
   -p 8080:8080 \
@@ -83,5 +85,6 @@ docker compose config
 ## Notes
 
 - The server defaults to HTTP mode on port `8080`.
+- Change `ZEP_MCP_HOST_PORT` in `.env` if `8080` is already allocated on the host.
 - The application itself still supports reading a `.env` file when run directly outside Docker.
 - For Docker, the standard path is `env_file: .env` in Compose or `--env-file .env` with `docker run`.

--- a/mcp/zep-mcp-server/docs/DOCKER.md
+++ b/mcp/zep-mcp-server/docs/DOCKER.md
@@ -1,369 +1,87 @@
 # Docker Deployment Guide
 
-This guide covers deploying the Zep MCP Server using Docker and Docker Compose.
+This package includes a minimal Docker image and a minimal Compose setup.
+
+## Files
+
+- `Dockerfile`: multi-stage build that produces a small non-root runtime image
+- `docker-compose.yml`: runs the server and loads environment variables from `.env`
+- `.env.example`: template for the required runtime variables
 
 ## Quick Start
 
-1. **Create environment file:**
-   ```bash
-   cp .env.example .env
-   # Edit .env and add your ZEP_API_KEY
-   ```
+1. Create the environment file:
 
-2. **Start with Docker Compose:**
-   ```bash
-   docker-compose up
-   ```
+```bash
+cp .env.example .env
+```
 
-The server will be available at `http://localhost:8080`.
+2. Set `ZEP_API_KEY` in `.env`.
 
-## Docker Build
+3. Start the server:
 
-### Building the Image
+```bash
+docker compose up --build
+```
 
-Build the Docker image manually:
+The server listens on `http://localhost:8080`.
+
+## Compose Environment Loading
+
+`docker-compose.yml` uses:
+
+```yaml
+env_file:
+  - .env
+```
+
+That means `docker compose` loads `ZEP_API_KEY` and `LOG_LEVEL` from the local `.env` file and passes them into the container environment.
+
+## Build and Run Manually
+
+Build the image:
 
 ```bash
 docker build -t zep-mcp-server:latest .
 ```
 
-Or use the build script:
+Run it with the same `.env` file:
 
 ```bash
-./scripts/build.sh
+docker run --rm \
+  --env-file .env \
+  -p 8080:8080 \
+  zep-mcp-server:latest
 ```
 
-### Build Arguments
+## Common Commands
 
-- `VERSION`: Set the version string (default: 0.1.0)
+Start in the background:
 
 ```bash
-docker build --build-arg VERSION=1.0.0 -t zep-mcp-server:1.0.0 .
+docker compose up -d --build
 ```
 
-### Multi-Platform Builds
-
-Build for multiple platforms:
+Stop the service:
 
 ```bash
-docker buildx build \
-    --platform linux/amd64,linux/arm64 \
-    -t zep-mcp-server:latest \
-    .
+docker compose down
 ```
 
-## Running with Docker
-
-### Run with Environment Variables
+Follow logs:
 
 ```bash
-docker run -d \
-    --name zep-mcp-server \
-    -e ZEP_API_KEY=your-key-here \
-    -p 8080:8080 \
-    zep-mcp-server:latest
+docker compose logs -f
 ```
 
-### Run with Environment File
+Render the resolved Compose config:
 
 ```bash
-docker run -d \
-    --name zep-mcp-server \
-    --env-file .env \
-    -p 8080:8080 \
-    zep-mcp-server:latest
+docker compose config
 ```
 
-### Run with Custom Port
-
-```bash
-docker run -d \
-    --name zep-mcp-server \
-    -e ZEP_API_KEY=your-key-here \
-    -p 9000:8080 \
-    zep-mcp-server:latest \
-    --port 8080
-```
-
-### Run in Stdio Mode
-
-For use with Claude Desktop or Cline:
-
-```bash
-docker run -i \
-    --name zep-mcp-server \
-    -e ZEP_API_KEY=your-key-here \
-    zep-mcp-server:latest \
-    --stdio
-```
-
-## Docker Compose
-
-### Starting the Server
-
-Start in background:
-```bash
-docker-compose up -d
-```
-
-Start with logs:
-```bash
-docker-compose up
-```
-
-### Stopping the Server
-
-```bash
-docker-compose down
-```
-
-### Viewing Logs
-
-```bash
-docker-compose logs -f
-```
-
-### Checking Status
-
-```bash
-docker-compose ps
-```
-
-### Restarting the Server
-
-```bash
-docker-compose restart
-```
-
-## Configuration
-
-### Environment Variables
-
-Set these in `.env` file or pass via `-e` flag:
-
-- **ZEP_API_KEY** (required): Your Zep Cloud API key
-- **LOG_LEVEL** (optional): Logging level (debug, info, warn, error) - default: info
-
-### docker-compose.yml
-
-The compose file includes:
-
-- **Health checks**: Automatic health monitoring
-- **Resource limits**: CPU and memory constraints
-- **Security**: Non-root user, read-only filesystem, no new privileges
-- **Logging**: Configured with rotation (10MB max, 3 files)
-- **Restart policy**: Automatically restarts unless stopped manually
-
-### Customizing docker-compose.yml
-
-Edit resource limits:
-
-```yaml
-deploy:
-  resources:
-    limits:
-      cpus: '2'
-      memory: 256M
-```
-
-Change port mapping:
-
-```yaml
-ports:
-  - "9000:8080"
-```
-
-## Health Checks
-
-The Docker container includes health checks that verify the server is responding on port 8080.
-
-Check health status:
-```bash
-docker inspect --format='{{.State.Health.Status}}' zep-mcp-server
-```
-
-View health check logs:
-```bash
-docker inspect --format='{{range .State.Health.Log}}{{.Output}}{{end}}' zep-mcp-server
-```
-
-## Security
-
-### Non-Root User
-
-The container runs as user `zep` (UID 1001) for security.
-
-### Read-Only Filesystem
-
-The container uses a read-only root filesystem with only `/tmp` as writable.
-
-### Security Options
-
-- `no-new-privileges`: Prevents privilege escalation
-- Minimal Alpine base image with only essential packages
-
-## Troubleshooting
-
-### Container Won't Start
-
-Check logs:
-```bash
-docker-compose logs
-```
-
-Verify environment variables:
-```bash
-docker-compose config
-```
-
-### Connection Issues
-
-Verify port mapping:
-```bash
-docker ps
-```
-
-Test connectivity:
-```bash
-curl http://localhost:8080
-```
-
-### Health Check Failures
-
-Check health status:
-```bash
-docker inspect zep-mcp-server | grep -A 10 Health
-```
-
-### Permission Issues
-
-Ensure the container can write to /tmp:
-```bash
-docker exec zep-mcp-server ls -la /tmp
-```
-
-## Production Deployment
-
-### Using Docker Compose
-
-The included `docker-compose.yml` is configured for production with:
-
-- Automatic restarts
-- Resource limits
-- Health checks
-- Security hardening
-- Log rotation
-
-### Best Practices
-
-1. **Use secrets management** for ZEP_API_KEY:
-   - Docker secrets
-   - Kubernetes secrets
-   - Cloud provider secret managers
-
-2. **Monitor resource usage**:
-   ```bash
-   docker stats zep-mcp-server
-   ```
-
-3. **Set up log aggregation**:
-   - Configure Docker logging driver for your platform
-   - Use centralized logging (CloudWatch, Datadog, etc.)
-
-4. **Enable automatic updates**:
-   - Use Watchtower or similar tools
-   - Set up CI/CD pipeline
-
-5. **Use specific version tags**:
-   ```bash
-   docker build -t zep-mcp-server:1.0.0 .
-   ```
-
-## Makefile Integration
-
-Use make commands for common Docker operations:
-
-```bash
-# Build Docker image
-make docker-build
-
-# Run with Docker Compose
-make docker-run
-
-# Stop Docker Compose
-make docker-down
-
-# Clean Docker resources
-make docker-clean
-```
-
-## Registry Publishing
-
-### Tag for Registry
-
-```bash
-docker tag zep-mcp-server:latest your-registry.com/zep-mcp-server:latest
-```
-
-### Push to Registry
-
-```bash
-docker push your-registry.com/zep-mcp-server:latest
-```
-
-### Pull from Registry
-
-```bash
-docker pull your-registry.com/zep-mcp-server:latest
-```
-
-## Advanced Usage
-
-### Custom Entrypoint
-
-Override the entrypoint for debugging:
-
-```bash
-docker run -it --entrypoint /bin/sh zep-mcp-server:latest
-```
-
-### Volume Mounting
-
-Mount configuration files:
-
-```bash
-docker run -v $(pwd)/.env:/app/.env zep-mcp-server:latest
-```
-
-### Network Configuration
-
-Use custom networks:
-
-```bash
-docker network create zep-network
-docker run --network zep-network zep-mcp-server:latest
-```
-
-## CI/CD Integration
-
-### GitHub Actions Example
-
-```yaml
-- name: Build Docker image
-  run: docker build -t zep-mcp-server:${{ github.sha }} .
-
-- name: Run tests
-  run: docker run zep-mcp-server:${{ github.sha }} make test
-
-- name: Push to registry
-  run: |
-    docker tag zep-mcp-server:${{ github.sha }} registry/zep-mcp-server:latest
-    docker push registry/zep-mcp-server:latest
-```
-
-## Support
-
-For issues or questions:
-- Check the main [README.md](../README.md)
-- Review [TOOLS.md](TOOLS.md) for API documentation
-- Open an issue on GitHub
+## Notes
+
+- The server defaults to HTTP mode on port `8080`.
+- The application itself still supports reading a `.env` file when run directly outside Docker.
+- For Docker, the standard path is `env_file: .env` in Compose or `--env-file .env` with `docker run`.

--- a/mcp/zep-mcp-server/docs/DOCKER.md
+++ b/mcp/zep-mcp-server/docs/DOCKER.md
@@ -17,7 +17,7 @@ cp .env.example .env
 ```
 
 2. Set `ZEP_API_KEY` in `.env`.
-   If port `8080` is already in use, also change `ZEP_MCP_HOST_PORT` in `.env`.
+   Change `ZEP_MCP_HOST_PORT` in `.env` if you do not want the default host port `8081`.
 
 3. Start the server:
 
@@ -25,7 +25,7 @@ cp .env.example .env
 docker compose up --build
 ```
 
-By default the server listens on `http://localhost:8080`.
+By default Docker publishes the server on `http://localhost:8081`.
 
 ## Compose Environment Loading
 
@@ -52,7 +52,7 @@ Run it with the same `.env` file:
 # If you changed ZEP_MCP_HOST_PORT in .env, use the same host port here
 docker run --rm \
   --env-file .env \
-  -p 8080:8080 \
+  -p 8081:8080 \
   zep-mcp-server:latest
 ```
 
@@ -84,7 +84,7 @@ docker compose config
 
 ## Notes
 
-- The server defaults to HTTP mode on port `8080`.
-- Change `ZEP_MCP_HOST_PORT` in `.env` if `8080` is already allocated on the host.
+- The server inside the container still listens on port `8080`.
+- Docker publishes that container port on host `8081` by default.
 - The application itself still supports reading a `.env` file when run directly outside Docker.
 - For Docker, the standard path is `env_file: .env` in Compose or `--env-file .env` with `docker run`.

--- a/mcp/zep-mcp-server/docs/SDK_V3_17_DELTA.md
+++ b/mcp/zep-mcp-server/docs/SDK_V3_17_DELTA.md
@@ -1,0 +1,31 @@
+# Zep Go SDK v3.17.0 Delta
+
+Latest verified version: `github.com/getzep/zep-go/v3 v3.17.0` published on 2026-03-02.
+
+## Current MCP impact
+
+- `GraphSearchQuery.MinFactRating` was removed in `v3.17.0`.
+  The MCP `search_graph` tool must not accept or send `min_fact_rating`.
+- `ThreadGetUserContextRequest.MinRating` and `ThreadGetUserContextRequest.Mode` were removed.
+  The MCP server already does not expose them, so no code change is needed.
+- `MessageListResponse.ThreadCreatedAt` was added.
+  `get_thread_messages` already returns the raw SDK response, so the field is available automatically.
+
+## New SDK capabilities
+
+- `client.Graph.DetectPatterns(...)` added.
+  This is a read-only graph analysis API for relationships, paths, co-occurrences, hubs, and clusters.
+- `client.Graph.Node.Update(...)` added.
+- `client.Graph.Edge.Update(...)` added.
+
+## MCP changes implemented
+
+- Added a read-only `detect_patterns` tool.
+- Documented `thread_created_at` in `get_thread_messages` output.
+- Did not add `update_node` or `update_edge`.
+  The MCP server is explicitly read-only and these endpoints are mutating operations.
+
+## Sources
+
+- Go module resolution: `go list -m -json github.com/getzep/zep-go/v3@latest`
+- SDK docs: https://help.getzep.com/sdk-reference/graph/detect-patterns-experimental

--- a/mcp/zep-mcp-server/docs/TOOLS.md
+++ b/mcp/zep-mcp-server/docs/TOOLS.md
@@ -5,6 +5,7 @@ Complete reference for all tools provided by the Zep MCP Server.
 ## Table of Contents
 
 - [search_graph](#search_graph)
+- [detect_patterns](#detect_patterns)
 - [get_user_context](#get_user_context)
 - [get_user](#get_user)
 - [list_threads](#list_threads)
@@ -33,7 +34,6 @@ Search the Zep knowledge graph for relevant information about a user.
 | `scope` | string | No | Search scope: `edges`, `nodes`, or `episodes` (default: `edges`) |
 | `limit` | integer | No | Maximum results (default: 10, max: 50) |
 | `reranker` | string | No | Reranking strategy: `rrf`, `mmr`, `node_distance`, `episode_mentions`, `cross_encoder` |
-| `min_fact_rating` | number | No | Minimum fact rating threshold for filtering results |
 | `mmr_lambda` | number | No | Weighting for maximal marginal relevance reranking |
 | `center_node_uuid` | string | No | Node UUID to rerank around for `node_distance` reranking |
 | `node_labels` | array[string] | No | Filter results by node labels |
@@ -63,6 +63,60 @@ JSON object containing edges, nodes, and/or episodes depending on the search sco
 - Discovering relevant entities
 - Building context for conversations
 - Filtering by entity or relationship type
+
+---
+
+## detect_patterns
+
+Detect structural patterns in a user graph or named graph. Returns recurring relationships, paths, co-occurrences, hubs, and clusters.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `user_id` | string | Conditionally | User graph target. Provide exactly one of `user_id` or `graph_id` |
+| `graph_id` | string | Conditionally | Named graph target. Provide exactly one of `graph_id` or `user_id` |
+| `seeds` | object | No | Seed selection with `node_uuids`, `node_labels`, and/or `edge_types` |
+| `search_filters` | object | No | Filters for participating nodes and edges. Uses the same structure as graph search |
+| `limit` | integer | No | Maximum number of patterns to return (default: 50, max: 200) |
+| `min_occurrences` | integer | No | Minimum occurrence count to report a pattern (default: 2) |
+| `include_examples` | boolean | No | Include example node and edge UUIDs for each pattern |
+| `recency_weight` | string | No | Temporal decay half-life: `none`, `7_days`, `30_days`, or `90_days` |
+| `detect` | object | No | Pattern-specific configuration for `relationships`, `paths`, `co_occurrences`, `hubs`, and `clusters` |
+
+### Returns
+
+JSON object containing:
+- `patterns`: detected patterns sorted by weighted score
+- `metadata`: analysis metadata including `nodes_analyzed`, `edges_analyzed`, and `elapsed_ms`
+
+### Example
+
+```javascript
+{
+  "user_id": "alice_123",
+  "seeds": {
+    "node_labels": ["Decision"]
+  },
+  "recency_weight": "30_days",
+  "include_examples": true,
+  "detect": {
+    "hubs": {
+      "min_degree": 4
+    },
+    "paths": {
+      "max_hops": 3
+    }
+  }
+}
+```
+
+### Use Cases
+
+- Finding repeated relationship structures in a user graph
+- Discovering hubs and common multi-hop paths
+- Surfacing recurring patterns for agent planning or summarization
+- Inspecting graph structure without mutating data
 
 ---
 
@@ -269,7 +323,7 @@ Retrieve messages from a conversation thread.
 
 ### Returns
 
-JSON object containing messages with `role`, `content`, `uuid`, and timestamps.
+JSON object containing messages with `role`, `content`, `uuid`, timestamps, pagination counts, and `thread_created_at`.
 
 ### Example
 

--- a/mcp/zep-mcp-server/go.mod
+++ b/mcp/zep-mcp-server/go.mod
@@ -3,7 +3,7 @@ module github.com/getzep/zep/mcp/zep-mcp-server
 go 1.23.0
 
 require (
-	github.com/getzep/zep-go/v3 v3.16.0
+	github.com/getzep/zep-go/v3 v3.17.0
 	github.com/joho/godotenv v1.5.1
 	github.com/modelcontextprotocol/go-sdk v1.1.0
 )

--- a/mcp/zep-mcp-server/go.sum
+++ b/mcp/zep-mcp-server/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/getzep/zep-go/v3 v3.16.0 h1:2zQ9RAJsjnxpR/o7MqfmQ81nX/HqI4Q5VuOb6ILDHE8=
-github.com/getzep/zep-go/v3 v3.16.0/go.mod h1:gTP6uw5RPlcFSs5z0pGUzhOpx8+w/S2swSc08efsSyQ=
+github.com/getzep/zep-go/v3 v3.17.0 h1:TyDiwCYOmP9KQZabEQn7Q9lMRlS0LxbtaBioNSZzUQ4=
+github.com/getzep/zep-go/v3 v3.17.0/go.mod h1:gTP6uw5RPlcFSs5z0pGUzhOpx8+w/S2swSc08efsSyQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=

--- a/mcp/zep-mcp-server/internal/handlers/patterns.go
+++ b/mcp/zep-mcp-server/internal/handlers/patterns.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	zep "github.com/getzep/zep-go/v3"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/getzep/zep/mcp/zep-mcp-server/internal/transform"
+	zepclient "github.com/getzep/zep/mcp/zep-mcp-server/pkg/zep"
+)
+
+// HandleDetectPatterns handles the detect_patterns tool.
+func HandleDetectPatterns(client *zepclient.Client) mcp.ToolHandlerFor[DetectPatternsInput, any] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input DetectPatternsInput) (*mcp.CallToolResult, any, error) {
+		detectReq, err := buildDetectPatternsRequest(input)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		results, err := client.Graph.DetectPatterns(ctx, detectReq)
+		if err != nil {
+			return nil, nil, fmt.Errorf("pattern detection failed: %w", err)
+		}
+
+		resultJSON, err := transform.FormatJSON(results)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to format results: %w", err)
+		}
+
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				&mcp.TextContent{
+					Text: resultJSON,
+				},
+			},
+		}, results, nil
+	}
+}
+
+func buildDetectPatternsRequest(input DetectPatternsInput) (*zep.DetectPatternsRequest, error) {
+	if input.UserID == "" && input.GraphID == "" {
+		return nil, fmt.Errorf("either user_id or graph_id is required")
+	}
+	if input.UserID != "" && input.GraphID != "" {
+		return nil, fmt.Errorf("provide only one of user_id or graph_id")
+	}
+
+	detectReq := &zep.DetectPatternsRequest{
+		Detect:        input.Detect,
+		SearchFilters: input.SearchFilters,
+		Seeds:         input.Seeds,
+	}
+
+	if input.UserID != "" {
+		detectReq.UserID = &input.UserID
+	}
+	if input.GraphID != "" {
+		detectReq.GraphID = &input.GraphID
+	}
+	if input.Limit > 0 {
+		detectReq.Limit = &input.Limit
+	}
+	if input.MinOccurrences > 0 {
+		detectReq.MinOccurrences = &input.MinOccurrences
+	}
+	if input.IncludeExamples {
+		detectReq.IncludeExamples = &input.IncludeExamples
+	}
+	if input.RecencyWeight != "" {
+		recencyWeight, err := zep.NewRecencyWeightFromString(input.RecencyWeight)
+		if err != nil {
+			return nil, fmt.Errorf("invalid recency_weight: %w", err)
+		}
+		detectReq.RecencyWeight = &recencyWeight
+	}
+
+	return detectReq, nil
+}

--- a/mcp/zep-mcp-server/internal/handlers/patterns_test.go
+++ b/mcp/zep-mcp-server/internal/handlers/patterns_test.go
@@ -1,0 +1,50 @@
+package handlers
+
+import "testing"
+
+func TestBuildDetectPatternsRequestRequiresGraphTarget(t *testing.T) {
+	_, err := buildDetectPatternsRequest(DetectPatternsInput{})
+	if err == nil {
+		t.Fatal("expected an error when neither user_id nor graph_id is set")
+	}
+}
+
+func TestBuildDetectPatternsRequestRejectsAmbiguousGraphTarget(t *testing.T) {
+	_, err := buildDetectPatternsRequest(DetectPatternsInput{
+		UserID:  "user-123",
+		GraphID: "graph-123",
+	})
+	if err == nil {
+		t.Fatal("expected an error when both user_id and graph_id are set")
+	}
+}
+
+func TestBuildDetectPatternsRequestParsesRecencyWeight(t *testing.T) {
+	req, err := buildDetectPatternsRequest(DetectPatternsInput{
+		UserID:        "user-123",
+		RecencyWeight: "30_days",
+		Limit:         25,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.UserID == nil || *req.UserID != "user-123" {
+		t.Fatalf("expected user_id to be set, got %#v", req.UserID)
+	}
+	if req.RecencyWeight == nil || string(*req.RecencyWeight) != "30_days" {
+		t.Fatalf("expected recency_weight to be 30_days, got %#v", req.RecencyWeight)
+	}
+	if req.Limit == nil || *req.Limit != 25 {
+		t.Fatalf("expected limit to be 25, got %#v", req.Limit)
+	}
+}
+
+func TestBuildDetectPatternsRequestRejectsInvalidRecencyWeight(t *testing.T) {
+	_, err := buildDetectPatternsRequest(DetectPatternsInput{
+		GraphID:       "graph-123",
+		RecencyWeight: "yesterday",
+	})
+	if err == nil {
+		t.Fatal("expected an error for invalid recency_weight")
+	}
+}

--- a/mcp/zep-mcp-server/internal/handlers/search.go
+++ b/mcp/zep-mcp-server/internal/handlers/search.go
@@ -41,10 +41,6 @@ func HandleSearchGraph(client *zepclient.Client) mcp.ToolHandlerFor[SearchGraphI
 			searchReq.Reranker = &rerankerType
 		}
 
-		if input.MinFactRating > 0.0 {
-			searchReq.MinFactRating = &input.MinFactRating
-		}
-
 		if input.MmrLambda > 0.0 {
 			searchReq.MmrLambda = &input.MmrLambda
 		}

--- a/mcp/zep-mcp-server/internal/handlers/types.go
+++ b/mcp/zep-mcp-server/internal/handlers/types.go
@@ -1,5 +1,7 @@
 package handlers
 
+import zep "github.com/getzep/zep-go/v3"
+
 // Input and output types for MCP tool handlers
 // These types are used to automatically generate JSON schemas
 
@@ -10,11 +12,23 @@ type SearchGraphInput struct {
 	Scope          string   `json:"scope,omitempty" jsonschema:"Search scope: edges nodes or episodes (default: edges)"`
 	Limit          int      `json:"limit,omitempty" jsonschema:"Maximum number of results to return (default: 10)"`
 	Reranker       string   `json:"reranker,omitempty" jsonschema:"Reranking strategy: rrf mmr node_distance episode_mentions or cross_encoder"`
-	MinFactRating  float64  `json:"min_fact_rating,omitempty" jsonschema:"Minimum fact rating threshold for filtering results"`
 	MmrLambda      float64  `json:"mmr_lambda,omitempty" jsonschema:"Weighting for maximal marginal relevance reranking"`
 	CenterNodeUUID string   `json:"center_node_uuid,omitempty" jsonschema:"Node UUID to rerank around for node_distance reranking"`
 	NodeLabels     []string `json:"node_labels,omitempty" jsonschema:"Filter results by node labels"`
 	EdgeTypes      []string `json:"edge_types,omitempty" jsonschema:"Filter results by edge types"`
+}
+
+// DetectPatternsInput defines the input parameters for detect_patterns
+type DetectPatternsInput struct {
+	UserID          string             `json:"user_id,omitempty" jsonschema:"User ID when detecting patterns on a user graph. Provide either user_id or graph_id"`
+	GraphID         string             `json:"graph_id,omitempty" jsonschema:"Graph ID when detecting patterns on a named graph. Provide either graph_id or user_id"`
+	Seeds           *zep.PatternSeeds  `json:"seeds,omitempty" jsonschema:"Seed selection. Recommended for focused analysis using node_uuids node_labels or edge_types"`
+	SearchFilters   *zep.SearchFilters `json:"search_filters,omitempty" jsonschema:"Optional filters which edges and nodes participate in pattern detection"`
+	Limit           int                `json:"limit,omitempty" jsonschema:"Maximum number of patterns to return (default: 50 max: 200)"`
+	MinOccurrences  int                `json:"min_occurrences,omitempty" jsonschema:"Minimum occurrence count to report a pattern (default: 2)"`
+	IncludeExamples bool               `json:"include_examples,omitempty" jsonschema:"Include example node and edge UUIDs for each detected pattern"`
+	RecencyWeight   string             `json:"recency_weight,omitempty" jsonschema:"Temporal decay half-life: none 7_days 30_days or 90_days"`
+	Detect          *zep.DetectConfig  `json:"detect,omitempty" jsonschema:"Optional pattern-type configuration for relationships paths co_occurrences hubs and clusters"`
 }
 
 // GetUserContextInput defines the input parameters for get_user_context

--- a/mcp/zep-mcp-server/internal/handlers/types_test.go
+++ b/mcp/zep-mcp-server/internal/handlers/types_test.go
@@ -11,6 +11,7 @@ func TestInputTypes(t *testing.T) {
 		input interface{}
 	}{
 		{"SearchGraphInput", SearchGraphInput{}},
+		{"DetectPatternsInput", DetectPatternsInput{}},
 		{"GetUserContextInput", GetUserContextInput{}},
 		{"GetUserInput", GetUserInput{}},
 		{"ListThreadsInput", ListThreadsInput{}},

--- a/mcp/zep-mcp-server/internal/server/server.go
+++ b/mcp/zep-mcp-server/internal/server/server.go
@@ -69,6 +69,7 @@ func (s *Server) registerTools() {
 
 	// Phase 1: Core search and retrieval tools
 	mcp.AddTool[handlers.SearchGraphInput, any](s.mcp, SearchGraphTool, handlers.HandleSearchGraph(s.zepClient))
+	mcp.AddTool[handlers.DetectPatternsInput, any](s.mcp, DetectPatternsTool, handlers.HandleDetectPatterns(s.zepClient))
 	mcp.AddTool[handlers.GetUserContextInput, any](s.mcp, GetUserContextTool, handlers.HandleGetUserContext(s.zepClient))
 	mcp.AddTool[handlers.GetUserInput, any](s.mcp, GetUserTool, handlers.HandleGetUser(s.zepClient))
 	mcp.AddTool[handlers.ListThreadsInput, any](s.mcp, ListThreadsTool, handlers.HandleListThreads(s.zepClient))
@@ -86,7 +87,7 @@ func (s *Server) registerTools() {
 	mcp.AddTool[handlers.GetNodeEdgesInput, any](s.mcp, GetNodeEdgesTool, handlers.HandleGetNodeEdges(s.zepClient))
 	mcp.AddTool[handlers.GetEpisodeMentionsInput, any](s.mcp, GetEpisodeMentionsTool, handlers.HandleGetEpisodeMentions(s.zepClient))
 
-	s.logger.Info("Registered 13 tools")
+	s.logger.Info("Registered 14 tools")
 }
 
 // Run starts the MCP server

--- a/mcp/zep-mcp-server/internal/server/server_test.go
+++ b/mcp/zep-mcp-server/internal/server/server_test.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/getzep/zep/mcp/zep-mcp-server/internal/config"
+)
+
+func TestNewRegistersTools(t *testing.T) {
+	cfg := &config.Config{
+		ZepAPIKey:     "test-key",
+		LogLevel:      "info",
+		ServerName:    "zep-mcp-server",
+		ServerVersion: "0.1.0",
+	}
+
+	srv, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	if srv == nil {
+		t.Fatal("New() returned nil server")
+	}
+}

--- a/mcp/zep-mcp-server/internal/server/tools.go
+++ b/mcp/zep-mcp-server/internal/server/tools.go
@@ -10,6 +10,11 @@ var SearchGraphTool = &mcp.Tool{
 	Description: "Search the Zep knowledge graph for relevant information about a user. Returns facts, entities, and relationships.",
 }
 
+var DetectPatternsTool = &mcp.Tool{
+	Name:        "detect_patterns",
+	Description: "Detect recurring structural patterns in a user or named graph, including relationships, paths, hubs, clusters, and co-occurrences.",
+}
+
 var GetUserContextTool = &mcp.Tool{
 	Name:        "get_user_context",
 	Description: "Retrieve formatted context string for a conversation thread. Returns facts and entities relevant to the thread.",


### PR DESCRIPTION
This updates `mcp/zep-mcp-server` to `github.com/getzep/zep-go/v3 v3.17.0` and removes the stale `min_fact_rating` handling that no longer exists in the SDK. It adds a new read-only `detect_patterns` MCP tool, updates tool counts/docs/examples, and records the v3.17 delta. It also replaces the container setup with a minimal distroless image plus a simplified `docker-compose.yml` that loads runtime variables from `.env`, and aligns the Makefile/README/Docker guide with `docker compose`. Validation: `go test ./...`, `docker build -t zep-mcp-server:test .`, and `docker compose config` (with `.env.example` copied to `.env`).