### PR TITLE
Add 'auto' scope to ADK graph search tool

### DIFF
--- a/integrations/python/zep_adk/CHANGELOG.md
+++ b/integrations/python/zep_adk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.0 (2026-04-07)
+
+### Added
+
+- `auto` scope for `ZepGraphSearchTool` -- lets Zep decide the best mix of edges, nodes, and episodes to return.
+- Support for pinning optional parameters to `None` to hide them from the model schema without passing them to the SDK.
+
+### Changed
+
+- Improved `scope` parameter descriptions to be more precise about what each scope searches.
+
 ## 0.1.0 (2026-03-23)
 
 ### Added

--- a/integrations/python/zep_adk/pyproject.toml
+++ b/integrations/python/zep_adk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-adk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Google ADK integration for Zep"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/integrations/python/zep_adk/src/zep_adk/graph_search_tool.py
+++ b/integrations/python/zep_adk/src/zep_adk/graph_search_tool.py
@@ -299,7 +299,7 @@ class ZepGraphSearchTool(BaseTool):
         if scope == "auto":
             # Auto scope returns a pre-formatted context string in result.context
             # rather than populating the individual edges/nodes/episodes lists.
-            context = getattr(result, "context", None)
+            context: str | None = getattr(result, "context", None)
             if context and context.strip():
                 return context.strip()
         elif scope == "edges" and result.edges:

--- a/integrations/python/zep_adk/src/zep_adk/graph_search_tool.py
+++ b/integrations/python/zep_adk/src/zep_adk/graph_search_tool.py
@@ -49,9 +49,11 @@ _SEARCH_PARAMS: dict[str, dict[str, Any]] = {
         "type": "STRING",
         "description": (
             "What to search for: 'edges' for facts and relationships, "
-            "'nodes' for entity summaries, 'episodes' for raw messages."
+            "'nodes' for entities and their summaries, "
+            "'episodes' for raw text data (unstructured text, messages, or JSON), "
+            "'auto' to let Zep decide the best mix of results."
         ),
-        "enum": ["edges", "nodes", "episodes"],
+        "enum": ["edges", "nodes", "episodes", "auto"],
         "default": "edges",
     },
     "reranker": {
@@ -110,6 +112,10 @@ class ZepGraphSearchTool(BaseTool):
     to the given value.  Parameters not pinned are exposed in the model's tool
     schema with sensible defaults.
 
+    Pinning an optional parameter to ``None`` hides it from the model schema
+    without passing it to the Zep SDK -- useful for suppressing irrelevant
+    parameters (e.g. ``mmr_lambda=None`` when the reranker is not ``mmr``).
+
     Args:
         zep_client: An initialised ``AsyncZep`` client.
         graph_id: Optional fixed graph ID for shared-graph search.  When set,
@@ -160,6 +166,14 @@ class ZepGraphSearchTool(BaseTool):
             raise ValueError(
                 f"Unknown pinned parameters: {unknown}. Allowed: {sorted(allowed_pinned)}"
             )
+        # Pinning to None means "hide from model but don't send to SDK".
+        # This is only valid for optional parameters.
+        for k, v in pinned.items():
+            if v is None and _SEARCH_PARAMS.get(k, {}).get("required"):
+                raise ValueError(
+                    f"Cannot pin required parameter '{k}' to None. "
+                    "Only optional parameters can be hidden with None."
+                )
 
         # Store pinned search params
         self._pinned: dict[str, Any] = dict(pinned)
@@ -229,9 +243,12 @@ class ZepGraphSearchTool(BaseTool):
             search_kwargs["user_id"] = user_id
 
         # --- Merge params: pinned > model-provided > default ----------
+        # A param pinned to None is hidden from the model and omitted from
+        # the SDK call (used to suppress optional params from the schema).
         for param_name, param_def in _SEARCH_PARAMS.items():
             if param_name in self._pinned:
-                search_kwargs[param_name] = self._pinned[param_name]
+                if self._pinned[param_name] is not None:
+                    search_kwargs[param_name] = self._pinned[param_name]
             elif param_name in args:
                 search_kwargs[param_name] = args[param_name]
             elif "default" in param_def:
@@ -279,7 +296,13 @@ class ZepGraphSearchTool(BaseTool):
         """Format search results as readable text for the model."""
         parts: list[str] = []
 
-        if scope == "edges" and result.edges:
+        if scope == "auto":
+            # Auto scope returns a pre-formatted context string in result.context
+            # rather than populating the individual edges/nodes/episodes lists.
+            context = getattr(result, "context", None)
+            if context and context.strip():
+                return context.strip()
+        elif scope == "edges" and result.edges:
             for edge in result.edges:
                 if edge.fact:
                     parts.append(f"- {edge.fact}")

--- a/integrations/python/zep_adk/tests/test_integration.py
+++ b/integrations/python/zep_adk/tests/test_integration.py
@@ -467,12 +467,15 @@ async def main() -> None:
                 ),
             ],
             after_model_callback=create_after_model_callback(
-                zep_client=zep_client, ignore_roles=["assistant"],
+                zep_client=zep_client,
+                ignore_roles=["assistant"],
             ),
         )
 
         auto_runner = Runner(
-            agent=auto_agent, app_name=APP_NAME, session_service=session_service,
+            agent=auto_agent,
+            app_name=APP_NAME,
+            session_service=session_service,
         )
 
         await session_service.create_session(

--- a/integrations/python/zep_adk/tests/test_integration.py
+++ b/integrations/python/zep_adk/tests/test_integration.py
@@ -65,7 +65,6 @@ THREAD_1_ID = f"adk-integ-t1-{_suffix}"
 THREAD_2_ID = f"adk-integ-t2-{_suffix}"
 THREAD_3_ID = f"adk-integ-t3-{_suffix}"
 THREAD_4_ID = f"adk-integ-t4-{_suffix}"
-THREAD_5_ID = f"adk-integ-t5-{_suffix}"
 APP_NAME = "zep-adk-integ-test"
 
 FIRST_NAME = "IntegTest"
@@ -180,7 +179,7 @@ async def main() -> None:
     print("Zep ADK Integration Test")
     print(f"{'=' * 70}")
     print(f"  User ID:  {USER_ID}")
-    print(f"  Threads:  {THREAD_1_ID}, {THREAD_2_ID}, {THREAD_3_ID}, {THREAD_4_ID}, {THREAD_5_ID}")
+    print(f"  Threads:  {THREAD_1_ID}, {THREAD_2_ID}, {THREAD_3_ID}, {THREAD_4_ID}")
     print(f"{'=' * 70}\n")
 
     try:
@@ -448,17 +447,18 @@ async def main() -> None:
         # ==================================================================
         print("\n[Step 11] Session 5: testing ZepGraphSearchTool with scope='auto'...")
 
-        # Build a separate agent with scope pinned to "auto"
+        # Build a separate agent with ONLY the graph search tool (no
+        # ZepContextTool) so the model has no pre-injected memory and must
+        # call the search tool to answer questions about the user.
         auto_agent = Agent(
             name="zep_integ_auto_scope_agent",
             model="gemini-2.5-flash",
             description="A test agent with auto-scope graph search.",
             instruction=(
-                "You are a helpful assistant. When asked about the user, "
-                "use the search_user_memory tool. Be concise."
+                "You have no prior knowledge about the user. You MUST use "
+                "the search_user_memory tool to answer any question about them."
             ),
             tools=[
-                ZepContextTool(zep_client=zep_client, ignore_roles=["assistant"]),
                 ZepGraphSearchTool(
                     zep_client=zep_client,
                     name="search_user_memory",
@@ -466,10 +466,6 @@ async def main() -> None:
                     scope="auto",
                 ),
             ],
-            after_model_callback=create_after_model_callback(
-                zep_client=zep_client,
-                ignore_roles=["assistant"],
-            ),
         )
 
         auto_runner = Runner(
@@ -482,12 +478,7 @@ async def main() -> None:
             app_name=APP_NAME,
             user_id=USER_ID,
             session_id=SESSION_5_ID,
-            state={
-                "zep_thread_id": THREAD_5_ID,
-                "zep_first_name": FIRST_NAME,
-                "zep_last_name": LAST_NAME,
-                "zep_email": EMAIL,
-            },
+            state={"zep_user_id": USER_ID},
         )
 
         auto_search_message = (

--- a/integrations/python/zep_adk/tests/test_integration.py
+++ b/integrations/python/zep_adk/tests/test_integration.py
@@ -60,10 +60,12 @@ SESSION_1_ID = f"adk-integ-s1-{_suffix}"
 SESSION_2_ID = f"adk-integ-s2-{_suffix}"
 SESSION_3_ID = f"adk-integ-s3-{_suffix}"
 SESSION_4_ID = f"adk-integ-s4-{_suffix}"
+SESSION_5_ID = f"adk-integ-s5-{_suffix}"
 THREAD_1_ID = f"adk-integ-t1-{_suffix}"
 THREAD_2_ID = f"adk-integ-t2-{_suffix}"
 THREAD_3_ID = f"adk-integ-t3-{_suffix}"
 THREAD_4_ID = f"adk-integ-t4-{_suffix}"
+THREAD_5_ID = f"adk-integ-t5-{_suffix}"
 APP_NAME = "zep-adk-integ-test"
 
 FIRST_NAME = "IntegTest"
@@ -178,7 +180,7 @@ async def main() -> None:
     print("Zep ADK Integration Test")
     print(f"{'=' * 70}")
     print(f"  User ID:  {USER_ID}")
-    print(f"  Threads:  {THREAD_1_ID}, {THREAD_2_ID}, {THREAD_3_ID}, {THREAD_4_ID}")
+    print(f"  Threads:  {THREAD_1_ID}, {THREAD_2_ID}, {THREAD_3_ID}, {THREAD_4_ID}, {THREAD_5_ID}")
     print(f"{'=' * 70}\n")
 
     try:
@@ -442,10 +444,73 @@ async def main() -> None:
             passed = False
 
         # ==================================================================
-        # Step 11: Tool-call message persistence — verify only final
+        # Step 11: Session 5 — ZepGraphSearchTool with scope="auto"
+        # ==================================================================
+        print("\n[Step 11] Session 5: testing ZepGraphSearchTool with scope='auto'...")
+
+        # Build a separate agent with scope pinned to "auto"
+        auto_agent = Agent(
+            name="zep_integ_auto_scope_agent",
+            model="gemini-2.5-flash",
+            description="A test agent with auto-scope graph search.",
+            instruction=(
+                "You are a helpful assistant. When asked about the user, "
+                "use the search_user_memory tool. Be concise."
+            ),
+            tools=[
+                ZepContextTool(zep_client=zep_client, ignore_roles=["assistant"]),
+                ZepGraphSearchTool(
+                    zep_client=zep_client,
+                    name="search_user_memory",
+                    description="Search the user's knowledge graph.",
+                    scope="auto",
+                ),
+            ],
+            after_model_callback=create_after_model_callback(
+                zep_client=zep_client, ignore_roles=["assistant"],
+            ),
+        )
+
+        auto_runner = Runner(
+            agent=auto_agent, app_name=APP_NAME, session_service=session_service,
+        )
+
+        await session_service.create_session(
+            app_name=APP_NAME,
+            user_id=USER_ID,
+            session_id=SESSION_5_ID,
+            state={
+                "zep_thread_id": THREAD_5_ID,
+                "zep_first_name": FIRST_NAME,
+                "zep_last_name": LAST_NAME,
+                "zep_email": EMAIL,
+            },
+        )
+
+        auto_search_message = (
+            "Use the search_user_memory tool to search for what you know "
+            "about where I live. Tell me exactly what the search returns."
+        )
+        print(f"  User:  {auto_search_message}")
+        response5 = await send_message(auto_runner, SESSION_5_ID, USER_ID, auto_search_message)
+        print(f"  Agent: {response5}\n")
+
+        response5_lower = response5.lower()
+        auto_keywords = ["portland", "oregon"]
+        found_auto_kw = [kw for kw in auto_keywords if kw in response5_lower]
+        print(f"  Auto-scope keywords found: {found_auto_kw}")
+
+        passed &= check(
+            "Auto-scope graph search returned location facts",
+            len(found_auto_kw) > 0,
+            f"found={found_auto_kw}, expected_one_of={auto_keywords}",
+        )
+
+        # ==================================================================
+        # Step 12: Tool-call message persistence — verify only final
         # assistant message is persisted (not intermediate "thoughts")
         # ==================================================================
-        print("\n[Step 11] Session 4: tool-call persistence test (get_current_weather)...")
+        print("\n[Step 12] Session 4: tool-call persistence test (get_current_weather)...")
 
         await session_service.create_session(
             app_name=APP_NAME,


### PR DESCRIPTION
## Summary
- Adds `auto` as an allowed scope value for `ZepGraphSearchTool`, letting Zep decide the best mix of edges, nodes, and episodes to return
- Updates scope parameter descriptions to be more precise (`nodes` → "entities and their summaries", `episodes` → "raw text data (unstructured text, messages, or JSON)")
- Handles `auto` scope formatting by reading `result.context` from the API response
- Adds support for pinning optional parameters to `None` to hide them from the model schema without sending to the SDK
- Adds integration test (Step 11) verifying auto-scope search returns expected results

## Test plan
- [x] Full integration test suite passes (all 18 checks) against production Zep API
- [x] New auto-scope test (Step 11) confirms `scope="auto"` returns facts and entities via `result.context`

🤖 Generated with [Claude Code](https://claude.com/claude-code)