### PR TITLE
Add building-with-zep Claude Code plugin (skill + Zep docs MCP server)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "zep",
+  "owner": {
+    "name": "Zep",
+    "url": "https://www.getzep.com"
+  },
+  "metadata": {
+    "description": "Claude Code plugins for building with Zep.",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "building-with-zep",
+      "source": "./plugins/building-with-zep",
+      "description": "Skill plus the Zep documentation MCP server for building apps on Zep.",
+      "version": "0.1.0",
+      "category": "development",
+      "keywords": ["zep", "agent-memory", "context-graph"]
+    }
+  ]
+}

--- a/plugins/building-with-zep/.claude-plugin/plugin.json
+++ b/plugins/building-with-zep/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "building-with-zep",
+  "version": "0.1.0",
+  "description": "Build and configure applications that use Zep — agent memory built on temporal Context Graphs. Bundles the building-with-zep skill (how to reason about and build on Zep) and the Zep documentation MCP server (real-time docs search).",
+  "author": {
+    "name": "Zep",
+    "url": "https://www.getzep.com"
+  },
+  "homepage": "https://help.getzep.com",
+  "keywords": ["zep", "agent-memory", "context-graph", "mcp"],
+  "mcpServers": {
+    "zep-docs": {
+      "type": "http",
+      "url": "https://docs-mcp.getzep.com/mcp"
+    }
+  }
+}

--- a/plugins/building-with-zep/README.md
+++ b/plugins/building-with-zep/README.md
@@ -1,0 +1,39 @@
+# building-with-zep (Claude Code plugin)
+
+A Claude Code plugin for building applications that use [Zep](https://www.getzep.com) — agent memory built on temporal Context Graphs.
+
+It bundles two things:
+
+- **The `building-with-zep` skill** (`skills/building-with-zep/`) — what Zep is, its core concepts, the high-level vs low-level APIs, customization, and how to start simple and benchmark. Model-invoked when you work on Zep integration code.
+- **The Zep documentation MCP server** (`zep-docs`) — real-time search over Zep's docs at `https://docs-mcp.getzep.com/mcp` (HTTP transport, no API key).
+
+## Install
+
+This repo's root (`.claude-plugin/marketplace.json`) is a plugin marketplace named `zep`.
+
+```bash
+# Add the marketplace (from this repo)
+/plugin marketplace add getzep/zep
+
+# Install the plugin
+/plugin install building-with-zep@zep
+```
+
+To develop locally without the marketplace, point Claude Code at the plugin directory:
+
+```bash
+claude --plugin-dir plugins/building-with-zep
+```
+
+## Contents
+
+```
+plugins/building-with-zep/
+├── .claude-plugin/
+│   └── plugin.json          # manifest; declares the zep-docs MCP server
+├── skills/
+│   └── building-with-zep/
+│       ├── SKILL.md
+│       └── references/      # concepts, apis, customization, getting-started, evaluation, governance
+└── README.md
+```

--- a/plugins/building-with-zep/skills/building-with-zep/SKILL.md
+++ b/plugins/building-with-zep/skills/building-with-zep/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: building-with-zep
+description: Guide for building and configuring applications that use Zep — agent memory built on temporal Context Graphs, for use cases that need low-latency retrieval, many users and agents, multi-source ingestion, and governance. Use whenever you are writing or designing code that integrates Zep: adding agent memory or long-term context to an agent or chatbot, ingesting chat/business/document data into a Context Graph, retrieving a Context Block or searching the graph, choosing between user graphs and standalone graphs, defining a custom ontology or custom instructions, or deciding how to evaluate and tune Zep for a use case. Triggers on requests like "add memory to my agent", "integrate Zep", "store this in Zep", "search the Zep graph", "set up a Zep ontology", "how should I structure my Zep graphs", "make my agent remember users". Covers what Zep is, its core concepts, the high-level vs low-level APIs, customization, and how to start simple and benchmark.
+---
+
+# Building with Zep
+
+Zep is **agent memory** — for use cases that require low-latency retrieval, large numbers of users and agents, ingestion from many sources, and governance. This skill teaches you how to reason about Zep and build apps on it correctly — what it is, how its pieces fit together, which API to reach for, when to customize, and how to validate that it works for a given use case.
+
+Read this top-to-bottom before writing Zep code. Pull in the reference files (under `references/`) when you need exact method signatures, parameters, or code.
+
+> All guidance here is for **Zep V3** (SDK packages `zep-cloud` for Python/TypeScript, `github.com/getzep/zep-go/v3` for Go). Ignore anything you may know about the legacy V2 `Memory` API.
+>
+> Zep has no meaningful free tier — it is a paid product (Subscription and Enterprise plans). Some features noted below are limited to specific plans.
+
+---
+
+## Looking up current details (read first)
+
+This plugin bundles the **`zep-docs` MCP server** — Zep's documentation search. Treat it as the source of truth for anything that must be exact or current: method names, parameters, limits, plan availability, and newer features the summaries here may not cover.
+
+1. **Query the `zep-docs` MCP server first.** Use its documentation-search tool to look up the specific guide or API before relying on memory or on the summaries in this skill, whenever precision matters. It covers both the **guides** and the **SDK/API reference**.
+2. **If the MCP server is unavailable, fall back to the Zep documentation directly:**
+   - Guides: https://help.getzep.com
+   - SDK / API reference: https://help.getzep.com/sdk-reference
+
+The reference files in this skill are a fast, curated map of the API surface and the judgment around it — not a replacement for the live docs. If this skill and the live docs ever disagree, the live docs win.
+
+---
+
+## 1. What Zep does
+
+Zep gives an agent durable, up-to-date memory of **users, the business, and work done**, and serves it back as ready-to-use context in milliseconds.
+
+The flow is always the same three moves:
+
+1. **Ingest** data from any source — chat messages, business records, documents, JSON.
+2. Zep **builds a temporal knowledge graph** (its *Context Graph*) of the entities, relationships, and facts in that data, and keeps it current as new data arrives.
+3. **Retrieve** a token-efficient *Context Block* (or run targeted graph searches) and drop it into your prompt.
+
+This gives an agent access to relevant prior context across sessions without building and maintaining a separate retrieval pipeline.
+
+The mental model to hold: **Zep is not a chat-log store and not a vector database.** It extracts structured, time-aware knowledge from whatever you feed it, fuses it into a graph per subject, and returns the slice that matters for the current moment.
+
+## 2. How Zep is different
+
+When you're deciding whether Zep fits, or explaining it, these are the differentiators that matter:
+
+- **Many sources, one graph.** Chat, documents, JSON, and business events all flow into the same Context Graph and are fused into one coherent picture of a subject. You don't keep separate stores per data type.
+- **Temporal by design.** Every fact carries validity timestamps. When new data contradicts an old fact, Zep invalidates the old one *and keeps it as history* — so you can ask what is true now, or what was true at a past date. This is the key advantage over static GraphRAG and over plain vector search, which have no notion of change over time.
+- **Built for change, not static corpora.** Zep is designed for streaming, frequently-updated data and incremental graph updates. Traditional GraphRAG is built for one-time summarization of static documents; reach for Zep when knowledge evolves.
+- **Hybrid retrieval, not similarity alone.** Retrieval combines semantic search, full-text (BM25) search, and graph traversal with reranking — capturing conceptual matches, exact keywords, and relationships in one ranked result. It optimizes for **recall** (give the agent everything relevant) over precision.
+- **Low latency at scale.** Sub-200ms (P95) retrieval regardless of graph size or number of graphs, which supports large numbers of users and latency-sensitive applications such as voice agents.
+- **Many users, many agents.** Each user gets their own graph; standalone graphs hold shared or domain knowledge. The same memory can be served to whichever agents need it.
+- **Governance.** Authorization (RBAC/ABAC), retention policies, audit logging, and provenance (every fact traces to the source episode that produced it) apply across every graph and query. Deployment can be Cloud, Cloud + BYOK, or BYOC (your VPC); SOC 2 Type II and HIPAA BAA are available.
+
+## 3. Core concepts
+
+You must get these right — most integration mistakes come from misunderstanding what a thread or a graph actually *is*. Full detail and code in **`references/concepts.md`**; the essentials and the common misconceptions:
+
+| Concept | What it is | What it is **not** |
+|---------|-----------|--------------------|
+| **User graph** | A Context Graph automatically created for one user; fuses *all* of that user's threads and business data into one picture. The home for agent memory. | Not something you create by hand, and not partitioned by thread. |
+| **Standalone graph** | A general-purpose graph (`graph_id`) for knowledge about an object or system — shared knowledge bases, product/domain data, runbooks. | Not for personalized user memory (no user node, **no user summary**). For a user, use a user graph. |
+| **Thread** | A conversation: an ordered sequence of messages for one user. Adding messages both records history *and* ingests into the user graph. | **Not** an isolated conversation store and **not** the container for facts. Facts are extracted across *all* threads into the user graph. |
+| **Entity (node)** | A noun extracted from data — person, account, product, place, concept — with a regenerated narrative **summary**. | Not where precise claims live (those are facts on edges). Deduplication is automatic; you don't manage node identity. |
+| **Edge / fact** | A fact is a precise, time-stamped claim ("Emily's account is suspended") stored *on an edge* between two entities, with `valid_at`/`invalid_at`/`created_at`/`expired_at`. | A fact is not independent of its edge, and not a vector chunk. |
+| **Entity summary vs facts** | Summaries roll an entity's history into a narrative (depth); facts are granular dated claims (breadth). The Context Block uses both. | A summary is not a fact and is not citable as a precise dated claim. |
+| **Episode** | The raw ingested artifact (a message, text chunk, or JSON object), stored verbatim alongside what Zep derives from it. | Not the extracted knowledge itself — reach for episodes when you need the exact source wording or a citation. |
+| **User summary** | One always-on narrative of who the user is, on the user node; included **unconditionally** in every Context Block. | Not query-filtered and not per-thread; the same baseline regardless of the latest message. Standalone graphs don't have one. |
+| **Thread summary** | An auto-maintained natural-language summary of *one* thread's arc (what happened in that conversation). One per thread. | Not a user-wide view (that's the user summary / facts) and not something you trigger manually. |
+| **Observation** *(Flex Plus and Enterprise plans)* | A durable, evidence-backed pattern Zep derives across many facts/entities — a decision, commitment, preference, recurring behavior. | Not "just more facts" — it's a cross-entity synthesis, and it's read-only (you can't create or edit observations). |
+
+The single most important runtime fact: **`thread.get_user_context(thread_id=...)` returns context from the entire user graph, not just that thread.** The thread is used only to figure out *what's relevant right now* (from its last two messages).
+
+## 4. Choosing an API: high-level first, low-level when you must
+
+Zep's high-level APIs cover most use cases. **Default to the high-level path** and only drop down when you have a concrete reason. Full API surface, parameters, scopes, rerankers, and filters are in **`references/apis.md`**.
+
+**High-level (start here):**
+- **`thread.get_user_context(thread_id)`** → returns the **Context Block**: an optimized, prompt-ready string assembled by *Smart Context Assembly* (auto search over the whole user graph, based on the last two messages). This is the right answer for most conversational agents. Sub-200ms.
+- **Context templates** → same automatic relevance, but your own fixed layout/sections (`%{user_summary}`, `%{edges}`, `%{entities}`, …). Use when you need consistent custom formatting across threads.
+- **`graph.search(..., scope="auto")`** → the recommended entry point for *standalone* graphs (and for non-thread queries). Retrieves across all data shapes, cross-scope reranks, packs to a character budget, returns a ready-to-use `context` string.
+
+**Low-level (when the high-level path isn't enough):**
+- **`graph.search` with a specific `scope`** (`edges`, `nodes`, `episodes`, `observations`, `thread_summaries`), plus rerankers (`rrf` default, `mmr`, `cross_encoder`, `episode_mentions`, `node_distance`), `search_filters` (entity/edge types, properties, dates, metadata), and BFS from recent episodes. Use for UI features, tool-call retrieval where the LLM decides when to search, or precise control.
+- **Advanced/manual context construction** → run several searches and assemble the string yourself. Maximum control, most code. This is the **required** pattern for retrieving from standalone graphs into a custom block.
+
+Decision shortcut:
+- Conversational agent, user memory → `thread.get_user_context`.
+- Need fixed sections but automatic relevance → context template.
+- Domain/standalone graph → `graph.search(scope="auto")`, or manual construction for a custom block.
+- LLM-driven "search when needed" → expose `graph.search` as a tool.
+- Need one result type, a filter, or a specific reranker → scoped `graph.search`.
+
+## 5. Customization: ontology and instructions
+
+Customization improves extraction quality, but it is **prompt engineering — iterate, don't front-load it.** Full APIs, limits, and code in **`references/customization.md`**.
+
+- **Custom ontology** (`graph.set_ontology`) — define your own entity types and edge types (max 10 each per scope, ≤10 fields each). Good for: focusing extraction on the entities/relationships that matter in your domain, and enabling precise type-filtered retrieval. Recommended for most production use cases. **Not** good for: modeling everything up front, or as a substitute for good data — many use cases are fully served by default entities + node summaries + facts. Custom *attributes* on types are an advanced feature; you often don't need them. Design entity types as nouns and edge types as verbs/relationships, and start with a few generic types.
+- **Custom instructions** (`graph.add_custom_instructions`, Enterprise) — describe your *domain* (terminology, concepts) so Zep interprets data better during extraction. Applied automatically on ingest. Good for: specialized vocabularies (legal, healthcare, internal jargon). **Not** for: defining entity/relationship *types* — that's what ontology is for.
+- **User summary instructions** (`user.add_user_summary_instructions`) — steer what the user summary captures (short, question-shaped prompts). Good for: shaping the always-on user baseline. Note they don't apply to Batch-API-ingested data.
+
+The unifying rule: **ontology = the *shape* of the graph (types); instructions = *how to interpret* your domain.** Both are scoped project-wide or per user/graph.
+
+## 6. Best practices: start simple, then benchmark
+
+1. **Start simple.** Get the basic loop working first — create user → create thread → `add_messages` → `get_user_context` — with default ontology and the default Context Block. Don't add custom ontology, templates, or low-level search until you've measured a concrete gap. See **`references/getting-started.md`**.
+2. **Ingestion is asynchronous.** Graph building takes time (seconds per message). Don't expect a fact to be retrievable the instant you add it; design for eventual availability and check status when it matters.
+3. **Feed data well.** Use `thread.add_messages` for conversation, `graph.add` for documents/JSON/business data (≤10,000 chars/call — chunk larger). Prepare JSON: split large/deeply-nested objects, keep each piece understandable in isolation. Always pass real user names (and ideally last name + email) so the graph resolves identity correctly.
+4. **Optimize latency only when needed.** Reuse one client instance; use `return_context=True` on `add_messages` to fold retrieval into the same call; run ingest and search concurrently; warm the user cache on login. Relevant for voice/real-time agents.
+5. **Benchmark for your use case before tuning.** Don't guess whether retrieval is good enough — measure it. Zep ships an evaluation harness: write 3–5 example interactions, generate test conversations + questions, ingest, and grade *context completeness* (Zep's job) separately from *answer accuracy* (also your LLM's job). Iterate on ontology and search strategy against that suite, and keep it as a regression test. Full workflow in **`references/evaluation.md`**.
+6. **Lead with the high-level path.** Most "Zep isn't returning the right thing" problems are solved by better data and the default Context Block, not by jumping to low-level `graph.search` tuning.
+
+---
+
+## Reference files
+
+- **`references/getting-started.md`** — install, client init, the quick-start loop, adding messages / business data / JSON, batch ingestion, ingestion status.
+- **`references/concepts.md`** — every core concept in depth, with what-it-is / what-it-isn't and retrieval code.
+- **`references/apis.md`** — the full retrieval and search API surface: Context Block, templates, `graph.search` scopes, rerankers, filters, BFS, direct getters.
+- **`references/customization.md`** — ontology, custom instructions, user summary instructions, fact triplets, pattern detection, defaults and limits.
+- **`references/evaluation.md`** — the evaluation harness, benchmarking methodology, and what to measure.
+- **`references/governance.md`** — RBAC, audit logging, deployment models, compliance.
+
+When you need an exact endpoint or a detail not covered here, look it up rather than guessing: query the **`zep-docs` MCP server** first, and fall back to the SDK/API reference at https://help.getzep.com/sdk-reference and the guides at https://help.getzep.com. This skill captures the shape and the judgment, not every parameter — the live docs are authoritative.

--- a/plugins/building-with-zep/skills/building-with-zep/references/apis.md
+++ b/plugins/building-with-zep/skills/building-with-zep/references/apis.md
@@ -1,0 +1,156 @@
+# Zep retrieval and search APIs
+
+Three retrieval methods, from most automatic to most manual. Default to the top of this list; descend only with a reason.
+
+| Method | Query control | Format control | Graph types | Best for |
+|--------|---------------|----------------|-------------|----------|
+| `thread.get_user_context()` (Context Block) | Automatic (last 2 messages) | Fixed | User graphs only | Most conversational agents |
+| Context templates | Automatic (last 2 messages) | Custom | User graphs only | Consistent custom layout |
+| `graph.search()` + manual assembly | Full | Full | User or standalone | Max control, standalone graphs |
+
+## 1. Context Block — `thread.get_user_context`
+
+Optimized, prompt-ready string built by **Smart Context Assembly** (auto search: semantic + full-text + breadth-first, over the entire user graph, relevance from the last two messages). P95 < 200ms.
+
+```python
+user_context = client.thread.get_user_context(thread_id=thread_id)
+context_block = user_context.context     # drop into prompt
+```
+
+Output shape:
+```text
+<USER_SUMMARY>
+Emily Painter is a user with account ID Emily0e62 who uses digital art tools...
+</USER_SUMMARY>
+<FACTS>
+  - Emily is experiencing issues with logging in. (2024-11-14 02:13:19+00:00 - present)
+  - User account Emily0e62 has a suspended status due to payment failure. (... - present)
+</FACTS>
+```
+
+Always includes the user summary; adds the most relevant facts, entities, episodes, observations, and thread summaries. You can also get it from `add_messages(..., return_context=True)`.
+
+## 2. Context templates
+
+Automatic relevance, your fixed layout. Define once, reuse via `template_id`.
+
+```python
+client.context.create_context_template(
+    template_id="customer-support",
+    template="""# CUSTOMER PROFILE
+%{user_summary}
+
+# FACTS
+%{edges limit=10}
+
+# KEY ENTITIES
+%{entities limit=5 types=[person,organization]}
+
+# RECENT CONVERSATIONS
+%{thread_summaries limit=3}""",
+)
+
+user_context = client.thread.get_user_context(thread_id=thread_id,
+                                               template_id="customer-support")
+```
+
+Variables: `%{user_summary}` (no params), `%{edges}`, `%{entities}`, `%{episodes}`, `%{observations}`, `%{thread_summaries}`. Params (except user_summary): `limit=N` (≤1000; observations/thread_summaries render ≤20), `types=[...]`, `include_attributes=true/false`. Manage with `context.{get,list,update,delete}_context_template`.
+
+## 3. `graph.search`
+
+The general-purpose method for standalone graphs, non-thread queries, tool-call retrieval, and precise control. Works with `user_id=` or `graph_id=`.
+
+### Auto search (recommended entry point)
+
+```python
+res = client.graph.search(
+    user_id=user_id,
+    query="What did we decide about the pricing rollout?",
+    scope="auto",
+    max_characters=2500,          # default 2500, max 50000
+    return_raw_results=False,     # True to also get typed arrays
+)
+print(res.context)                # ready-to-use block
+```
+
+`scope="auto"` retrieves across all data shapes in parallel, applies a **cross-scope rerank**, and packs to the character budget. With `scope="auto"` the `reranker` param is ignored (it uses its own). `return_raw_results=True` exposes `res.edges`, `res.nodes`, etc. with `score` and `selection_rank`.
+
+### Scoped search (one result type)
+
+```python
+res = client.graph.search(user_id=user_id, query="payment failures",
+                          scope="edges", limit=5)   # facts
+for edge in res.edges or []:
+    print(edge.name, edge.fact, edge.score)
+```
+
+Scopes: `edges` (facts, default), `nodes` (entities → `res.nodes`), `episodes` (`res.episodes`), `observations` (`res.observations`), `thread_summaries` (`res.thread_summaries`).
+
+### Rerankers (ignored when scope=auto)
+
+| Reranker | Behavior | Notes |
+|----------|----------|-------|
+| `rrf` (default) | Reciprocal Rank Fusion of semantic + BM25 | general purpose |
+| `mmr` | relevance + diversity | requires `mmr_lambda` (0.0 diversity → 1.0 relevance) |
+| `cross_encoder` | joint neural model, higher accuracy, slower | adds `relevance` field (0–1) for thresholding |
+| `episode_mentions` | favors items mentioned across many episodes | frequency bias |
+| `node_distance` | ranks by graph hops from a center node | requires `center_node_uuid` |
+
+### Filters — `search_filters`
+
+```python
+from zep_cloud.types import SearchFilters, PropertyFilter
+
+res = client.graph.search(
+    user_id=user_id, query="engineering team", scope="edges",
+    search_filters=SearchFilters(
+        property_filters=[PropertyFilter(comparison_operator="=",
+                          property_name="department", property_value="Engineering")],
+    ),
+)
+```
+
+- Type filters: `{"node_labels": [...]}`, `{"edge_types": [...]}`, plus `exclude_node_labels` / `exclude_edge_types`.
+- Property filters: operators `=`, `<>`, `>`, `<`, `>=`, `<=`, `IS NULL`, `IS NOT NULL`.
+- Datetime filters (edge scope): on `created_at`/`valid_at`/`invalid_at`/`expired_at`; inner list = AND, outer list = OR.
+- Episode metadata filters via `EpisodeMetadataFilter` / `MetadataFilterGroup`.
+
+### Breadth-first search (recency bias)
+
+Bias results toward what's connected to recent context by seeding from recent episode nodes:
+
+```python
+eps = client.graph.episode.get_by_user_id(user_id=user_id, lastn=10).episodes
+res = client.graph.search(user_id=user_id, query="project updates", scope="edges",
+                          bfs_origin_node_uuids=[e.uuid_ for e in eps], limit=10)
+```
+
+## 4. Manual context construction
+
+Required for building a custom block from a **standalone** graph; also for full control on user graphs. Run several searches and format the string yourself:
+
+```python
+edges = client.graph.search(graph_id="company-kb", query=q, scope="edges", limit=10)
+nodes = client.graph.search(graph_id="company-kb", query=q, scope="nodes", limit=5)
+block = "<FACTS>\n" + "".join(f"  - {e.fact}\n" for e in edges.edges or []) + "</FACTS>\n"
+block += "<ENTITIES>\n" + "".join(f"  - {n.name}: {n.summary}\n" for n in nodes.nodes or []) + "</ENTITIES>\n"
+```
+
+## Direct getters (no search)
+
+| Method | Returns |
+|--------|---------|
+| `graph.edge.get(uuid_)` / `graph.edge.get_by_user_id(user_id, limit, uuid_cursor)` | fact(s) |
+| `graph.node.get(uuid_)` / `graph.node.get_by_user_id(...)` | entity/entities |
+| `graph.episode.get(uuid_)` / `graph.episode.get_by_user_id(user_id, lastn)` | episode(s) |
+| `user.get_node(user_id)` | user node (+ `.summary`) |
+| `graph.observation.get(...)` / `graph.observation.get_by_user_id(...)` | observation(s) |
+| `thread.get_summary(thread_id)` / `graph.thread_summary.get_by_user_id(...)` | thread summary/summaries |
+
+Replace `_by_user_id` with `_by_graph_id` for standalone graphs.
+
+For exact parameters or endpoints not captured here, query the **`zep-docs` MCP server**, or see the SDK/API reference at https://help.getzep.com/sdk-reference and the guides at https://help.getzep.com.
+
+## Retrieval philosophy
+
+Zep optimizes for **recall over precision**: missing a critical fact can break the agent, so it returns everything relevant and lets the LLM filter, rather than risk omission. Hybrid search (semantic + BM25 + graph/BFS, reranked) is why it beats vector similarity alone — it captures concepts, exact terms, and relationships together. Benchmarks: LoCoMo 94.7% @ 155ms; LongMemEval 90.2% @ 162ms.

--- a/plugins/building-with-zep/skills/building-with-zep/references/concepts.md
+++ b/plugins/building-with-zep/skills/building-with-zep/references/concepts.md
@@ -1,0 +1,123 @@
+# Zep core concepts, in depth
+
+Each concept below includes what it **is**, what it **is not** (the misconceptions that cause integration bugs), and how to read it.
+
+## Users and user graphs
+
+A **user** represents an individual using your application (`user_id`, plus optional `email`, `first_name`, `last_name`). Each user has an associated **user graph**, created automatically the first time you add data for them.
+
+The user graph fuses **everything** about that user — every thread, plus any business data added with `graph.add(user_id=...)` — into one unified Context Graph. It carries a single **user node** with a regenerated **user summary**, and uses Zep's default ontology unless you customize it.
+
+- **It is not** partitioned by thread. > "The knowledge graph does not separate the data from different threads, but integrates the data together to create a unified picture of the user."
+- **It is not** something you create explicitly — adding a user (or adding data for one) creates it.
+- Deleting the user deletes all their threads, artifacts, and graph knowledge in one operation (Right To Be Forgotten).
+
+## Standalone graphs
+
+A standalone graph (`graph.create(graph_id=...)`) is a general-purpose Context Graph about an *object or system* rather than a person: shared knowledge bases, product catalogs, policy/runbook corpora, domain knowledge used across many users, or test graphs.
+
+- **It is not** for personalized user memory. It has **no user node and no user summary**. For up-to-date knowledge about a user, use a user graph.
+- Retrieval from a standalone graph uses `graph.search` (there is no `get_user_context` for it) — typically `scope="auto"`, or manual construction for a custom block.
+
+Use the same `graph.add` / `graph.search` methods, passing `graph_id=` instead of `user_id=`. Direct getters: `graph.node.get_by_graph_id`, `graph.edge.get_by_graph_id`, etc.
+
+## Threads
+
+A **thread** is a conversation: an ordered sequence of messages belonging to one user. A user can have many. `thread.add_messages` records history *and* ingests messages into the user graph (each message is also stored as a `message` episode).
+
+- **It is not** an isolated conversation store, and **not** the container for facts. Facts extracted from a thread land in the *user* graph and are fused with everything else.
+- **It is not** the scope of retrieval. `thread.get_user_context(thread_id)` searches the whole user graph; the thread's last two messages only decide *what's relevant now*.
+- Creating a thread warms the user's graph cache in the background, improving first-retrieval latency.
+
+## Entities (nodes) and entity summaries
+
+An **entity** is a noun extracted from ingested data — a person, account, product, place, or concept. Each has a short **name** and a narrative **summary** that is regenerated incrementally as new facts arrive (previous summary + new information).
+
+- The summary gives **depth** (contextualized history of that entity). It **is not** a precise dated claim — those are facts on edges.
+- Zep **deduplicates and merges** entities automatically when it decides two refer to the same thing. You don't manage node identity.
+
+Read them:
+```python
+entities = client.graph.node.get_by_user_id(user_id="emily-painter", limit=20)
+for e in entities:
+    print(e.name, e.summary)
+one = client.graph.node.get(uuid_=entities[0].uuid_)
+```
+
+## Edges and facts
+
+A **fact** is a precise, time-stamped claim stored **on an edge** between two entities — e.g. "User account Emily0e62 has a suspended status due to payment failure." Edges have a SCREAMING_SNAKE_CASE `name` (`WORKS_AT`, `OWNS`) and four timestamps:
+
+| Field | Meaning |
+|-------|---------|
+| `created_at` | when Zep learned the fact |
+| `valid_at` | when the fact became true (real-world time) |
+| `invalid_at` | when the fact stopped being true |
+| `expired_at` | when Zep learned it was no longer valid |
+
+Facts give **breadth** — many granular, citable, dated claims.
+
+- A fact **is not** independent of its edge, and **not** a vector chunk.
+- **Temporal updates are automatic.** When new data contradicts a fact, Zep invalidates the old fact (sets `invalid_at`) and adds new ones — keeping the old as history. You don't manage temporal consistency. Example: "Kendra loves Adidas shoes" → later → invalidate that, add "Kendra's Adidas shoes broke" and "Kendra likes Puma shoes."
+
+Read them:
+```python
+edges = client.graph.edge.get_by_user_id(user_id="emily-painter")
+for edge in edges:
+    print(edge.name, edge.fact, edge.valid_at, edge.invalid_at)
+```
+
+**Entity summaries vs facts:** the Context Block uses both deliberately. Facts = discrete dated claims; entity summaries = rolled-up narrative. Reach for facts when you need a specific, citable claim; for entity summaries when you need an entity's overall story.
+
+## Episodes
+
+An **episode** is the raw artifact you handed Zep — a chat message, a text chunk, or a JSON object — stored **verbatim** alongside the entities, edges, and summaries derived from it.
+
+- **It is not** the extracted knowledge. Reach for episodes when the agent needs the exact source wording, a citation, or surrounding context that didn't become its own fact.
+
+```python
+recent = client.graph.episode.get_by_user_id(user_id="emily-painter", lastn=20)
+for ep in recent.episodes:
+    print(ep.created_at, ep.source, ep.content)
+```
+
+## User summary
+
+A single derived narrative of **who the user is** — stable traits, preferences, what they've done — synthesized from the whole graph and attached to the user node. It is included **unconditionally** at the top of every Context Block.
+
+- **It is not** query-filtered and **not** per-conversation: the same baseline regardless of the latest message. It answers "who am I talking to," independent of what was just said.
+- Standalone graphs have no user summary.
+- You don't write it directly; Zep regenerates it as facts accumulate. Shape it with [user summary instructions](customization.md).
+
+```python
+resp = client.user.get_node(user_id="emily-painter")
+print(resp.node.summary if resp.node else None)
+```
+
+## Thread summaries
+
+A natural-language summary of the messages in **one** thread — the arc of a single conversation (e.g. what problem arose and how it resolved). One per thread, auto-generated and incrementally updated, persisted on the user's graph.
+
+- **It is not** a user-wide view (that's the user summary and facts across threads), and **not** something you trigger manually.
+
+```python
+s = client.thread.get_summary(thread_id="thread-42")            # one thread
+page = client.graph.thread_summary.get_by_user_id(user_id="u", limit=20)  # all for a user
+```
+
+## Observations (Flex Plus and Enterprise plans)
+
+A **durable, evidence-backed pattern** Zep automatically derives by analyzing graph structure — a decision, commitment, constraint, preference, state transition, recurring pattern, or stable relationship spanning one or more entities. It captures *why something matters* across many facts.
+
+- **It is not** "just more facts" (granular edge claims) nor an entity summary (single-node narrative) — it's a cross-entity synthesis.
+- **Read-only.** You can't create, edit, or delete observations; they follow the evidence and are regenerated/retired as the graph changes.
+
+```python
+obs = client.graph.observation.get_by_user_id(user_id="emily-painter", limit=20)
+for o in obs:
+    print(o.name, o.summary)
+```
+
+## How a concept maps to the Context Block
+
+`thread.get_user_context` returns a string containing the **user summary (always)** plus the most relevant **facts, entities, episodes, observations, and thread summaries** for the current moment — sized for the token budget. Everything above is what fills it.

--- a/plugins/building-with-zep/skills/building-with-zep/references/customization.md
+++ b/plugins/building-with-zep/skills/building-with-zep/references/customization.md
@@ -1,0 +1,119 @@
+# Customizing Zep: ontology, instructions, manual facts
+
+Customization improves extraction quality and enables precise retrieval — but it is prompt engineering. **Start simple and iterate**; don't model everything up front.
+
+## Custom ontology (entity & edge types)
+
+Defines the *types* your graph should contain — the entities (nouns) and relationships (verbs) that matter in your domain. Recommended for most production use cases: it focuses extraction and lets you filter retrieval by type.
+
+### Define types
+
+```python
+from zep_cloud.external_clients.ontology import EntityModel, EntityText, EdgeModel
+from pydantic import Field
+
+class Restaurant(EntityModel):
+    """Represents a specific restaurant."""
+    cuisine_type: EntityText = Field(description="The cuisine type", default=None)
+
+class RestaurantVisit(EdgeModel):
+    """The fact that the user visited a restaurant."""
+    restaurant_name: EntityText = Field(description="Name of the restaurant", default=None)
+```
+
+TS uses `entityFields.text(...)` with `EntityType`/`EdgeType`; Go uses `zep.BaseEntity`/`zep.BaseEdge` struct tags.
+
+### Apply
+
+```python
+from zep_cloud import EntityEdgeSourceTarget
+
+client.graph.set_ontology(
+    entities={"Restaurant": Restaurant},
+    edges={"RESTAURANT_VISIT": (RestaurantVisit,
+            [EntityEdgeSourceTarget(source="User", target="Restaurant")])},
+    # scope: omit user_ids/graph_ids = project-wide; provide them = per user/graph
+)
+```
+
+`set_ontology` **overwrites** the previous set — the active types are always those from the last call. Scope per user/graph with `user_ids=[...]` / `graph_ids=[...]`.
+
+### Default ontology
+
+User graphs apply Zep defaults unless disabled. Entity types: `User`, `Assistant`, `Preference`, `Location`, `Event`, `Object`, `Topic`, `Organization`, `Document`. Edge types: `LOCATED_AT`, `OCCURRED_AT`. Disable with `client.user.add(..., disable_default_ontology=True)` (or `user.update`).
+
+### Limits & rules
+
+- Max **10 entity types** and **10 edge types** per scope; ≤10 fields each.
+- A custom type must define ≥1 custom property.
+- Reserved attribute names (don't use): `uuid`, `name`, `graph_id`, `name_embedding`, `summary`, `created_at`.
+- Each node/edge gets a **single** type — no multi-classification.
+- Changing types does **not** reclassify existing nodes/edges.
+
+### Good for / not good for
+
+- **Good for:** focusing extraction on domain-critical entities/relationships; type-filtered retrieval (`types=[...]`, `node_labels`, `edge_types`); better results than defaults alone in most production apps.
+- **Not good for / cautions:** modeling everything up front. Start with a few generic types and minimal fields, then add complexity. Custom **attributes** are an advanced "precision context engineering" feature — many use cases are fully served by node summaries + facts with no attributes. Design entity types as nouns, edge types as relationships, or a type may end up on the wrong element. Resolve overlapping types (e.g. "Hobby" vs "Hiking") by stating priority in the descriptions.
+
+### Retrieve from custom types
+
+Template: `%{entities types=[Restaurant] limit=5}`, `%{edges types=[RESTAURANT_VISIT] limit=10}`. Or search: `graph.search(..., scope="nodes", search_filters={"node_labels": ["Restaurant"]})`.
+
+## Custom instructions (Enterprise)
+
+Describe the *domain itself* — terminology and concepts Zep wouldn't otherwise know — so it interprets data better during extraction. Applied **automatically** on every ingest to the target graph (no per-call parameter).
+
+```python
+from zep_cloud import CustomInstruction
+client.graph.add_custom_instructions(
+    instructions=[CustomInstruction(name="legal_domain",
+        text="This app operates in the legal domain. Terms include: estoppel, tort, indemnification...")],
+    # scope with user_ids / graph_ids; omit for project-wide
+)
+```
+
+- Resolution order: graph-specific → project-wide default → built-in logic.
+- Re-adding a name **updates** that instruction (upsert).
+- Limits: 5 instructions/request, name ≤100 chars, text 1–5,000 chars, ≤50 user/graph IDs per request.
+- **Good for:** specialized vocabulary (legal, healthcare, internal jargon). **Not for:** defining entity/edge *types* — that's ontology. Ontology = the *shape*; instructions = how to *interpret* the domain.
+
+## User summary instructions
+
+Steer what the always-on user summary captures (lives on the user node). Up to 5 per user/set/project-wide; `name` + `text` (≤100 chars).
+
+```python
+from zep_cloud.types import UserInstruction
+client.user.add_user_summary_instructions(
+    instructions=[UserInstruction(name="professional_background",
+        text="What are the user's key professional skills and achievements?")],
+    user_ids=[user_id],   # omit for project-wide defaults
+)
+# list_user_summary_instructions(user_id=...), delete_user_summary_instructions(instruction_names=[...], user_ids=[...])
+```
+
+Defaults cover personal details, relationships, work, preferences/goals, and AI-assistance preferences. Best practice: focused, question-shaped prompts answerable in a sentence or two. **Limitation:** they don't apply to Batch-API-ingested data.
+
+## Manual fact triplets
+
+Insert a fact directly when you already know it (async — returns `task_id`):
+
+```python
+result = client.graph.add_fact_triple(
+    user_id=user_id, fact="Paul met Eric", fact_name="MET",
+    source_node_name="Paul", target_node_name="Eric Clapton",
+)
+```
+
+Optionally attach `source_node_labels` / `target_node_labels`, `*_node_attributes`, `edge_attributes`, `valid_at`/`invalid_at`, `metadata`. If a label/`fact_name` matches an ontology type *with* defined properties, attributes are validated strictly (HTTP 400 on mismatch); otherwise they pass through. Limits: `fact` ≤250 chars, `fact_name` ≤50 chars SCREAMING_SNAKE_CASE, node names ≤50 chars.
+
+## Pattern detection (experimental)
+
+Analyze graph structure for recurring patterns — relationships, multi-hop paths, co-occurrences, hubs, clusters. Seed mode (explicit labels/edge types) or query mode (natural language, relationship patterns only).
+
+```python
+result = client.graph.detect_patterns(user_id="alice", seeds={"node_labels": ["Decision"]})
+for p in result.patterns:
+    print(p.type, p.description, p.occurrences)
+```
+
+Useful for graph auditing, schema discovery, and data-quality checks — not part of the normal retrieval path.

--- a/plugins/building-with-zep/skills/building-with-zep/references/evaluation.md
+++ b/plugins/building-with-zep/skills/building-with-zep/references/evaluation.md
@@ -1,0 +1,35 @@
+# Evaluating and benchmarking Zep for your use case
+
+Don't guess whether retrieval is good enough — measure it, before you tune anything. Zep ships an evaluation harness for exactly this. It lets you evaluate retrieval for your domain and conversation patterns, experiment systematically with ontology and search settings, and keep a regression suite for CI.
+
+## What to measure (and why two metrics)
+
+- **Context completeness** — did the retrieved context contain the information needed? (`COMPLETE` / `PARTIAL` / `INSUFFICIENT`.) **This is Zep's job** and the primary metric.
+- **Answer accuracy** — was the final answer correct vs. a golden answer? (`CORRECT` / `WRONG`.) Secondary, because it also depends on your LLM and prompt, not only retrieval.
+
+Separating them tells you *where* a failure is: a wrong answer with `COMPLETE` context is an LLM/prompt problem; `INSUFFICIENT` context is a retrieval/ingestion problem.
+
+## Workflow
+
+1. **Write 3–5 example interactions** — the things you want the agent to answer from memory (e.g. "What is my dog's name?" → "Max").
+2. **Generate test data with an LLM** — use the harness prompt template to expand each interaction into ~10 test cases (variations, edge cases) and ~5 short conversations (≈6 messages each) that *contain* the answers, with all needed information distributed across them.
+3. **Set up the harness:**
+   ```bash
+   git clone https://github.com/getzep/zep.git
+   cd zep/zep-eval-harness
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   uv sync
+   cp .env.example .env        # add ZEP_API_KEY and OPENAI_API_KEY
+   ```
+4. **Ingest conversations:** `uv run zep_ingest.py` (add `--custom-ontology` to test your types). Allow for async processing — roughly **5–10 seconds per message** (≈2.5–5 min for 5×6-message conversations).
+5. **Run evaluation:** `uv run zep_evaluate.py` (or `uv run zep_evaluate.py 1` for a specific run). Each run: searches the graph (cross-encoder rerank) → scores context completeness → generates an answer → grades it against the golden answer. Results land in `runs/{n}/evaluation_results_{ts}.json`.
+
+## Iterating on misses
+
+For each missed question: confirm the conversation data actually contains the info; check the golden answer is clear and specific; read the retrieved context in the results JSON; adjust data or question; re-ingest and re-run.
+
+Then expand: add more examples and variations, define a domain ontology, ingest larger background datasets so target facts are "buried" (realistic recall test), add JSON/unstructured data, and tune the search strategy (rerankers, scopes, parameters) against the suite.
+
+## Reference numbers
+
+Zep's published benchmarks set expectations for the recall/latency/token tradeoff: **LoCoMo 94.7% accuracy @ 155ms**, **LongMemEval 90.2% @ 162ms**. Use them as orientation, not as a substitute for evaluating on *your* data — your domain, conversation style, and ontology are what determine real-world quality.

--- a/plugins/building-with-zep/skills/building-with-zep/references/getting-started.md
+++ b/plugins/building-with-zep/skills/building-with-zep/references/getting-started.md
@@ -1,0 +1,164 @@
+# Getting started with Zep
+
+Install, initialize, and run the minimal loop. All examples are Zep V3.
+
+## Install
+
+```bash
+# Python
+pip install zep-cloud          # or: uv pip install zep-cloud
+
+# TypeScript
+npm install @getzep/zep-cloud  # yarn add / pnpm install also work
+
+# Go
+go get github.com/getzep/zep-go/v3
+```
+
+## Initialize the client
+
+Create **one** client and reuse it across the app — the SDK keeps an HTTP connection pool, and creating a client per request hurts latency. The API key comes from the `ZEP_API_KEY` environment variable.
+
+```python
+from zep_cloud.client import Zep
+client = Zep(api_key=API_KEY)
+```
+
+```typescript
+import { ZepClient } from "@getzep/zep-cloud";
+const client = new ZepClient({ apiKey: API_KEY });
+```
+
+```go
+import (
+    "github.com/getzep/zep-go/v3/client"
+    "github.com/getzep/zep-go/v3/option"
+)
+client := zepclient.NewClient(option.WithAPIKey(apiKey))
+```
+
+## The minimal loop
+
+The core integration is: **create a user → create a thread → add messages → get context**. Do this with defaults first; add nothing else until you've measured a gap.
+
+### 1. Create a user (once per user)
+
+Set the Zep `user_id` to your internal user ID. Always pass at least a first name — ideally last name and email — so Zep resolves the user against references in the data.
+
+```python
+user = client.user.add(
+    user_id="your_internal_user_id",
+    email="jane.smith@example.com",
+    first_name="Jane",
+    last_name="Smith",
+)
+```
+
+Backfill existing users with a one-time loop calling `user.add` for each. Creating a user implicitly creates their user graph.
+
+### 2. Create a thread (once per conversation)
+
+```python
+import uuid
+thread_id = uuid.uuid4().hex
+client.thread.create(thread_id=thread_id, user_id=user_id)
+```
+
+### 3. Add messages and retrieve context (per turn)
+
+```python
+from zep_cloud.types import Message
+from datetime import datetime, timezone
+
+# Add the incoming user message
+client.thread.add_messages(
+    thread_id,
+    messages=[Message(
+        name="Jane Smith",
+        role="user",
+        content="Who was Octavia Butler?",
+        created_at=datetime.now(timezone.utc).isoformat(),
+    )],
+)
+
+# Retrieve the Context Block before calling your LLM
+user_context = client.thread.get_user_context(thread_id=thread_id)
+context_block = user_context.context   # drop this string into your prompt
+
+# ... call your LLM with context_block in the system/context section ...
+
+# Persist the assistant's reply so it becomes memory too
+client.thread.add_messages(
+    thread_id,
+    messages=[Message(
+        name="AI Assistant",
+        role="assistant",
+        content="Octavia Butler was an American science fiction author...",
+        created_at=datetime.now(timezone.utc).isoformat(),
+    )],
+)
+```
+
+`thread.add_messages` does two things in one call: appends to thread history **and** ingests into the user graph. `get_user_context` returns context from the *entire* user graph; the thread only determines relevance.
+
+TypeScript/Go mirror these names: `client.thread.addMessages`, `client.thread.getUserContext`; `client.Thread.AddMessages`, `client.Thread.GetUserContext`.
+
+## Adding messages — details
+
+`thread.add_messages(thread_id, messages=[...], return_context=False, ignore_roles=None)`
+
+- `Message` fields: `role` (required: `user`/`assistant`/`system`/`tool`/`function`/`norole`), `content` (required, ≤4,096 chars), `name` (real speaker name — important for graph construction), `created_at` (RFC3339, recommended), `metadata` (≤10 scalar key/values).
+- Limits: **max 30 messages per call**, **4,096 chars per message**. Split or use the Batch API beyond that.
+- `return_context=True` returns the Context Block in the same response — a latency win that avoids a second round trip.
+- `ignore_roles=["assistant"]` keeps a role in thread history but excludes it from graph ingestion.
+
+## Adding business data / documents / JSON — `graph.add`
+
+For anything that isn't a live conversation, ingest directly into a user graph (`user_id=`) or standalone graph (`graph_id=`):
+
+```python
+import json
+
+# Text (documents, wikis, handbooks)
+client.graph.add(user_id="user123", type="text",
+                 data="The user is an avid fan of Eric Clapton")
+
+# JSON (structured business data, API responses)
+client.graph.add(user_id="user123", type="json",
+                 data=json.dumps({"name": "Eric Clapton", "age": 78, "genre": "Rock"}))
+
+# Message (conversational data not part of a thread — e.g. imported emails)
+client.graph.add(user_id="user123", type="message",
+                 data="Paul (user): I went to an Eric Clapton concert last night")
+```
+
+- **10,000 character limit** per `graph.add` call — chunk larger documents.
+- Optional `created_at` (when the data was originally created — important for temporal accuracy) and `metadata` (≤10 scalar keys).
+- Adds to the **same graph** are processed sequentially. For large datasets use the Batch API.
+
+### JSON best practices
+
+Bad JSON produces a sparse graph. Before ingesting JSON:
+- **Split large objects** into pieces of ~3–4 properties; duplicate identifying fields (`id`, `name`, `description`) across pieces.
+- **Flatten** nesting deeper than 3–4 levels while preserving context.
+- Make each piece **understandable in isolation** (descriptive keys, include descriptions).
+- Ensure each piece represents **one unified entity**; split objects that bundle several.
+
+## Batch ingestion (Enterprise)
+
+For historical backfills, document collections, and migrations — faster than per-item calls and isolated from live traffic.
+
+```python
+batch = client.batch.create(metadata={"description": "support backfill"})
+client.batch.add(batch.batch_id, items=[...])   # up to 500 items/call, 50,000/batch
+client.batch.process(batch.batch_id)            # async
+# poll until terminal
+while (s := client.batch.get(batch.batch_id)).status not in ("succeeded","partial","failed","invalid"):
+    time.sleep(5)
+```
+
+Item types: `graph_episode` (= `graph.add`) and `thread_message` (= one message in `add_messages`). Note: user summary instructions don't apply to Batch-ingested data.
+
+## Ingestion is asynchronous
+
+Graph construction runs in the background — on the order of seconds per message. A fact you just added is not instantly retrievable. Design for eventual availability; when you must confirm processing, inspect the returned message/episode UUIDs and poll their status (or, in the eval harness, allow time before querying).

--- a/plugins/building-with-zep/skills/building-with-zep/references/governance.md
+++ b/plugins/building-with-zep/skills/building-with-zep/references/governance.md
@@ -1,0 +1,34 @@
+# Governance, security, and deployment
+
+Zep applies authorization, retention, and audit across every Context Graph and every query. Relevant when building for regulated or enterprise environments.
+
+## Access control (RBAC) — Enterprise
+
+Roles at two scopes:
+
+- **Account-level:** Account Owner (full control, billing, assigns owners), Account Admin (manage projects, ingest/delete data, assign project roles), Billing Admin (invoices/payments only), Account Viewer (read-only metadata), Project Creator (create projects only).
+- **Project-level:** Project Admin (manage project, invite, create API keys, ingest/delete), Project Editor (read/write data; no role/key management), Project Viewer (read-only).
+
+A member can hold multiple assignments. Beyond RBAC, Zep supports attribute-based access control (ABAC) and retention policies (including legal hold).
+
+## Audit logging — Enterprise
+
+Tracks **web dashboard** actions (not API calls — see API logging for those): authentication, member/role changes, API key lifecycle, project changes, access-control changes, data operations (create/delete/view of threads/users/graphs), and settings changes. Each entry records timestamp (ms precision), actor, action, resource, IP, and user agent. Retention: 30 days in dashboard; 1 year cold storage (Enterprise); 7 years with HIPAA BAA.
+
+## Provenance
+
+Every fact traces back to the source episode that produced it — so any answer can be audited to where it came from. This is why episodes are stored verbatim alongside derived knowledge.
+
+## Deployment models
+
+The trust boundary moves with the choice:
+
+1. **Cloud** — Zep-managed. SOC 2 Type II; HIPAA BAA available for Enterprise.
+2. **Cloud + BYOK** — Zep runs the service; you control AWS KMS encryption keys (and can revoke).
+3. **BYOC** — Zep deployed in your VPC; full network and compliance boundary.
+
+**Bring Your Own LLM (BYOM):** route extraction/generation through your own OpenAI, Anthropic, Google, AWS Bedrock, or Azure account to apply your negotiated pricing and compliance commitments.
+
+## Compliance
+
+SOC 2 Type II certified; HIPAA BAA available. Real-time status at trust.getzep.com.


### PR DESCRIPTION
## Summary

Adds **`building-with-zep`**, a **Claude Code plugin** that bundles an agent skill with the Zep documentation MCP server. One install gives an agent both the guidance to build on Zep and real-time docs search.

Content is grounded in the V3 docs and follows Zep's positioning. Copy is plain and factual. Plan-gated features are labeled precisely (e.g. Observations: Flex Plus and Enterprise; custom instructions: Enterprise), and the skill notes Zep is a paid product with no meaningful free tier.

Moved from `getzep/fern-config` PR #641 — this repo is a better home because the skill's evaluation reference points at this repo's `zep-eval-harness`, co-locating the plugin with the code it cites.

## What's in the plugin

```
.claude-plugin/marketplace.json            # a "zep" marketplace exposing the plugin
plugins/building-with-zep/
├── .claude-plugin/plugin.json             # manifest; declares the zep-docs MCP server
├── skills/building-with-zep/              # the skill (SKILL.md + references/)
└── README.md                              # install instructions
```

- **Skill** — what Zep is; differentiators; a concepts table including *what each concept is NOT*; high-level (`thread.get_user_context`) vs low-level (`graph.search`) API guidance; ontology & custom-instructions trade-offs; start-simple + benchmark best practices. Detail lives in `references/{getting-started,concepts,apis,customization,evaluation,governance}.md`.
- **MCP server** — `zep-docs` (`https://docs-mcp.getzep.com/mcp`, HTTP, no API key).

## Install

```bash
/plugin marketplace add getzep/zep
/plugin install building-with-zep@zep
```

## Notes

- Targets Zep V3 SDKs (`zep-cloud`, `zep-go/v3`); API names/limits verified against the V3 docs.
- Adds tooling under `.claude-plugin/` and `plugins/` only — no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)