### PR TITLE
Add zep-pydantic-ai integration

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -36,6 +36,8 @@ jobs:
               - 'integrations/livekit/python/**'
             ag2:
               - 'integrations/ag2/python/**'
+            pydantic-ai:
+              - 'integrations/pydantic-ai/python/**'
 
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: typescript

--- a/integrations/pydantic-ai/python/CHANGELOG.md
+++ b/integrations/pydantic-ai/python/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## 0.1.0 (2026-06-16)
+
+### Added
+
+- `ZepDeps` -- dataclass carrying the Zep client and user/thread identity, used as the agent's `deps_type`.
+- `zep_history_processor` -- a Pydantic AI history processor (registered via `capabilities=[ProcessHistory(...)]`) that persists each user turn via `thread.add_messages(return_context=True)` and prepends Zep's context block to the prompt. Dedupes by latest user message to handle `ProcessHistory`'s once-per-model-request invocation, preventing duplicate episodes during tool-calling runs.
+- `persist_run` -- helper to persist the assistant reply from `result.new_messages()` to the Zep thread, skipping tool-call scaffolding.
+- `create_zep_search_tool` -- factory producing a model-callable `@agent.tool` over `graph.search`, targeting the current user's graph or a standalone graph.
+- Lazy Zep user and thread creation on first use.
+- Graceful error handling throughout: Zep failures are logged and never crash the agent run; failed persists are retried.
+- Mock-based test suite plus end-to-end wiring tests using Pydantic AI's `TestModel`.
+- Working example demonstrating fact seeding and memory recall.

--- a/integrations/pydantic-ai/python/Makefile
+++ b/integrations/pydantic-ai/python/Makefile
@@ -1,0 +1,72 @@
+# Makefile for zep-pydantic-ai development
+
+.PHONY: help install format lint lint-fix type-check test test-cov clean build all pre-commit ci
+
+# Default target
+help:
+	@echo "Available commands:"
+	@echo "  install     - Install package and dependencies in development mode"
+	@echo "  format      - Format code with ruff"
+	@echo "  lint        - Run linting checks"
+	@echo "  type-check  - Run type checking with mypy"
+	@echo "  test        - Run tests"
+	@echo "  test-cov    - Run tests with coverage report"
+	@echo "  all         - Run format, lint, type-check, and test"
+	@echo "  build       - Build the package"
+	@echo "  clean       - Clean build artifacts"
+
+# Install package in development mode
+install:
+	uv sync --extra dev
+
+# Format code
+format:
+	uv run ruff format .
+
+# Run linting checks
+lint:
+	uv run ruff check .
+
+# Fix linting issues automatically
+lint-fix:
+	uv run ruff check --fix .
+
+# Run type checking
+type-check:
+	uv run mypy src/
+
+# Run tests
+test:
+	uv run pytest tests/ -v
+
+# Run tests with coverage
+test-cov:
+	uv run pytest tests/ -v --cov=zep_pydantic_ai --cov-report=term-missing --cov-report=xml
+
+# Run all checks (the order matters: format first, then lint, then type-check, then test)
+all: format lint type-check test
+
+# Build the package
+build:
+	uv build
+
+# Clean build artifacts
+clean:
+	rm -rf dist/
+	rm -rf build/
+	rm -rf *.egg-info/
+	rm -rf .pytest_cache/
+	rm -rf .mypy_cache/
+	rm -rf .ruff_cache/
+	find . -type d -name __pycache__ -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+	rm -f coverage.xml
+	rm -f .coverage
+
+# Development workflow - run this before committing
+pre-commit: lint-fix format lint type-check test
+	@echo "All checks passed! Ready to commit."
+
+# CI workflow - strict checks without auto-fixing
+ci: lint type-check test
+	@echo "CI checks passed!"

--- a/integrations/pydantic-ai/python/README.md
+++ b/integrations/pydantic-ai/python/README.md
@@ -119,9 +119,9 @@ skipped, so Zep sees one clean assistant message per turn.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `graph_id` | `str` | `None` | Standalone graph to search; when unset, searches the current user's graph |
-| `scope` | `"edges" \| "nodes" \| "episodes" \| "auto"` | `"edges"` | What to search |
-| `reranker` | `"rrf" \| "mmr" \| "node_distance" \| "episode_mentions" \| "cross_encoder"` | `"rrf"` | Result ordering |
-| `limit` | `int` | `10` | Maximum results |
+| `scope` | `"edges" \| "nodes" \| "episodes" \| "observations" \| "thread_summaries" \| "auto"` | `"edges"` | What to search |
+| `reranker` | `"rrf" \| "mmr" \| "node_distance" \| "episode_mentions" \| "cross_encoder"` | `"rrf"` | Result ordering (ignored for `scope="auto"`) |
+| `limit` | `int` | `10` | Maximum results (clamped to Zep's ceiling of 50) |
 | `name` | `str` | `"zep_search"` | Tool name exposed to the model |
 
 ## Features

--- a/integrations/pydantic-ai/python/README.md
+++ b/integrations/pydantic-ai/python/README.md
@@ -1,0 +1,186 @@
+# Zep Pydantic AI Integration
+
+A memory integration package that gives [Pydantic AI](https://ai.pydantic.dev) agents long-term memory powered by [Zep](https://www.getzep.com). User turns are persisted to Zep and relevant context from Zep's temporal knowledge graph is injected into the model prompt on every turn -- using Pydantic AI's native `ProcessHistory` capability -- plus an on-demand graph-search tool.
+
+## Installation
+
+```bash
+pip install zep-pydantic-ai
+```
+
+See [SETUP.md](SETUP.md) for how to sign up for Zep, create an API key, configure your environment, and run the example.
+
+## Quick Start
+
+```python
+import asyncio
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from zep_cloud.client import AsyncZep
+from zep_pydantic_ai import (
+    ZepDeps,
+    zep_history_processor,
+    create_zep_search_tool,
+    persist_run,
+)
+
+zep = AsyncZep(api_key="your-zep-api-key")
+
+agent = Agent(
+    "openai:gpt-4o-mini",
+    deps_type=ZepDeps,
+    capabilities=[ProcessHistory(zep_history_processor)],
+    tools=[create_zep_search_tool()],
+    instructions="You are a helpful assistant with long-term memory.",
+)
+
+async def main() -> None:
+    deps = ZepDeps(
+        client=zep,
+        user_id="user_123",
+        thread_id="thread_abc",
+        first_name="Jane",
+        last_name="Smith",
+    )
+    result = await agent.run("What did I tell you about my project?", deps=deps)
+    print(result.output)
+    # Persist the assistant's reply (the user turn was already persisted).
+    await persist_run(deps, result.new_messages())
+
+asyncio.run(main())
+```
+
+## How It Works
+
+The integration plugs into Pydantic AI through three components.
+
+### `ZepDeps`
+
+A dataclass used as the agent's `deps_type`. It carries the Zep client and the
+user/thread identity (plus optional name, email, and display names). Construct
+one per conversation and pass it to `agent.run(..., deps=deps)`; the history
+processor and the search tool both reach it via `RunContext.deps`. The Zep user
+and thread are created lazily on first use -- you do not have to pre-create
+them.
+
+### `zep_history_processor`
+
+Registered via `capabilities=[ProcessHistory(zep_history_processor)]`. Pydantic
+AI runs a history processor immediately before **every** model request. On the
+user's turn this processor:
+
+1. resolves the Zep client and identity from `ctx.deps`;
+2. lazily creates the Zep user and thread;
+3. persists the latest user message via `thread.add_messages(return_context=True)` -- folding the write and context retrieval into a single round-trip;
+4. prepends Zep's returned context block to the message history as a system message.
+
+A subtle but important detail (see [SPIKE_FINDINGS](../../SPIKE_FINDINGS.md)):
+`ProcessHistory` fires **once per model request, not once per run**. A single
+`agent.run` that makes a tool call invokes the processor more than once with the
+same user turn. The processor therefore **dedupes by the latest user message
+text** per `(user_id, thread_id)`: it persists and retrieves on the first sight
+of a turn, caches the context, and replays the cached context on re-invocations
+without writing to Zep again. This prevents duplicate episodes.
+
+### `create_zep_search_tool`
+
+A factory that returns a model-callable `@agent.tool` over `graph.search`. The
+model decides when to search the knowledge graph for specific facts, entities,
+or prior episodes. By default it searches the current user's graph; pass
+`graph_id=...` to target a shared standalone graph (e.g. a documentation
+knowledge base). Search parameters (`scope`, `reranker`, `limit`) are pinned at
+construction time.
+
+### `persist_run`
+
+Call after `agent.run` with `result.new_messages()` to persist the assistant's
+reply to the Zep thread. Only assistant text is sent -- the user turn (already
+persisted by the processor) and any tool-call/tool-return scaffolding are
+skipped, so Zep sees one clean assistant message per turn.
+
+## Public API
+
+### `ZepDeps`
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `client` | `AsyncZep` | Yes | -- | Initialised Zep async client (caller owns its lifecycle) |
+| `user_id` | `str` | Yes | -- | Zep user ID (one user graph) |
+| `thread_id` | `str` | Yes | -- | Zep thread ID for the conversation |
+| `first_name` | `str` | No | `None` | User first name (recommended; anchors the user node) |
+| `last_name` | `str` | No | `None` | User last name |
+| `email` | `str` | No | `None` | User email (helps identity resolution) |
+| `user_name` | `str` | No | `None` | Display name for persisted user messages (defaults to first + last) |
+| `assistant_name` | `str` | No | `"Assistant"` | Display name for persisted assistant messages |
+| `ignore_roles` | `list[str]` | No | `None` | Roles to exclude from graph ingestion |
+
+### `create_zep_search_tool`
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `graph_id` | `str` | `None` | Standalone graph to search; when unset, searches the current user's graph |
+| `scope` | `"edges" \| "nodes" \| "episodes" \| "auto"` | `"edges"` | What to search |
+| `reranker` | `"rrf" \| "mmr" \| "node_distance" \| "episode_mentions" \| "cross_encoder"` | `"rrf"` | Result ordering |
+| `limit` | `int` | `10` | Maximum results |
+| `name` | `str` | `"zep_search"` | Tool name exposed to the model |
+
+## Features
+
+- **Native `ProcessHistory` capability** -- the current Pydantic AI hook, not the deprecated `history_processors=` kwarg
+- **Single round-trip** -- persist + retrieve context in one `add_messages` call
+- **Once-per-request dedupe** -- correct under tool-calling runs that re-invoke the processor
+- **Lazy resource creation** -- Zep user and thread created on first use
+- **On-demand graph search** -- model-callable tool over `graph.search`
+- **Graceful error handling** -- Zep failures are logged but never crash the agent run
+- **Fully typed** -- ships type hints; passes `mypy --strict`-style checks
+
+## Error Handling
+
+Every Zep call is wrapped: a Zep outage, auth failure, or transient error is
+logged and the agent run continues. When persistence fails the turn is not
+cached, so the next model request retries it.
+
+## Configuration
+
+```bash
+export ZEP_API_KEY="your-zep-api-key"
+export OPENAI_API_KEY="your-openai-api-key"   # or another provider supported by Pydantic AI
+```
+
+## Examples
+
+See the [examples/](examples/) directory:
+
+- **[basic_agent.py](examples/basic_agent.py)** -- fact seeding and memory recall with the history processor + search tool.
+
+## Development
+
+```bash
+make install      # uv sync --extra dev
+make format       # ruff format
+make lint         # ruff check
+make type-check   # mypy src/
+make test         # pytest
+make all          # format + lint + type-check + test
+make build        # uv build
+```
+
+## Requirements
+
+- Python 3.11+
+- `pydantic-ai>=1.107,<2`
+- `zep-cloud>=3.23.0`
+
+## Support
+
+- [Zep Documentation](https://help.getzep.com)
+- [Pydantic AI Documentation](https://ai.pydantic.dev)
+- [GitHub Issues](https://github.com/getzep/zep/issues)
+
+## License
+
+Apache 2.0 - see [LICENSE](../../../LICENSE) for details.
+
+## Contributing
+
+Contributions are welcome! Please see our [Contributing Guide](../../../CONTRIBUTING.md) for details.

--- a/integrations/pydantic-ai/python/SETUP.md
+++ b/integrations/pydantic-ai/python/SETUP.md
@@ -1,0 +1,92 @@
+# Setup Guide
+
+This guide walks you from a fresh machine to running the example agent with Zep memory.
+
+## 1. Sign up for Zep and create an API key
+
+1. Go to [https://www.getzep.com](https://www.getzep.com) and create an account.
+2. Open the [Zep dashboard](https://app.getzep.com) and select (or create) a project.
+3. In the project settings, go to **API Keys** and create a new key.
+4. Copy the key — you will set it as `ZEP_API_KEY` below.
+
+Zep is a paid product; see [getzep.com](https://www.getzep.com) for plan details.
+
+## 2. Get an OpenAI API key (for the example)
+
+The integration itself is model-agnostic — it works with any model
+[Pydantic AI supports](https://ai.pydantic.dev/models/). The bundled example and
+live tests drive the agent with OpenAI. Create a key at
+[platform.openai.com/api-keys](https://platform.openai.com/api-keys) and copy it
+for `OPENAI_API_KEY`.
+
+## 3. Install
+
+Using `pip`:
+
+```bash
+pip install zep-pydantic-ai
+```
+
+Or, to work from the repository with `uv`:
+
+```bash
+git clone https://github.com/getzep/zep.git
+cd zep/integrations/pydantic-ai/python
+make install        # uv sync --extra dev
+```
+
+Requirements: Python 3.11+, `pydantic-ai>=1.107,<2`, `zep-cloud>=3.23.0`.
+
+## 4. Configure environment variables
+
+```bash
+export ZEP_API_KEY="your-zep-api-key"
+export OPENAI_API_KEY="your-openai-api-key"
+```
+
+## 5. Run the example
+
+From the repository:
+
+```bash
+uv run python examples/basic_agent.py
+```
+
+Or, if you installed with `pip`:
+
+```bash
+python examples/basic_agent.py
+```
+
+The example:
+
+1. Seeds facts about a user across two turns in one thread.
+2. Waits for Zep to process the knowledge graph (ingestion is asynchronous).
+3. Asks recall questions — the agent answers using facts fused into the user's
+   graph, injected automatically by the history processor.
+
+## 6. Run the tests
+
+Mock-based tests (no API keys needed):
+
+```bash
+make test
+```
+
+These include end-to-end wiring tests that run a real Pydantic AI agent against
+Pydantic AI's built-in `TestModel` (no LLM API key required) with a mocked Zep
+client.
+
+## Troubleshooting
+
+- **`ZepDependencyError` on import** — Pydantic AI is not installed. Run
+  `pip install zep-pydantic-ai` (which pulls `pydantic-ai`).
+- **Recall returns nothing** — Zep ingestion is asynchronous; a just-added fact
+  is not instantly retrievable. The example waits ~15s; increase the wait if your
+  graph is large or under load.
+- **Authentication errors** — confirm `ZEP_API_KEY` is set in the same shell and
+  belongs to the intended project.
+- **`PydanticAIDeprecationWarning` about `openai:`** — this is a forward-compat
+  notice from Pydantic AI itself, not from this integration. The example runs
+  correctly; pin a fully-qualified model string (e.g. `openai-chat:gpt-4o-mini`)
+  to silence it.

--- a/integrations/pydantic-ai/python/examples/basic_agent.py
+++ b/integrations/pydantic-ai/python/examples/basic_agent.py
@@ -1,0 +1,125 @@
+"""
+Basic Pydantic AI agent with Zep long-term memory.
+
+This example wires Zep into a Pydantic AI agent using three pieces:
+
+  - ``ZepDeps``               -- carries the Zep client + user/thread identity.
+  - ``zep_history_processor`` -- persists each user turn and injects Zep's
+                                 context block, registered as a capability.
+  - ``create_zep_search_tool``-- a model-callable graph-search tool.
+
+The flow each turn:
+
+  1. The history processor persists the user's message to Zep and prepends the
+     retrieved context block to the prompt.
+  2. The model answers (optionally calling ``zep_search``).
+  3. ``persist_run`` stores the assistant's reply back to the Zep thread.
+
+Prerequisites:
+    pip install zep-pydantic-ai
+
+    export ZEP_API_KEY="your-zep-api-key"
+    export OPENAI_API_KEY="your-openai-api-key"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from uuid import uuid4
+
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from zep_cloud.client import AsyncZep
+
+from zep_pydantic_ai import (
+    ZepDeps,
+    create_zep_search_tool,
+    persist_run,
+    zep_history_processor,
+)
+
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+
+if not ZEP_API_KEY:
+    raise OSError("ZEP_API_KEY is not set.")
+if not OPENAI_API_KEY:
+    raise OSError("OPENAI_API_KEY is not set.")
+
+# Unique IDs for this demo run so repeated runs don't collide.
+_suffix = uuid4().hex[:8]
+USER_ID = f"pydantic-ai-example-user-{_suffix}"
+THREAD_ID = f"pydantic-ai-example-thread-{_suffix}"
+
+
+# One agent definition, reused across turns. Per-user identity lives in ZepDeps.
+agent = Agent(
+    "openai:gpt-4o-mini",
+    deps_type=ZepDeps,
+    capabilities=[ProcessHistory(zep_history_processor)],
+    tools=[create_zep_search_tool()],
+    instructions=(
+        "You are a helpful assistant with access to long-term memory. "
+        "When context from Zep is injected into the prompt, use it to provide "
+        "personalised, memory-aware responses. If you know something about the "
+        "user from memory, reference it naturally. Use the zep_search tool when "
+        "you need to look up specific details the user shared earlier."
+    ),
+)
+
+
+async def chat(deps: ZepDeps, message: str) -> str:
+    """Send one message through the agent and persist the assistant reply."""
+    result = await agent.run(message, deps=deps)
+    await persist_run(deps, result.new_messages())
+    return result.output
+
+
+async def main() -> None:
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+
+    deps = ZepDeps(
+        client=zep,
+        user_id=USER_ID,
+        thread_id=THREAD_ID,
+        first_name="Alice",
+        last_name="Smith",
+        email="alice@example.com",
+    )
+
+    print(f"\n{'=' * 60}")
+    print("Pydantic AI + Zep Memory Example")
+    print(f"{'=' * 60}")
+    print(f"  User ID:   {USER_ID}")
+    print(f"  Thread ID: {THREAD_ID}")
+    print(f"{'=' * 60}\n")
+
+    # Phase 1: seed some facts.
+    print("--- Phase 1: Seeding facts ---\n")
+    for msg in (
+        "My name is Alice and I'm a software engineer.",
+        "I live in Portland and love hiking on weekends.",
+    ):
+        print(f"User:  {msg}")
+        print(f"Agent: {await chat(deps, msg)}\n")
+
+    # Phase 2: let Zep's async ingestion build the graph.
+    wait_seconds = 15
+    print(f"--- Waiting {wait_seconds}s for Zep graph processing ---\n")
+    await asyncio.sleep(wait_seconds)
+
+    # Phase 3: test memory recall in the same thread.
+    print("--- Phase 3: Testing memory recall ---\n")
+    for msg in (
+        "What do I do for work?",
+        "Where do I live?",
+    ):
+        print(f"User:  {msg}")
+        print(f"Agent: {await chat(deps, msg)}\n")
+
+    print("Done!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/pydantic-ai/python/pyproject.toml
+++ b/integrations/pydantic-ai/python/pyproject.toml
@@ -1,0 +1,86 @@
+[project]
+name = "zep-pydantic-ai"
+version = "0.1.0"
+description = "Pydantic AI integration for Zep"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "pydantic-ai>=1.107,<2",
+    "zep-cloud>=3.23.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/getzep/zep"
+Documentation = "https://help.getzep.com"
+Repository = "https://github.com/getzep/zep"
+"Bug Tracker" = "https://github.com/getzep/zep/issues"
+Changelog = "https://github.com/getzep/zep/blob/main/integrations/pydantic-ai/python/CHANGELOG.md"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov",
+    "pytest-asyncio",
+    "ruff>=0.1.0",
+    "mypy>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/zep_pydantic_ai"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+asyncio_mode = "auto"
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"
+]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "UP", # pyupgrade
+]
+ignore = [
+    "E501", # line too long, handled by formatter
+    "B008", # do not perform function calls in argument defaults
+    "C901", # too complex
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["zep_pydantic_ai"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = [
+    "zep_cloud.*",
+]
+ignore_missing_imports = true

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/__init__.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/__init__.py
@@ -1,0 +1,98 @@
+"""
+Zep Pydantic AI Integration.
+
+This package wires Zep's long-term agent memory into `Pydantic AI
+<https://ai.pydantic.dev>`_ agents.  It persists conversation turns to Zep and
+injects relevant context from Zep's temporal knowledge graph into the model's
+prompt on every turn -- using Pydantic AI's native ``ProcessHistory``
+capability -- plus an on-demand graph-search tool.
+
+The integration has three public pieces:
+
+* :class:`ZepDeps` -- a dataclass carrying the Zep client + user/thread identity.
+  Use it as the agent's ``deps_type`` and pass an instance to ``agent.run``.
+* :func:`zep_history_processor` -- registered via
+  ``capabilities=[ProcessHistory(zep_history_processor)]``; persists the latest
+  user turn and prepends Zep's context block.  Pair it with :func:`persist_run`
+  to store the assistant's reply after the run.
+* :func:`create_zep_search_tool` -- a factory producing a model-callable
+  ``@agent.tool`` over ``graph.search``.
+
+Installation::
+
+    pip install zep-pydantic-ai
+
+Usage::
+
+    from pydantic_ai import Agent
+    from pydantic_ai.capabilities import ProcessHistory
+    from zep_cloud.client import AsyncZep
+    from zep_pydantic_ai import (
+        ZepDeps,
+        zep_history_processor,
+        create_zep_search_tool,
+        persist_run,
+    )
+
+    zep = AsyncZep(api_key="your-api-key")
+
+    agent = Agent(
+        "openai:gpt-4o-mini",
+        deps_type=ZepDeps,
+        capabilities=[ProcessHistory(zep_history_processor)],
+        tools=[create_zep_search_tool()],
+        instructions="You are a helpful assistant with long-term memory.",
+    )
+
+    deps = ZepDeps(
+        client=zep,
+        user_id="user_123",
+        thread_id="thread_abc",
+        first_name="Jane",
+        last_name="Smith",
+    )
+
+    result = await agent.run("What did I tell you about my project?", deps=deps)
+    await persist_run(deps, result.new_messages())
+"""
+
+from .exceptions import ZepDependencyError
+
+__version__ = "0.1.0"
+__author__ = "Zep AI"
+__description__ = "Pydantic AI integration for Zep"
+
+try:
+    import pydantic_ai.capabilities  # noqa: F401
+
+    from .deps import ZepDeps
+    from .history_processor import (
+        HistoryProcessorFn,
+        persist_run,
+        reset_turn_cache,
+        zep_history_processor,
+    )
+    from .search import (
+        Reranker,
+        Scope,
+        ZepSearchTool,
+        create_zep_search_tool,
+    )
+
+    __all__ = [
+        "ZepDeps",
+        "zep_history_processor",
+        "persist_run",
+        "reset_turn_cache",
+        "HistoryProcessorFn",
+        "create_zep_search_tool",
+        "ZepSearchTool",
+        "Scope",
+        "Reranker",
+        "ZepDependencyError",
+    ]
+
+except ImportError as e:
+    raise ZepDependencyError(
+        framework="Pydantic AI", install_command="pip install zep-pydantic-ai"
+    ) from e

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/deps.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/deps.py
@@ -1,0 +1,277 @@
+"""
+``ZepDeps`` -- the dependency object that carries the Zep client and identity
+through a Pydantic AI run.
+
+A Pydantic AI ``Agent`` is parameterised by a *dependency type* (``deps_type``).
+The dependency object is constructed once per run and is available to every
+capability, tool, and instruction function via ``RunContext.deps``.  This
+integration stores everything Zep needs -- the client, the user, and the thread
+-- on a single ``ZepDeps`` dataclass so the history processor and the search
+tool can reach it uniformly.
+
+Helpers for translating between Pydantic AI ``ModelMessage`` objects and Zep
+``Message`` objects also live here, since both the processor and the
+persistence helper need them.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    UserPromptPart,
+)
+from zep_cloud import Message
+from zep_cloud.client import AsyncZep
+
+logger = logging.getLogger(__name__)
+
+#: Zep limits a single message to 4096 characters.  Longer text is truncated
+#: before it is sent so a Zep validation error never reaches the host agent.
+MAX_MESSAGE_CHARS = 2400 * 10  # generous; Zep truncates server-side too
+
+
+@dataclass
+class ZepDeps:
+    """Dependencies passed to a Pydantic AI agent that uses Zep memory.
+
+    Construct one ``ZepDeps`` per conversation turn (or reuse it across turns
+    for the same user/thread) and pass it to ``agent.run(..., deps=deps)``.
+    The history processor and the ``zep_search`` tool both read the client and
+    identity from here via ``RunContext.deps``.
+
+    The Zep user and thread are created lazily on first use (see
+    :func:`zep_pydantic_ai.history_processor.zep_history_processor`), so you do
+    **not** have to pre-create them -- though doing so out-of-band is fine and
+    slightly faster on the first turn.
+
+    Attributes:
+        client: An initialised ``AsyncZep`` client.  The integration never
+            closes this client -- the caller owns its lifecycle.
+        user_id: The Zep user ID.  Maps to one user graph; reused across all of
+            that user's threads.
+        thread_id: The Zep thread ID for the current conversation.
+        first_name: Optional user first name.  Passed to ``user.add`` so Zep can
+            anchor the user's identity node in the graph.  Strongly recommended.
+        last_name: Optional user last name.
+        email: Optional user email.  Helps Zep resolve identity.
+        user_name: Optional display name attached to persisted *user* messages.
+            Defaults to ``"{first_name} {last_name}"`` when names are provided,
+            otherwise ``None``.
+        assistant_name: Display name attached to persisted *assistant* messages.
+            Defaults to ``"Assistant"``.
+        ignore_roles: Optional list of message roles to exclude from Zep's
+            knowledge-graph ingestion.  Messages are still stored in the thread
+            history but are not processed into the user's graph.  Passed through
+            to every ``thread.add_messages`` call.
+    """
+
+    client: AsyncZep
+    user_id: str
+    thread_id: str
+    first_name: str | None = None
+    last_name: str | None = None
+    email: str | None = None
+    user_name: str | None = None
+    assistant_name: str = "Assistant"
+    ignore_roles: list[str] | None = None
+
+    #: Internal: tracks whether the user/thread have been created this process,
+    #: keyed by ``(user_id, thread_id)``, to avoid redundant create calls.
+    _created: set[tuple[str, str]] = field(default_factory=set, repr=False)
+
+    @property
+    def display_name(self) -> str | None:
+        """The name attached to persisted user messages.
+
+        Uses ``user_name`` if set, otherwise composes first/last name, otherwise
+        ``None``.
+        """
+        if self.user_name:
+            return self.user_name
+        composed = " ".join(p for p in (self.first_name, self.last_name) if p).strip()
+        return composed or None
+
+
+def _truncate(text: str) -> str:
+    """Clip text to Zep's per-message limit, never raising."""
+    if len(text) <= MAX_MESSAGE_CHARS:
+        return text
+    return text[:MAX_MESSAGE_CHARS]
+
+
+def latest_user_text(messages: list[ModelMessage]) -> str | None:
+    """Return the text of the most recent user prompt in ``messages``.
+
+    Pydantic AI represents a user turn as a ``ModelRequest`` containing a
+    ``UserPromptPart``.  ``UserPromptPart.content`` may be a plain string or a
+    sequence of content blocks (text, images, files); only string text blocks
+    are extracted and joined.
+
+    Args:
+        messages: The message history handed to a history processor.
+
+    Returns:
+        The latest user message text, or ``None`` if there is no user prompt
+        with extractable text.
+    """
+    for message in reversed(messages):
+        if not isinstance(message, ModelRequest):
+            continue
+        texts: list[str] = []
+        for part in message.parts:
+            if isinstance(part, UserPromptPart):
+                texts.extend(_user_part_texts(part))
+        if texts:
+            return " ".join(texts).strip()
+    return None
+
+
+def _user_part_texts(part: UserPromptPart) -> list[str]:
+    """Extract plain-text fragments from a ``UserPromptPart``."""
+    content = part.content
+    if isinstance(content, str):
+        return [content] if content else []
+    texts: list[str] = []
+    for block in content:
+        # Multimodal user content interleaves str text with binary/url blocks.
+        if isinstance(block, str) and block:
+            texts.append(block)
+    return texts
+
+
+def model_messages_to_zep(
+    messages: list[ModelMessage],
+    *,
+    user_name: str | None,
+    assistant_name: str,
+) -> list[Message]:
+    """Convert Pydantic AI messages into Zep ``Message`` objects.
+
+    Only conversational text is persisted:
+
+    * ``UserPromptPart`` (string text) -> a Zep ``user`` message.
+    * ``TextPart`` on a ``ModelResponse`` -> a Zep ``assistant`` message.
+
+    Tool calls, tool returns, system prompts, and non-text content are skipped
+    -- Zep ingests the conversation, not the model's internal tool-use
+    scaffolding.  Empty messages are dropped.
+
+    Args:
+        messages: Pydantic AI messages (e.g. from ``result.new_messages()``).
+        user_name: Display name for user messages (may be ``None``).
+        assistant_name: Display name for assistant messages.
+
+    Returns:
+        A list of Zep ``Message`` objects ready for ``thread.add_messages``.
+    """
+    out: list[Message] = []
+    for message in messages:
+        if isinstance(message, ModelRequest):
+            for part in message.parts:
+                if isinstance(part, UserPromptPart):
+                    text = " ".join(_user_part_texts(part)).strip()
+                    if text:
+                        out.append(Message(role="user", content=_truncate(text), name=user_name))
+        elif isinstance(message, ModelResponse):
+            texts = [
+                part.content
+                for part in message.parts
+                if isinstance(part, TextPart) and part.content
+            ]
+            text = " ".join(texts).strip()
+            if text:
+                out.append(Message(role="assistant", content=_truncate(text), name=assistant_name))
+    return out
+
+
+def make_context_request(context: str) -> ModelRequest:
+    """Wrap a Zep context block in a ``ModelRequest`` with a ``SystemPromptPart``.
+
+    The returned request is prepended to the message history by the processor so
+    the model sees Zep's memory before the conversation.
+
+    Args:
+        context: The Zep context block (facts, summaries, entities).
+
+    Returns:
+        A ``ModelRequest`` carrying a single system-prompt part.
+    """
+    instruction = (
+        "The following context is retrieved from Zep's long-term memory "
+        "service. It contains relevant facts, relationships, and prior "
+        "knowledge about the user. Use it to inform your responses.\n\n"
+        "<ZEP_CONTEXT>\n"
+        f"{context}\n"
+        "</ZEP_CONTEXT>"
+    )
+    return ModelRequest(parts=[SystemPromptPart(content=instruction)])
+
+
+async def ensure_user_and_thread(deps: ZepDeps) -> bool:
+    """Create the Zep user and thread if they do not already exist.
+
+    Creation is idempotent: "already exists" conflicts are treated as success,
+    and the ``(user_id, thread_id)`` pair is cached on ``deps`` so subsequent
+    turns skip the round-trips.  A genuine failure (network, auth) returns
+    ``False`` and is logged -- it never raises.
+
+    Args:
+        deps: The dependency object carrying the client and identity.
+
+    Returns:
+        ``True`` if the user and thread are ready, ``False`` on genuine failure.
+    """
+    key = (deps.user_id, deps.thread_id)
+    if key in deps._created:
+        return True
+
+    if not await _ensure_user(deps):
+        return False
+    if not await _ensure_thread(deps):
+        return False
+
+    deps._created.add(key)
+    return True
+
+
+def _is_already_exists(exc: Exception) -> bool:
+    text = str(exc).lower()
+    return "already exists" in text or "conflict" in text or "409" in text
+
+
+async def _ensure_user(deps: ZepDeps) -> bool:
+    try:
+        await deps.client.user.add(
+            user_id=deps.user_id,
+            first_name=deps.first_name,
+            last_name=deps.last_name,
+            email=deps.email,
+        )
+        logger.info("Created Zep user: %s", deps.user_id)
+        return True
+    except Exception as exc:
+        if _is_already_exists(exc):
+            logger.debug("Zep user %s already exists", deps.user_id)
+            return True
+        logger.warning("Failed to create Zep user %s: %s", deps.user_id, exc)
+        return False
+
+
+async def _ensure_thread(deps: ZepDeps) -> bool:
+    try:
+        await deps.client.thread.create(thread_id=deps.thread_id, user_id=deps.user_id)
+        logger.info("Created Zep thread: %s", deps.thread_id)
+        return True
+    except Exception as exc:
+        if _is_already_exists(exc):
+            logger.debug("Zep thread %s already exists", deps.thread_id)
+            return True
+        logger.warning("Failed to create Zep thread %s: %s", deps.thread_id, exc)
+        return False

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/deps.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/deps.py
@@ -32,9 +32,10 @@ from zep_cloud.client import AsyncZep
 
 logger = logging.getLogger(__name__)
 
-#: Zep limits a single message to 4096 characters.  Longer text is truncated
-#: before it is sent so a Zep validation error never reaches the host agent.
-MAX_MESSAGE_CHARS = 2400 * 10  # generous; Zep truncates server-side too
+#: Zep rejects a single message whose content exceeds 4096 characters (HTTP
+#: 400).  We truncate a little below that ceiling so the message is always
+#: accepted; longer text is clipped before it is sent and a warning is logged.
+MAX_MESSAGE_CHARS = 4000
 
 
 @dataclass
@@ -99,10 +100,31 @@ class ZepDeps:
         return composed or None
 
 
-def _truncate(text: str) -> str:
-    """Clip text to Zep's per-message limit, never raising."""
+def truncate_message_content(text: str, *, label: str = "message") -> str:
+    """Clip text to Zep's per-message limit, never raising.
+
+    Zep returns HTTP 400 for messages longer than 4096 characters, so overlong
+    content must be clipped before it is sent.  Truncation is logged at WARNING
+    level with **lengths only** -- never the content itself -- so no message
+    text or PII reaches the logs.
+
+    Args:
+        text: The candidate message content.
+        label: A short, non-PII tag for the log line (e.g. ``"user turn"``).
+
+    Returns:
+        ``text`` unchanged if within the limit, otherwise clipped to
+        :data:`MAX_MESSAGE_CHARS`.
+    """
     if len(text) <= MAX_MESSAGE_CHARS:
         return text
+    logger.warning(
+        "Truncating Zep %s: %d chars exceeds limit of %d; clipped to %d",
+        label,
+        len(text),
+        MAX_MESSAGE_CHARS,
+        MAX_MESSAGE_CHARS,
+    )
     return text[:MAX_MESSAGE_CHARS]
 
 
@@ -178,7 +200,13 @@ def model_messages_to_zep(
                 if isinstance(part, UserPromptPart):
                     text = " ".join(_user_part_texts(part)).strip()
                     if text:
-                        out.append(Message(role="user", content=_truncate(text), name=user_name))
+                        out.append(
+                            Message(
+                                role="user",
+                                content=truncate_message_content(text, label="user turn"),
+                                name=user_name,
+                            )
+                        )
         elif isinstance(message, ModelResponse):
             texts = [
                 part.content
@@ -187,7 +215,13 @@ def model_messages_to_zep(
             ]
             text = " ".join(texts).strip()
             if text:
-                out.append(Message(role="assistant", content=_truncate(text), name=assistant_name))
+                out.append(
+                    Message(
+                        role="assistant",
+                        content=truncate_message_content(text, label="assistant turn"),
+                        name=assistant_name,
+                    )
+                )
     return out
 
 

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/exceptions.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/exceptions.py
@@ -1,0 +1,12 @@
+"""
+Exception classes for the Pydantic AI integration.
+"""
+
+
+class ZepDependencyError(ImportError):
+    """Raised when required Pydantic AI dependencies are not installed."""
+
+    def __init__(self, framework: str, install_command: str):
+        self.framework = framework
+        self.install_command = install_command
+        super().__init__(f"{framework} dependencies not found. Install with: {install_command}")

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/history_processor.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/history_processor.py
@@ -1,0 +1,223 @@
+"""
+The Zep history processor for Pydantic AI.
+
+Pydantic AI runs a *history processor* (registered via
+``capabilities=[ProcessHistory(fn)]``) immediately before **every** model
+request.  This integration uses that hook to do two things on the user's turn:
+
+1. **Persist** the latest user message to Zep via
+   ``thread.add_messages(return_context=True)`` -- folding write and retrieval
+   into a single round-trip.
+2. **Prepend** Zep's returned context block to the message history as a system
+   ``ModelRequest`` so the model sees the user's long-term memory before the
+   conversation.
+
+The critical subtlety (verified against Pydantic AI 1.107): the processor fires
+**once per model request, not once per run**.  A single ``agent.run`` that makes
+a tool call therefore invokes the processor at least twice with the *same* user
+turn.  Persisting on every invocation would create duplicate Zep episodes, so
+the processor **dedupes by the latest user message text** per ``(user_id,
+thread_id)``: it persists + retrieves on the first sight of a user turn, caches
+the retrieved context, and on re-invocations within the same turn simply
+re-prepends the cached context without touching Zep again.
+
+Assistant responses are **not** persisted here (the model has not produced them
+yet at request time).  Persist them after the run with
+:func:`zep_pydantic_ai.history_processor.persist_run` (or
+``store_assistant_messages``).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from pydantic_ai import RunContext
+from pydantic_ai.messages import ModelMessage
+
+from .deps import (
+    ZepDeps,
+    ensure_user_and_thread,
+    latest_user_text,
+    make_context_request,
+    model_messages_to_zep,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Signature of the history processor registered with ``ProcessHistory``.
+HistoryProcessorFn = Callable[
+    [RunContext[ZepDeps], list[ModelMessage]],
+    Awaitable[list[ModelMessage]],
+]
+
+# Per-(user_id, thread_id) memo of the last user turn we persisted and the
+# context we retrieved for it.  Keyed so a single long-lived process serving
+# many users/threads stays correct.  Within one agent.run the processor fires
+# multiple times with the same user text -> we persist once and replay the
+# cached context on the re-invocations.
+_TurnCache = dict[tuple[str, str], tuple[str, str | None]]
+_turn_cache: _TurnCache = {}
+
+
+async def zep_history_processor(
+    ctx: RunContext[ZepDeps],
+    messages: list[ModelMessage],
+) -> list[ModelMessage]:
+    """Persist the latest user turn to Zep and prepend the context block.
+
+    Register this with a Pydantic AI agent::
+
+        from pydantic_ai import Agent
+        from pydantic_ai.capabilities import ProcessHistory
+        from zep_pydantic_ai import ZepDeps, zep_history_processor
+
+        agent = Agent(
+            "openai:gpt-4o-mini",
+            deps_type=ZepDeps,
+            capabilities=[ProcessHistory(zep_history_processor)],
+        )
+
+    On each model request the processor:
+
+    * resolves the Zep client + identity from ``ctx.deps``;
+    * lazily creates the Zep user and thread;
+    * extracts the latest user message text;
+    * if this user turn has not yet been persisted (dedupe guard), calls
+      ``thread.add_messages(return_context=True)`` and caches the returned
+      context;
+    * prepends the context block (fresh or cached) to ``messages`` as a system
+      ``ModelRequest``.
+
+    All Zep failures are caught and logged; the original ``messages`` are
+    returned unchanged so a Zep outage never breaks the agent run.
+
+    Args:
+        ctx: The Pydantic AI run context; ``ctx.deps`` must be a ``ZepDeps``.
+        messages: The current message history for this model request.
+
+    Returns:
+        ``messages`` with Zep's context block prepended (when available).
+    """
+    deps = ctx.deps
+    if deps is None:  # pragma: no cover - defensive; deps_type guarantees this
+        logger.warning("zep_history_processor: ctx.deps is None; skipping Zep")
+        return messages
+
+    user_text = latest_user_text(messages)
+    if not user_text:
+        # No user turn to anchor on (e.g. a tool-only continuation with no
+        # extractable text). Nothing to persist; pass history through.
+        return messages
+
+    key = (deps.user_id, deps.thread_id)
+    cached = _turn_cache.get(key)
+
+    # --- Re-invocation within the same turn: replay cached context ----------
+    if cached is not None and cached[0] == user_text:
+        return _with_context(messages, cached[1])
+
+    # --- First sight of this user turn: persist + retrieve ------------------
+    context: str | None = None
+    try:
+        if await ensure_user_and_thread(deps):
+            from zep_cloud import Message  # local import keeps module import light
+
+            response = await deps.client.thread.add_messages(
+                thread_id=deps.thread_id,
+                messages=[
+                    Message(
+                        role="user",
+                        content=user_text,
+                        name=deps.display_name,
+                    )
+                ],
+                return_context=True,
+                ignore_roles=deps.ignore_roles,
+            )
+            context = response.context if response else None
+            # Only cache after a successful round-trip so a transient failure
+            # can be retried on the next model request.
+            _turn_cache[key] = (user_text, context)
+            logger.info(
+                "Persisted user turn to Zep (thread=%s); context length=%s",
+                deps.thread_id,
+                len(context) if context else 0,
+            )
+    except Exception:
+        logger.warning(
+            "Failed to persist user turn / retrieve context from Zep",
+            exc_info=True,
+        )
+        return messages
+
+    return _with_context(messages, context)
+
+
+def _with_context(messages: list[ModelMessage], context: str | None) -> list[ModelMessage]:
+    """Prepend the Zep context block to the history, if any."""
+    if not context:
+        return messages
+    return [make_context_request(context), *messages]
+
+
+async def persist_run(
+    deps: ZepDeps,
+    new_messages: list[ModelMessage],
+) -> None:
+    """Persist the assistant messages produced by a run to the Zep thread.
+
+    Call this after ``agent.run`` with ``result.new_messages()`` to store the
+    assistant's reply (the user turn is already persisted by the history
+    processor)::
+
+        result = await agent.run("Hi", deps=deps)
+        await persist_run(deps, result.new_messages())
+
+    Only **assistant** text messages from ``new_messages`` are sent -- the user
+    turn (already in Zep) and any tool-call / tool-return scaffolding are
+    skipped, so Zep sees exactly one clean assistant message per turn.  If there
+    is no assistant text, this is a no-op.
+
+    Failures are caught and logged; this never raises.
+
+    Args:
+        deps: The dependency object carrying the client and identity.
+        new_messages: Messages from ``result.new_messages()``.
+    """
+    zep_messages = [
+        m
+        for m in model_messages_to_zep(
+            new_messages,
+            user_name=deps.display_name,
+            assistant_name=deps.assistant_name,
+        )
+        if m.role == "assistant"
+    ]
+    if not zep_messages:
+        return
+
+    try:
+        if await ensure_user_and_thread(deps):
+            await deps.client.thread.add_messages(
+                thread_id=deps.thread_id,
+                messages=zep_messages,
+                ignore_roles=deps.ignore_roles,
+            )
+            logger.info(
+                "Persisted %d assistant message(s) to Zep thread %s",
+                len(zep_messages),
+                deps.thread_id,
+            )
+    except Exception:
+        logger.warning("Failed to persist assistant messages to Zep", exc_info=True)
+
+
+def reset_turn_cache() -> None:
+    """Clear the in-process turn-dedupe cache.
+
+    Primarily useful in tests; production code rarely needs this.  The cache
+    only stores the latest user text + retrieved context per ``(user_id,
+    thread_id)`` and is naturally overwritten as conversations progress.
+    """
+    _turn_cache.clear()

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/history_processor.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/history_processor.py
@@ -16,10 +16,12 @@ The critical subtlety (verified against Pydantic AI 1.107): the processor fires
 **once per model request, not once per run**.  A single ``agent.run`` that makes
 a tool call therefore invokes the processor at least twice with the *same* user
 turn.  Persisting on every invocation would create duplicate Zep episodes, so
-the processor **dedupes by the latest user message text** per ``(user_id,
-thread_id)``: it persists + retrieves on the first sight of a user turn, caches
-the retrieved context, and on re-invocations within the same turn simply
-re-prepends the cached context without touching Zep again.
+the processor **dedupes per run**: the cache is keyed by the Pydantic AI
+``RunContext.run_id``, so it persists + retrieves on the first model request of a
+run, caches the retrieved context, and on re-invocations within the *same* run
+simply re-prepends the cached context without touching Zep again.  Keying on the
+run (rather than on the user text) is deliberate: two consecutive runs that send
+the *identical* user message are genuine repeat turns and must each be persisted.
 
 Assistant responses are **not** persisted here (the model has not produced them
 yet at request time).  Persist them after the run with
@@ -29,7 +31,9 @@ yet at request time).  Persist them after the run with
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 
 from pydantic_ai import RunContext
@@ -41,6 +45,7 @@ from .deps import (
     latest_user_text,
     make_context_request,
     model_messages_to_zep,
+    truncate_message_content,
 )
 
 logger = logging.getLogger(__name__)
@@ -51,13 +56,62 @@ HistoryProcessorFn = Callable[
     Awaitable[list[ModelMessage]],
 ]
 
-# Per-(user_id, thread_id) memo of the last user turn we persisted and the
-# context we retrieved for it.  Keyed so a single long-lived process serving
-# many users/threads stays correct.  Within one agent.run the processor fires
-# multiple times with the same user text -> we persist once and replay the
-# cached context on the re-invocations.
-_TurnCache = dict[tuple[str, str], tuple[str, str | None]]
-_turn_cache: _TurnCache = {}
+#: Maximum number of runs kept in the dedupe cache.  The processor fires once
+#: per model request; the cache only needs an entry per *in-flight* run, but we
+#: keep a small backlog so concurrent runs in a busy process all dedupe
+#: correctly.  Oldest entries are evicted first (LRU).
+_CACHE_MAX_ENTRIES = 1024
+
+
+class _RunDedupeCache:
+    """A bounded, lock-guarded LRU of per-run retrieved context.
+
+    Keyed by the Pydantic AI ``RunContext.run_id`` so each ``agent.run``
+    persists its user turn exactly once, while two consecutive runs that send
+    the *same* user text each persist (genuine repeat turns).  Bounded so a
+    long-lived process serving many runs never grows the cache without limit;
+    guarded by a lock so concurrent runs do not corrupt it.
+    """
+
+    def __init__(self, max_entries: int = _CACHE_MAX_ENTRIES) -> None:
+        self._max = max_entries
+        self._data: OrderedDict[str, str | None] = OrderedDict()
+        self._lock = asyncio.Lock()
+
+    async def get(self, run_key: str) -> tuple[bool, str | None]:
+        """Return ``(hit, context)`` for ``run_key``; refreshes LRU order."""
+        async with self._lock:
+            if run_key not in self._data:
+                return False, None
+            self._data.move_to_end(run_key)
+            return True, self._data[run_key]
+
+    async def set(self, run_key: str, context: str | None) -> None:
+        """Store ``context`` for ``run_key``, evicting the oldest if full."""
+        async with self._lock:
+            self._data[run_key] = context
+            self._data.move_to_end(run_key)
+            while len(self._data) > self._max:
+                self._data.popitem(last=False)
+
+    def clear(self) -> None:
+        self._data.clear()
+
+
+_turn_cache = _RunDedupeCache()
+
+
+def _run_key(ctx: RunContext[ZepDeps], deps: ZepDeps) -> str:
+    """Build the dedupe key for this run.
+
+    Prefers ``RunContext.run_id`` (one per ``agent.run``).  Falls back to the
+    ``(user_id, thread_id)`` pair only if a run id is unavailable, so dedupe
+    still degrades gracefully on older Pydantic AI versions.
+    """
+    run_id = getattr(ctx, "run_id", None)
+    if run_id:
+        return f"run:{run_id}"
+    return f"thread:{deps.user_id}:{deps.thread_id}"
 
 
 async def zep_history_processor(
@@ -82,10 +136,11 @@ async def zep_history_processor(
 
     * resolves the Zep client + identity from ``ctx.deps``;
     * lazily creates the Zep user and thread;
-    * extracts the latest user message text;
-    * if this user turn has not yet been persisted (dedupe guard), calls
-      ``thread.add_messages(return_context=True)`` and caches the returned
-      context;
+    * extracts the latest user message text (truncated to Zep's per-message
+      limit);
+    * if this run has not yet persisted its user turn (run-scoped dedupe
+      guard), calls ``thread.add_messages(return_context=True)`` and caches the
+      returned context;
     * prepends the context block (fresh or cached) to ``messages`` as a system
       ``ModelRequest``.
 
@@ -110,14 +165,18 @@ async def zep_history_processor(
         # extractable text). Nothing to persist; pass history through.
         return messages
 
-    key = (deps.user_id, deps.thread_id)
-    cached = _turn_cache.get(key)
+    run_key = _run_key(ctx, deps)
+    hit, cached_context = await _turn_cache.get(run_key)
 
-    # --- Re-invocation within the same turn: replay cached context ----------
-    if cached is not None and cached[0] == user_text:
-        return _with_context(messages, cached[1])
+    # --- Re-invocation within the same run: replay cached context -----------
+    if hit:
+        return _with_context(messages, cached_context)
 
-    # --- First sight of this user turn: persist + retrieve ------------------
+    # --- First model request of this run: persist + retrieve ---------------
+    # Truncate on the hot path before sending; Zep rejects content >4096 chars
+    # with HTTP 400.  Warn with lengths only (never content / PII).
+    user_text = truncate_message_content(user_text, label="user turn")
+
     context: str | None = None
     try:
         if await ensure_user_and_thread(deps):
@@ -137,8 +196,8 @@ async def zep_history_processor(
             )
             context = response.context if response else None
             # Only cache after a successful round-trip so a transient failure
-            # can be retried on the next model request.
-            _turn_cache[key] = (user_text, context)
+            # can be retried on the next model request of this run.
+            await _turn_cache.set(run_key, context)
             logger.info(
                 "Persisted user turn to Zep (thread=%s); context length=%s",
                 deps.thread_id,
@@ -214,10 +273,10 @@ async def persist_run(
 
 
 def reset_turn_cache() -> None:
-    """Clear the in-process turn-dedupe cache.
+    """Clear the in-process run-dedupe cache.
 
-    Primarily useful in tests; production code rarely needs this.  The cache
-    only stores the latest user text + retrieved context per ``(user_id,
-    thread_id)`` and is naturally overwritten as conversations progress.
+    Primarily useful in tests; production code rarely needs this.  The cache is
+    a bounded LRU keyed by run id and evicts old entries automatically as runs
+    complete, so it never grows without limit.
     """
     _turn_cache.clear()

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/search.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/search.py
@@ -1,0 +1,138 @@
+"""
+A Pydantic AI tool for searching a Zep knowledge graph on demand.
+
+The history processor injects the user's context automatically on every turn.
+This module provides the complementary *pull* path: a model-callable tool that
+lets the agent decide when to search the graph for specific facts, entities, or
+prior episodes.
+
+:func:`create_zep_search_tool` returns an async function with the
+``(ctx: RunContext[ZepDeps], query: str, ...)`` shape expected by Pydantic AI's
+``@agent.tool`` decorator (and by the ``tools=[...]`` constructor argument).
+Search parameters such as ``scope`` and ``reranker`` can be *pinned* at
+construction time, locking them to a fixed value and hiding them from the
+model's tool schema.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
+
+from pydantic_ai import RunContext
+from zep_cloud.types.graph_search_results import GraphSearchResults
+
+from .deps import ZepDeps
+
+logger = logging.getLogger(__name__)
+
+Scope = Literal["edges", "nodes", "episodes", "auto"]
+Reranker = Literal["rrf", "mmr", "node_distance", "episode_mentions", "cross_encoder"]
+
+#: The signature of the tool function ``create_zep_search_tool`` returns.
+ZepSearchTool = Callable[[RunContext[ZepDeps], str], Awaitable[str]]
+
+
+def create_zep_search_tool(
+    *,
+    graph_id: str | None = None,
+    scope: Scope = "edges",
+    reranker: Reranker = "rrf",
+    limit: int = 10,
+    name: str = "zep_search",
+) -> ZepSearchTool:
+    """Build a Pydantic AI tool that searches a Zep knowledge graph.
+
+    Register the returned function as a tool, either via the decorator-free
+    constructor argument or by re-decorating it::
+
+        from pydantic_ai import Agent
+        from zep_pydantic_ai import ZepDeps, create_zep_search_tool
+
+        agent = Agent(
+            "openai:gpt-4o-mini",
+            deps_type=ZepDeps,
+            tools=[create_zep_search_tool()],
+        )
+
+    By default the tool searches the **current user's** graph -- the user ID is
+    resolved at call time from ``ctx.deps.user_id``.  Pass ``graph_id`` to
+    target a shared standalone graph (e.g. a documentation knowledge base)
+    instead; the user ID is then ignored.
+
+    Args:
+        graph_id: Optional standalone graph ID.  When set, all searches target
+            this graph; when ``None`` (default), the current user's graph is
+            searched.
+        scope: What to search -- ``"edges"`` (facts, default), ``"nodes"``
+            (entities + summaries), ``"episodes"`` (raw source text), or
+            ``"auto"`` (Zep assembles a ready-to-use context string).
+        reranker: Result ordering algorithm.  Defaults to ``"rrf"``.
+        limit: Maximum number of results to return.  Defaults to ``10``.
+        name: The tool name exposed to the model.  Defaults to ``"zep_search"``.
+
+    Returns:
+        An async function suitable for ``@agent.tool`` / ``tools=[...]``.  It
+        accepts a ``RunContext[ZepDeps]`` and a ``query`` string and returns a
+        formatted, model-readable results string.  Zep failures are caught and
+        returned as an error string -- the tool never raises into the agent.
+    """
+
+    async def zep_search(ctx: RunContext[ZepDeps], query: str) -> str:
+        """Search the knowledge graph for facts, entities, or prior context.
+
+        Use this to look up specific details the user has shared before, or
+        domain knowledge stored in the graph. Provide a focused natural-language
+        query (max 400 characters).
+        """
+        deps = ctx.deps
+        if deps is None:  # pragma: no cover - deps_type guarantees this
+            return "Error: Zep dependencies are not available."
+
+        search_kwargs: dict[str, Any] = {
+            "query": query[:400],
+            "scope": scope,
+            "reranker": reranker,
+            "limit": limit,
+        }
+        if graph_id:
+            search_kwargs["graph_id"] = graph_id
+        else:
+            search_kwargs["user_id"] = deps.user_id
+
+        try:
+            results = await deps.client.graph.search(**search_kwargs)
+        except Exception as exc:
+            logger.warning("Zep graph search failed: %s", exc, exc_info=True)
+            return f"Graph search failed: {exc}"
+
+        return _format_results(results, scope)
+
+    zep_search.__name__ = name
+    return zep_search
+
+
+def _format_results(results: GraphSearchResults, scope: Scope) -> str:
+    """Render Zep search results as readable text for the model."""
+    if scope == "auto":
+        context = getattr(results, "context", None)
+        if context and str(context).strip():
+            return str(context).strip()
+        return "No results found."
+
+    parts: list[str] = []
+    if scope == "edges" and results.edges:
+        parts = [f"- {edge.fact}" for edge in results.edges if edge.fact]
+    elif scope == "nodes" and results.nodes:
+        for node in results.nodes:
+            node_name = getattr(node, "name", None) or "Entity"
+            summary = getattr(node, "summary", None)
+            if summary:
+                parts.append(f"- {node_name}: {summary}")
+            else:
+                parts.append(f"- {node_name}")
+    elif scope == "episodes" and results.episodes:
+        parts = [f"- {ep.content}" for ep in results.episodes if ep.content]
+
+    return "\n".join(parts) if parts else "No results found."

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/search.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/search.py
@@ -177,5 +177,23 @@ def _format_results(results: GraphSearchResults, scope: Scope) -> str:
                 parts.append(f"- {node_name}")
     elif scope == "episodes" and results.episodes:
         parts = [f"- {ep.content}" for ep in results.episodes if ep.content]
+    elif scope == "observations" and results.observations:
+        # Observations are DerivedNode items: ``name`` carries the derived
+        # pattern, with an optional region ``summary``.
+        for obs in results.observations:
+            obs_name = getattr(obs, "name", None) or "Observation"
+            summary = getattr(obs, "summary", None)
+            if summary:
+                parts.append(f"- {obs_name}: {summary}")
+            else:
+                parts.append(f"- {obs_name}")
+    elif scope == "thread_summaries" and results.thread_summaries:
+        # Thread summaries are GraphitiSagaNode items: ``summary`` holds the
+        # incremental thread summary; fall back to ``name`` when absent.
+        for ts in results.thread_summaries:
+            summary = getattr(ts, "summary", None)
+            text = summary or getattr(ts, "name", None)
+            if text:
+                parts.append(f"- {text}")
 
     return "\n".join(parts) if parts else "No results found."

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/search.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/search.py
@@ -27,8 +27,22 @@ from .deps import ZepDeps
 
 logger = logging.getLogger(__name__)
 
-Scope = Literal["edges", "nodes", "episodes", "auto"]
+Scope = Literal[
+    "edges",
+    "nodes",
+    "episodes",
+    "observations",
+    "thread_summaries",
+    "auto",
+]
 Reranker = Literal["rrf", "mmr", "node_distance", "episode_mentions", "cross_encoder"]
+
+#: Zep caps ``graph.search`` ``limit`` at 50; larger values are rejected.
+MAX_SEARCH_LIMIT = 50
+
+#: Rerankers Zep rejects when ``scope == "auto"`` (auto always uses RRF
+#: retrieval and applies its own internal cross-scope rerank).
+_AUTO_INCOMPATIBLE_RERANKERS = ("node_distance", "episode_mentions")
 
 #: The signature of the tool function ``create_zep_search_tool`` returns.
 ZepSearchTool = Callable[[RunContext[ZepDeps], str], Awaitable[str]]
@@ -66,10 +80,14 @@ def create_zep_search_tool(
             this graph; when ``None`` (default), the current user's graph is
             searched.
         scope: What to search -- ``"edges"`` (facts, default), ``"nodes"``
-            (entities + summaries), ``"episodes"`` (raw source text), or
-            ``"auto"`` (Zep assembles a ready-to-use context string).
-        reranker: Result ordering algorithm.  Defaults to ``"rrf"``.
-        limit: Maximum number of results to return.  Defaults to ``10``.
+            (entities + summaries), ``"episodes"`` (raw source text),
+            ``"observations"``, ``"thread_summaries"``, or ``"auto"`` (Zep
+            assembles a ready-to-use context string).
+        reranker: Result ordering algorithm.  Defaults to ``"rrf"``.  Ignored
+            when ``scope == "auto"``; ``"node_distance"`` / ``"episode_mentions"``
+            are dropped there (Zep rejects them for auto search).
+        limit: Maximum number of results to return.  Defaults to ``10`` and is
+            clamped to Zep's ceiling of ``50``.
         name: The tool name exposed to the model.  Defaults to ``"zep_search"``.
 
     Returns:
@@ -78,6 +96,30 @@ def create_zep_search_tool(
         formatted, model-readable results string.  Zep failures are caught and
         returned as an error string -- the tool never raises into the agent.
     """
+    # Clamp limit to Zep's ceiling at construction time so the call never 400s.
+    if limit > MAX_SEARCH_LIMIT:
+        logger.warning(
+            "zep_search limit %d exceeds Zep ceiling %d; clamping to %d",
+            limit,
+            MAX_SEARCH_LIMIT,
+            MAX_SEARCH_LIMIT,
+        )
+        limit = MAX_SEARCH_LIMIT
+    elif limit < 1:
+        limit = 1
+
+    # Auto scope rejects node_distance / episode_mentions and ignores reranker
+    # entirely.  Resolve the effective reranker once, here, so the call path is
+    # always valid.
+    effective_reranker: Reranker | None = reranker
+    if scope == "auto":
+        if reranker in _AUTO_INCOMPATIBLE_RERANKERS:
+            logger.warning(
+                "zep_search reranker %r is invalid for scope='auto'; "
+                "omitting reranker (auto search uses RRF).",
+                reranker,
+            )
+        effective_reranker = None
 
     async def zep_search(ctx: RunContext[ZepDeps], query: str) -> str:
         """Search the knowledge graph for facts, entities, or prior context.
@@ -93,9 +135,10 @@ def create_zep_search_tool(
         search_kwargs: dict[str, Any] = {
             "query": query[:400],
             "scope": scope,
-            "reranker": reranker,
             "limit": limit,
         }
+        if effective_reranker is not None:
+            search_kwargs["reranker"] = effective_reranker
         if graph_id:
             search_kwargs["graph_id"] = graph_id
         else:

--- a/integrations/pydantic-ai/python/tests/test_agent_wiring.py
+++ b/integrations/pydantic-ai/python/tests/test_agent_wiring.py
@@ -1,0 +1,131 @@
+"""
+End-to-end wiring tests: a real Pydantic AI ``Agent`` driven by ``TestModel``
+(no LLM API key needed) with a mocked Zep client.
+
+These prove the integration plugs into Pydantic AI as documented:
+
+* ``capabilities=[ProcessHistory(zep_history_processor)]`` fires and injects
+  context, persisting the user turn exactly once even across the multiple model
+  requests a tool-calling run makes;
+* the ``create_zep_search_tool`` tool registers and is callable with ``ZepDeps``;
+* ``persist_run`` stores the assistant reply from ``result.new_messages()``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai.messages import SystemPromptPart
+from pydantic_ai.models.test import TestModel
+
+from zep_pydantic_ai import (
+    ZepDeps,
+    create_zep_search_tool,
+    persist_run,
+    reset_turn_cache,
+    zep_history_processor,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    reset_turn_cache()
+
+
+def _make_mock_client(context: str | None = "User likes blue.") -> MagicMock:
+    client = MagicMock()
+    client.user = MagicMock()
+    client.user.add = AsyncMock()
+    client.thread = MagicMock()
+    client.thread.create = AsyncMock()
+    response = MagicMock()
+    response.context = context
+    client.thread.add_messages = AsyncMock(return_value=response)
+    search_result = MagicMock()
+    edge = MagicMock()
+    edge.fact = "User's favourite colour is blue"
+    search_result.edges = [edge]
+    client.graph.search = AsyncMock(return_value=search_result)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_processor_injects_context_into_run() -> None:
+    """The history processor runs during agent.run and the model sees the
+    injected Zep context (captured via the model's last request)."""
+    client = _make_mock_client(context="User likes blue.")
+    deps = ZepDeps(client=client, user_id="u", thread_id="t", first_name="Jane")
+
+    agent = Agent(
+        TestModel(custom_output_text="ack"),
+        deps_type=ZepDeps,
+        capabilities=[ProcessHistory(zep_history_processor)],
+    )
+
+    result = await agent.run("What's my favourite colour?", deps=deps)
+
+    # The user turn was persisted with return_context once.
+    client.thread.add_messages.assert_called_once()
+    assert client.thread.add_messages.call_args.kwargs["return_context"] is True
+
+    # The model history that ran includes the injected Zep system context.
+    all_messages = result.all_messages()
+    system_texts = [
+        part.content
+        for msg in all_messages
+        for part in msg.parts
+        if isinstance(part, SystemPromptPart)
+    ]
+    assert any("User likes blue." in t for t in system_texts)
+
+
+@pytest.mark.asyncio
+async def test_tool_run_persists_user_turn_once() -> None:
+    """A tool-calling run invokes the processor multiple times; the user turn
+    must be persisted to Zep exactly once."""
+    client = _make_mock_client(context=None)
+    deps = ZepDeps(client=client, user_id="u", thread_id="t")
+
+    agent = Agent(
+        TestModel(),  # TestModel calls available tools, then returns
+        deps_type=ZepDeps,
+        capabilities=[ProcessHistory(zep_history_processor)],
+        tools=[create_zep_search_tool()],
+    )
+
+    result = await agent.run("look it up", deps=deps)
+
+    # The run made >1 model request (tool call + final), but only one persist.
+    assert client.thread.add_messages.call_count == 1
+    # The search tool actually ran against the mocked Zep client.
+    client.graph.search.assert_called()
+    assert client.graph.search.call_args.kwargs["user_id"] == "u"
+
+    # persist_run stores the assistant reply afterwards.
+    await persist_run(deps, result.new_messages())
+    # Now two add_messages calls total: the user turn + the assistant reply.
+    assert client.thread.add_messages.call_count == 2
+    last_kwargs = client.thread.add_messages.call_args.kwargs
+    assert all(m.role == "assistant" for m in last_kwargs["messages"])
+
+
+@pytest.mark.asyncio
+async def test_zep_outage_does_not_break_run() -> None:
+    """If every Zep call fails, the agent run still completes."""
+    client = MagicMock()
+    client.user = MagicMock()
+    client.user.add = AsyncMock(side_effect=RuntimeError("down"))
+    client.thread = MagicMock()
+    client.thread.create = AsyncMock(side_effect=RuntimeError("down"))
+    client.thread.add_messages = AsyncMock(side_effect=RuntimeError("down"))
+    deps = ZepDeps(client=client, user_id="u", thread_id="t")
+
+    agent = Agent(
+        TestModel(custom_output_text="still works"),
+        deps_type=ZepDeps,
+        capabilities=[ProcessHistory(zep_history_processor)],
+    )
+
+    result = await agent.run("hello", deps=deps)
+    assert result.output == "still works"

--- a/integrations/pydantic-ai/python/tests/test_basic.py
+++ b/integrations/pydantic-ai/python/tests/test_basic.py
@@ -1,0 +1,89 @@
+"""
+Basic structure / import tests for the zep-pydantic-ai package.
+"""
+
+from unittest.mock import MagicMock
+
+
+def test_package_import() -> None:
+    """The package imports successfully."""
+    import zep_pydantic_ai
+
+    assert zep_pydantic_ai is not None
+
+
+def test_public_exports() -> None:
+    """The expected public API is exported."""
+    from zep_pydantic_ai import (
+        ZepDeps,
+        create_zep_search_tool,
+        persist_run,
+        zep_history_processor,
+    )
+
+    assert ZepDeps is not None
+    assert zep_history_processor is not None
+    assert persist_run is not None
+    assert create_zep_search_tool is not None
+
+
+class TestPackageMetadata:
+    def test_version_exists(self) -> None:
+        import zep_pydantic_ai
+
+        assert hasattr(zep_pydantic_ai, "__version__")
+        assert zep_pydantic_ai.__version__ == "0.1.0"
+
+    def test_author_and_description(self) -> None:
+        import zep_pydantic_ai
+
+        assert hasattr(zep_pydantic_ai, "__author__")
+        assert hasattr(zep_pydantic_ai, "__description__")
+
+
+class TestZepDeps:
+    def test_construct_minimal(self) -> None:
+        from zep_pydantic_ai import ZepDeps
+
+        deps = ZepDeps(client=MagicMock(), user_id="u", thread_id="t")
+        assert deps.user_id == "u"
+        assert deps.thread_id == "t"
+        assert deps.assistant_name == "Assistant"
+        assert deps.ignore_roles is None
+
+    def test_display_name_from_first_last(self) -> None:
+        from zep_pydantic_ai import ZepDeps
+
+        deps = ZepDeps(
+            client=MagicMock(),
+            user_id="u",
+            thread_id="t",
+            first_name="Jane",
+            last_name="Smith",
+        )
+        assert deps.display_name == "Jane Smith"
+
+    def test_display_name_explicit_user_name_wins(self) -> None:
+        from zep_pydantic_ai import ZepDeps
+
+        deps = ZepDeps(
+            client=MagicMock(),
+            user_id="u",
+            thread_id="t",
+            first_name="Jane",
+            last_name="Smith",
+            user_name="JaneS",
+        )
+        assert deps.display_name == "JaneS"
+
+    def test_display_name_none_when_no_names(self) -> None:
+        from zep_pydantic_ai import ZepDeps
+
+        deps = ZepDeps(client=MagicMock(), user_id="u", thread_id="t")
+        assert deps.display_name is None
+
+    def test_display_name_first_only(self) -> None:
+        from zep_pydantic_ai import ZepDeps
+
+        deps = ZepDeps(client=MagicMock(), user_id="u", thread_id="t", first_name="Jane")
+        assert deps.display_name == "Jane"

--- a/integrations/pydantic-ai/python/tests/test_deps.py
+++ b/integrations/pydantic-ai/python/tests/test_deps.py
@@ -1,0 +1,195 @@
+"""
+Tests for the message-conversion helpers and lazy resource creation in
+``zep_pydantic_ai.deps``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from zep_pydantic_ai import ZepDeps
+from zep_pydantic_ai.deps import (
+    MAX_MESSAGE_CHARS,
+    ensure_user_and_thread,
+    latest_user_text,
+    make_context_request,
+    model_messages_to_zep,
+)
+
+
+def _make_deps(client: MagicMock | None = None) -> ZepDeps:
+    return ZepDeps(client=client or _make_mock_client(), user_id="u", thread_id="t")
+
+
+def _make_mock_client() -> MagicMock:
+    client = MagicMock()
+    client.user = MagicMock()
+    client.user.add = AsyncMock()
+    client.thread = MagicMock()
+    client.thread.create = AsyncMock()
+    client.thread.add_messages = AsyncMock()
+    return client
+
+
+class TestLatestUserText:
+    def test_extracts_string_content(self) -> None:
+        messages = [ModelRequest(parts=[UserPromptPart(content="Hello there")])]
+        assert latest_user_text(messages) == "Hello there"
+
+    def test_returns_most_recent_user_turn(self) -> None:
+        messages = [
+            ModelRequest(parts=[UserPromptPart(content="first")]),
+            ModelResponse(parts=[TextPart(content="reply")]),
+            ModelRequest(parts=[UserPromptPart(content="second")]),
+        ]
+        assert latest_user_text(messages) == "second"
+
+    def test_joins_list_content_text_blocks(self) -> None:
+        messages = [ModelRequest(parts=[UserPromptPart(content=["Describe", "this"])])]
+        assert latest_user_text(messages) == "Describe this"
+
+    def test_skips_system_prompt(self) -> None:
+        messages = [ModelRequest(parts=[SystemPromptPart(content="system")])]
+        assert latest_user_text(messages) is None
+
+    def test_returns_none_when_no_user_message(self) -> None:
+        messages = [ModelResponse(parts=[TextPart(content="hi")])]
+        assert latest_user_text(messages) is None
+
+    def test_empty_messages(self) -> None:
+        assert latest_user_text([]) is None
+
+
+class TestModelMessagesToZep:
+    def test_converts_user_and_assistant(self) -> None:
+        messages = [
+            ModelRequest(parts=[UserPromptPart(content="Hi")]),
+            ModelResponse(parts=[TextPart(content="Hello!")]),
+        ]
+        zep = model_messages_to_zep(messages, user_name="Jane", assistant_name="Bot")
+        assert len(zep) == 2
+        assert zep[0].role == "user"
+        assert zep[0].content == "Hi"
+        assert zep[0].name == "Jane"
+        assert zep[1].role == "assistant"
+        assert zep[1].content == "Hello!"
+        assert zep[1].name == "Bot"
+
+    def test_skips_tool_call_and_tool_return(self) -> None:
+        messages = [
+            ModelResponse(parts=[ToolCallPart(tool_name="t", args={"q": "x"})]),
+            ModelRequest(parts=[ToolReturnPart(tool_name="t", content="result")]),
+            ModelResponse(parts=[TextPart(content="Final answer")]),
+        ]
+        zep = model_messages_to_zep(messages, user_name=None, assistant_name="Bot")
+        assert len(zep) == 1
+        assert zep[0].role == "assistant"
+        assert zep[0].content == "Final answer"
+
+    def test_skips_empty_text(self) -> None:
+        messages = [ModelResponse(parts=[TextPart(content="")])]
+        zep = model_messages_to_zep(messages, user_name=None, assistant_name="Bot")
+        assert zep == []
+
+    def test_joins_multiple_assistant_text_parts(self) -> None:
+        messages = [
+            ModelResponse(parts=[TextPart(content="Part one."), TextPart(content="Part two.")]),
+        ]
+        zep = model_messages_to_zep(messages, user_name=None, assistant_name="Bot")
+        assert zep[0].content == "Part one. Part two."
+
+    def test_truncates_overlong_content(self) -> None:
+        long_text = "x" * (MAX_MESSAGE_CHARS + 500)
+        messages = [ModelRequest(parts=[UserPromptPart(content=long_text)])]
+        zep = model_messages_to_zep(messages, user_name=None, assistant_name="Bot")
+        assert len(zep[0].content) == MAX_MESSAGE_CHARS
+
+
+class TestMakeContextRequest:
+    def test_wraps_context_in_system_part(self) -> None:
+        req = make_context_request("User likes blue.")
+        assert isinstance(req, ModelRequest)
+        assert len(req.parts) == 1
+        part = req.parts[0]
+        assert isinstance(part, SystemPromptPart)
+        assert "<ZEP_CONTEXT>" in part.content
+        assert "User likes blue." in part.content
+
+
+class TestEnsureUserAndThread:
+    @pytest.mark.asyncio
+    async def test_creates_user_and_thread(self) -> None:
+        client = _make_mock_client()
+        deps = _make_deps(client)
+
+        ok = await ensure_user_and_thread(deps)
+
+        assert ok is True
+        client.user.add.assert_called_once_with(
+            user_id="u", first_name=None, last_name=None, email=None
+        )
+        client.thread.create.assert_called_once_with(thread_id="t", user_id="u")
+
+    @pytest.mark.asyncio
+    async def test_caches_after_first_creation(self) -> None:
+        client = _make_mock_client()
+        deps = _make_deps(client)
+
+        await ensure_user_and_thread(deps)
+        await ensure_user_and_thread(deps)
+
+        assert client.user.add.call_count == 1
+        assert client.thread.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_already_exists_is_success(self) -> None:
+        client = _make_mock_client()
+        client.user.add.side_effect = Exception("user already exists")
+        client.thread.create.side_effect = Exception("409 conflict")
+        deps = _make_deps(client)
+
+        ok = await ensure_user_and_thread(deps)
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_genuine_user_failure_returns_false_and_not_cached(self) -> None:
+        client = _make_mock_client()
+        client.user.add.side_effect = RuntimeError("network timeout")
+        deps = _make_deps(client)
+
+        ok = await ensure_user_and_thread(deps)
+        assert ok is False
+        # thread.create should not have been attempted
+        client.thread.create.assert_not_called()
+
+        # retry succeeds after the transient error clears
+        client.user.add.side_effect = None
+        ok2 = await ensure_user_and_thread(deps)
+        assert ok2 is True
+
+    @pytest.mark.asyncio
+    async def test_passes_identity_fields(self) -> None:
+        client = _make_mock_client()
+        deps = ZepDeps(
+            client=client,
+            user_id="u",
+            thread_id="t",
+            first_name="Jane",
+            last_name="Smith",
+            email="jane@example.com",
+        )
+
+        await ensure_user_and_thread(deps)
+
+        client.user.add.assert_called_once_with(
+            user_id="u", first_name="Jane", last_name="Smith", email="jane@example.com"
+        )

--- a/integrations/pydantic-ai/python/tests/test_history_processor.py
+++ b/integrations/pydantic-ai/python/tests/test_history_processor.py
@@ -1,0 +1,282 @@
+"""
+Tests for ``zep_history_processor`` and ``persist_run`` with a mocked Zep
+client and a stub ``RunContext``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from zep_pydantic_ai import ZepDeps, persist_run, reset_turn_cache, zep_history_processor
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    """Each test starts with a clean turn-dedupe cache."""
+    reset_turn_cache()
+
+
+def _make_mock_client(context: str | None = None) -> MagicMock:
+    client = MagicMock()
+    client.user = MagicMock()
+    client.user.add = AsyncMock()
+    client.thread = MagicMock()
+    client.thread.create = AsyncMock()
+    response = MagicMock()
+    response.context = context
+    client.thread.add_messages = AsyncMock(return_value=response)
+    return client
+
+
+def _make_deps(client: MagicMock, **kwargs: object) -> ZepDeps:
+    base = {"user_id": "user-1", "thread_id": "thread-1"}
+    base.update(kwargs)
+    return ZepDeps(client=client, **base)  # type: ignore[arg-type]
+
+
+def _make_ctx(deps: ZepDeps) -> MagicMock:
+    ctx = MagicMock()
+    ctx.deps = deps
+    return ctx
+
+
+def _user_history(text: str = "Hello") -> list:
+    return [ModelRequest(parts=[UserPromptPart(content=text)])]
+
+
+class TestPersistAndContext:
+    @pytest.mark.asyncio
+    async def test_persists_user_message_with_return_context(self) -> None:
+        client = _make_mock_client(context="Some context")
+        deps = _make_deps(client, first_name="Jane", last_name="Smith")
+        ctx = _make_ctx(deps)
+
+        await zep_history_processor(ctx, _user_history("Hi there"))
+
+        client.thread.add_messages.assert_called_once()
+        kwargs = client.thread.add_messages.call_args.kwargs
+        assert kwargs["thread_id"] == "thread-1"
+        assert kwargs["return_context"] is True
+        assert len(kwargs["messages"]) == 1
+        assert kwargs["messages"][0].role == "user"
+        assert kwargs["messages"][0].content == "Hi there"
+        assert kwargs["messages"][0].name == "Jane Smith"
+
+    @pytest.mark.asyncio
+    async def test_creates_user_and_thread_lazily(self) -> None:
+        client = _make_mock_client(context=None)
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        await zep_history_processor(ctx, _user_history())
+
+        client.user.add.assert_called_once()
+        client.thread.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_prepends_context_block(self) -> None:
+        client = _make_mock_client(context="User likes blue.")
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        messages = _user_history("What's my favourite colour?")
+        result = await zep_history_processor(ctx, messages)
+
+        # First message should be the injected context request.
+        assert len(result) == len(messages) + 1
+        first = result[0]
+        assert isinstance(first, ModelRequest)
+        assert isinstance(first.parts[0], SystemPromptPart)
+        assert "User likes blue." in first.parts[0].content
+        # Original messages preserved after it.
+        assert result[1:] == messages
+
+    @pytest.mark.asyncio
+    async def test_no_context_returns_history_unchanged(self) -> None:
+        client = _make_mock_client(context=None)
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        messages = _user_history()
+        result = await zep_history_processor(ctx, messages)
+
+        assert result == messages
+
+    @pytest.mark.asyncio
+    async def test_ignore_roles_passed_through(self) -> None:
+        client = _make_mock_client(context=None)
+        deps = _make_deps(client, ignore_roles=["assistant"])
+        ctx = _make_ctx(deps)
+
+        await zep_history_processor(ctx, _user_history())
+
+        kwargs = client.thread.add_messages.call_args.kwargs
+        assert kwargs["ignore_roles"] == ["assistant"]
+
+
+class TestDedupeGuard:
+    @pytest.mark.asyncio
+    async def test_same_turn_reinvocation_persists_once(self) -> None:
+        """The processor fires once per model request; the same user turn must
+        only be persisted to Zep once, with context replayed from cache."""
+        client = _make_mock_client(context="cached context")
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        messages = _user_history("Same question")
+        r1 = await zep_history_processor(ctx, messages)
+        r2 = await zep_history_processor(ctx, messages)
+
+        # Persisted only once across the two model requests.
+        assert client.thread.add_messages.call_count == 1
+        # But both invocations still inject the (cached) context block.
+        assert isinstance(r1[0].parts[0], SystemPromptPart)
+        assert isinstance(r2[0].parts[0], SystemPromptPart)
+        assert "cached context" in r2[0].parts[0].content
+
+    @pytest.mark.asyncio
+    async def test_new_user_turn_persists_again(self) -> None:
+        client = _make_mock_client(context="ctx")
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        await zep_history_processor(ctx, _user_history("first"))
+        await zep_history_processor(ctx, _user_history("second"))
+
+        assert client.thread.add_messages.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_distinct_threads_tracked_separately(self) -> None:
+        client = _make_mock_client(context="ctx")
+        deps_a = _make_deps(client, user_id="user-A", thread_id="thread-A")
+        deps_b = _make_deps(client, user_id="user-B", thread_id="thread-B")
+
+        await zep_history_processor(_make_ctx(deps_a), _user_history("hi"))
+        await zep_history_processor(_make_ctx(deps_b), _user_history("hi"))
+
+        # Same text but different threads -> two persists.
+        assert client.thread.add_messages.call_count == 2
+
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_zep_failure_returns_history_unchanged(self) -> None:
+        client = _make_mock_client()
+        client.thread.add_messages.side_effect = RuntimeError("Zep down")
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        messages = _user_history()
+        result = await zep_history_processor(ctx, messages)
+
+        # No crash; original history returned with no context injected.
+        assert result == messages
+
+    @pytest.mark.asyncio
+    async def test_failed_persist_not_cached_so_retries(self) -> None:
+        client = _make_mock_client()
+        ok_response = MagicMock()
+        ok_response.context = "ctx"
+        client.thread.add_messages.side_effect = [RuntimeError("transient"), ok_response]
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        messages = _user_history("retry me")
+        await zep_history_processor(ctx, messages)  # fails
+        await zep_history_processor(ctx, messages)  # retries, succeeds
+
+        assert client.thread.add_messages.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_user_text_skips_persist(self) -> None:
+        client = _make_mock_client()
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        # History with only an assistant turn -> nothing to persist.
+        messages = [ModelResponse(parts=[TextPart(content="hello")])]
+        result = await zep_history_processor(ctx, messages)
+
+        client.thread.add_messages.assert_not_called()
+        assert result == messages
+
+    @pytest.mark.asyncio
+    async def test_resource_creation_failure_skips_persist(self) -> None:
+        client = _make_mock_client()
+        client.user.add.side_effect = RuntimeError("auth error")
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        messages = _user_history()
+        result = await zep_history_processor(ctx, messages)
+
+        client.thread.add_messages.assert_not_called()
+        # No context injected; the same history object is returned unchanged.
+        assert result == messages
+
+
+class TestPersistRun:
+    @pytest.mark.asyncio
+    async def test_persists_assistant_message(self) -> None:
+        client = _make_mock_client()
+        deps = _make_deps(client, assistant_name="Bot")
+
+        new_messages = [
+            ModelRequest(parts=[UserPromptPart(content="Hi")]),
+            ModelResponse(parts=[TextPart(content="Hello, friend!")]),
+        ]
+        await persist_run(deps, new_messages)
+
+        client.thread.add_messages.assert_called_once()
+        kwargs = client.thread.add_messages.call_args.kwargs
+        # Only the assistant message is persisted (user turn already in Zep).
+        assert len(kwargs["messages"]) == 1
+        assert kwargs["messages"][0].role == "assistant"
+        assert kwargs["messages"][0].content == "Hello, friend!"
+        assert kwargs["messages"][0].name == "Bot"
+        assert "return_context" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_skips_tool_scaffolding(self) -> None:
+        client = _make_mock_client()
+        deps = _make_deps(client)
+
+        new_messages = [
+            ModelResponse(parts=[ToolCallPart(tool_name="search", args={"q": "x"})]),
+            ModelRequest(parts=[ToolReturnPart(tool_name="search", content="result")]),
+            ModelResponse(parts=[TextPart(content="The answer is 42.")]),
+        ]
+        await persist_run(deps, new_messages)
+
+        kwargs = client.thread.add_messages.call_args.kwargs
+        assert len(kwargs["messages"]) == 1
+        assert kwargs["messages"][0].content == "The answer is 42."
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_assistant_text(self) -> None:
+        client = _make_mock_client()
+        deps = _make_deps(client)
+
+        new_messages = [ModelRequest(parts=[UserPromptPart(content="Hi")])]
+        await persist_run(deps, new_messages)
+
+        client.thread.add_messages.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failure_does_not_raise(self) -> None:
+        client = _make_mock_client()
+        client.thread.add_messages.side_effect = RuntimeError("Zep down")
+        deps = _make_deps(client)
+
+        new_messages = [ModelResponse(parts=[TextPart(content="answer")])]
+        # Should not raise.
+        await persist_run(deps, new_messages)

--- a/integrations/pydantic-ai/python/tests/test_history_processor.py
+++ b/integrations/pydantic-ai/python/tests/test_history_processor.py
@@ -43,9 +43,23 @@ def _make_deps(client: MagicMock, **kwargs: object) -> ZepDeps:
     return ZepDeps(client=client, **base)  # type: ignore[arg-type]
 
 
-def _make_ctx(deps: ZepDeps) -> MagicMock:
+_RUN_COUNTER = 0
+
+
+def _make_ctx(deps: ZepDeps, run_id: str | None = None) -> MagicMock:
+    """Build a stub RunContext.
+
+    Each call gets a *distinct* ``run_id`` by default, mirroring how Pydantic AI
+    assigns a fresh id per ``agent.run``.  Pass an explicit ``run_id`` to model
+    multiple model requests *within the same run* (the dedupe case).
+    """
+    global _RUN_COUNTER
+    if run_id is None:
+        _RUN_COUNTER += 1
+        run_id = f"run-{_RUN_COUNTER}"
     ctx = MagicMock()
     ctx.deps = deps
+    ctx.run_id = run_id
     return ctx
 
 
@@ -122,21 +136,63 @@ class TestPersistAndContext:
         kwargs = client.thread.add_messages.call_args.kwargs
         assert kwargs["ignore_roles"] == ["assistant"]
 
+    @pytest.mark.asyncio
+    async def test_overlong_user_turn_truncated_before_add(self) -> None:
+        """Regression: a user message longer than Zep's 4096-char limit is
+        truncated on the hot path before add_messages, so Zep never 400s."""
+        from zep_pydantic_ai.deps import MAX_MESSAGE_CHARS
+
+        client = _make_mock_client(context=None)
+        deps = _make_deps(client)
+        ctx = _make_ctx(deps)
+
+        long_text = "x" * (MAX_MESSAGE_CHARS + 500)
+        await zep_history_processor(ctx, _user_history(long_text))
+
+        kwargs = client.thread.add_messages.call_args.kwargs
+        sent = kwargs["messages"][0].content
+        assert len(sent) == MAX_MESSAGE_CHARS
+
+    @pytest.mark.asyncio
+    async def test_max_message_chars_matches_zep_limit(self) -> None:
+        """The clip ceiling must stay at or below Zep's 4096-char hard limit."""
+        from zep_pydantic_ai.deps import MAX_MESSAGE_CHARS
+
+        assert MAX_MESSAGE_CHARS <= 4096
+
+    @pytest.mark.asyncio
+    async def test_dedupe_falls_back_to_thread_without_run_id(self) -> None:
+        """If RunContext has no run_id, dedupe degrades to (user_id, thread_id)
+        so within-turn re-invocations still persist only once."""
+        client = _make_mock_client(context="ctx")
+        deps = _make_deps(client)
+        ctx = MagicMock()
+        ctx.deps = deps
+        ctx.run_id = None  # older Pydantic AI / no run id available
+
+        messages = _user_history("hello")
+        await zep_history_processor(ctx, messages)
+        await zep_history_processor(ctx, messages)
+
+        assert client.thread.add_messages.call_count == 1
+
 
 class TestDedupeGuard:
     @pytest.mark.asyncio
-    async def test_same_turn_reinvocation_persists_once(self) -> None:
-        """The processor fires once per model request; the same user turn must
-        only be persisted to Zep once, with context replayed from cache."""
+    async def test_same_run_reinvocation_persists_once(self) -> None:
+        """The processor fires once per model request; within ONE run the user
+        turn must only be persisted to Zep once, with context replayed from
+        cache on the re-invocation."""
         client = _make_mock_client(context="cached context")
         deps = _make_deps(client)
-        ctx = _make_ctx(deps)
+        # Same run_id -> two model requests of the same agent.run.
+        ctx = _make_ctx(deps, run_id="run-fixed")
 
         messages = _user_history("Same question")
         r1 = await zep_history_processor(ctx, messages)
         r2 = await zep_history_processor(ctx, messages)
 
-        # Persisted only once across the two model requests.
+        # Persisted only once across the two model requests of the run.
         assert client.thread.add_messages.call_count == 1
         # But both invocations still inject the (cached) context block.
         assert isinstance(r1[0].parts[0], SystemPromptPart)
@@ -147,12 +203,31 @@ class TestDedupeGuard:
     async def test_new_user_turn_persists_again(self) -> None:
         client = _make_mock_client(context="ctx")
         deps = _make_deps(client)
-        ctx = _make_ctx(deps)
 
-        await zep_history_processor(ctx, _user_history("first"))
-        await zep_history_processor(ctx, _user_history("second"))
+        # Distinct runs (distinct run_id) -> each persists.
+        await zep_history_processor(_make_ctx(deps), _user_history("first"))
+        await zep_history_processor(_make_ctx(deps), _user_history("second"))
 
         assert client.thread.add_messages.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_two_consecutive_identical_runs_persist_twice(self) -> None:
+        """Regression: dedupe is scoped to the RUN, not the user text.  Two
+        consecutive runs that send the *identical* user message are genuine
+        repeat turns and must each be persisted (the old text-keyed cache
+        silently dropped the second)."""
+        client = _make_mock_client(context="ctx")
+        deps = _make_deps(client)
+
+        same_text = "ping"
+        # Two separate agent.run invocations -> two distinct run ids.
+        await zep_history_processor(_make_ctx(deps), _user_history(same_text))
+        await zep_history_processor(_make_ctx(deps), _user_history(same_text))
+
+        assert client.thread.add_messages.call_count == 2
+        # Both persisted the same content.
+        for call in client.thread.add_messages.call_args_list:
+            assert call.kwargs["messages"][0].content == same_text
 
     @pytest.mark.asyncio
     async def test_distinct_threads_tracked_separately(self) -> None:
@@ -163,8 +238,24 @@ class TestDedupeGuard:
         await zep_history_processor(_make_ctx(deps_a), _user_history("hi"))
         await zep_history_processor(_make_ctx(deps_b), _user_history("hi"))
 
-        # Same text but different threads -> two persists.
+        # Different runs -> two persists.
         assert client.thread.add_messages.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_is_bounded(self) -> None:
+        """The run cache is a bounded LRU and never grows without limit."""
+        from zep_pydantic_ai.history_processor import _CACHE_MAX_ENTRIES, _turn_cache
+
+        # Insert more entries than the cache can hold.
+        for i in range(_CACHE_MAX_ENTRIES + 50):
+            await _turn_cache.set(f"k-{i}", None)
+
+        assert len(_turn_cache._data) == _CACHE_MAX_ENTRIES
+        # Oldest evicted, newest retained.
+        hit_old, _ = await _turn_cache.get("k-0")
+        hit_new, _ = await _turn_cache.get(f"k-{_CACHE_MAX_ENTRIES + 49}")
+        assert hit_old is False
+        assert hit_new is True
 
 
 class TestErrorHandling:

--- a/integrations/pydantic-ai/python/tests/test_search.py
+++ b/integrations/pydantic-ai/python/tests/test_search.py
@@ -1,0 +1,180 @@
+"""
+Tests for the ``create_zep_search_tool`` factory with a mocked Zep client.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from zep_pydantic_ai import ZepDeps, create_zep_search_tool
+
+
+def _make_deps(client: MagicMock) -> ZepDeps:
+    return ZepDeps(client=client, user_id="user-1", thread_id="thread-1")
+
+
+def _make_ctx(deps: ZepDeps) -> MagicMock:
+    ctx = MagicMock()
+    ctx.deps = deps
+    return ctx
+
+
+def _make_result(edges=None, nodes=None, episodes=None, context=None) -> MagicMock:
+    result = MagicMock()
+    result.edges = edges
+    result.nodes = nodes
+    result.episodes = episodes
+    result.context = context
+    return result
+
+
+def _edge(fact: str) -> MagicMock:
+    e = MagicMock()
+    e.fact = fact
+    return e
+
+
+def _node(name: str, summary: str | None) -> MagicMock:
+    n = MagicMock()
+    n.name = name
+    n.summary = summary
+    return n
+
+
+def _episode(content: str) -> MagicMock:
+    ep = MagicMock()
+    ep.content = content
+    return ep
+
+
+class TestSearchTargeting:
+    @pytest.mark.asyncio
+    async def test_searches_user_graph_by_default(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[_edge("fact")]))
+        tool = create_zep_search_tool()
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "what do you know")
+
+        kwargs = client.graph.search.call_args.kwargs
+        assert kwargs["user_id"] == "user-1"
+        assert "graph_id" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_searches_graph_id_when_set(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[]))
+        tool = create_zep_search_tool(graph_id="docs-graph")
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        kwargs = client.graph.search.call_args.kwargs
+        assert kwargs["graph_id"] == "docs-graph"
+        assert "user_id" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_default_params(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[]))
+        tool = create_zep_search_tool()
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        kwargs = client.graph.search.call_args.kwargs
+        assert kwargs["scope"] == "edges"
+        assert kwargs["reranker"] == "rrf"
+        assert kwargs["limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_pinned_params_used(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(nodes=[]))
+        tool = create_zep_search_tool(scope="nodes", reranker="cross_encoder", limit=3)
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        kwargs = client.graph.search.call_args.kwargs
+        assert kwargs["scope"] == "nodes"
+        assert kwargs["reranker"] == "cross_encoder"
+        assert kwargs["limit"] == 3
+
+    @pytest.mark.asyncio
+    async def test_query_truncated_to_400(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[]))
+        tool = create_zep_search_tool()
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "x" * 1000)
+
+        kwargs = client.graph.search.call_args.kwargs
+        assert len(kwargs["query"]) == 400
+
+    def test_custom_tool_name(self) -> None:
+        tool = create_zep_search_tool(name="search_memory")
+        assert tool.__name__ == "search_memory"
+
+
+class TestResultFormatting:
+    @pytest.mark.asyncio
+    async def test_formats_edges(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(
+            return_value=_make_result(edges=[_edge("Alice works at Acme"), _edge("Bob hikes")])
+        )
+        tool = create_zep_search_tool(scope="edges")
+        out = await tool(_make_ctx(_make_deps(client)), "q")
+        assert "Alice works at Acme" in out
+        assert "Bob hikes" in out
+
+    @pytest.mark.asyncio
+    async def test_formats_nodes(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(
+            return_value=_make_result(nodes=[_node("Alice", "An engineer")])
+        )
+        tool = create_zep_search_tool(scope="nodes")
+        out = await tool(_make_ctx(_make_deps(client)), "q")
+        assert "Alice: An engineer" in out
+
+    @pytest.mark.asyncio
+    async def test_formats_episodes(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(
+            return_value=_make_result(episodes=[_episode("I work at Acme")])
+        )
+        tool = create_zep_search_tool(scope="episodes")
+        out = await tool(_make_ctx(_make_deps(client)), "q")
+        assert "I work at Acme" in out
+
+    @pytest.mark.asyncio
+    async def test_auto_scope_returns_context(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(
+            return_value=_make_result(context="Assembled context block")
+        )
+        tool = create_zep_search_tool(scope="auto")
+        out = await tool(_make_ctx(_make_deps(client)), "q")
+        assert out == "Assembled context block"
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[]))
+        tool = create_zep_search_tool()
+        out = await tool(_make_ctx(_make_deps(client)), "q")
+        assert out == "No results found."
+
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_search_failure_returns_error_string(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(side_effect=RuntimeError("boom"))
+        tool = create_zep_search_tool()
+        out = await tool(_make_ctx(_make_deps(client)), "q")
+        assert "failed" in out.lower()

--- a/integrations/pydantic-ai/python/tests/test_search.py
+++ b/integrations/pydantic-ai/python/tests/test_search.py
@@ -119,6 +119,96 @@ class TestSearchTargeting:
         assert tool.__name__ == "search_memory"
 
 
+class TestLimitClamping:
+    @pytest.mark.asyncio
+    async def test_limit_clamped_to_50(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[]))
+        tool = create_zep_search_tool(limit=1000)
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        kwargs = client.graph.search.call_args.kwargs
+        assert kwargs["limit"] == 50
+
+    @pytest.mark.asyncio
+    async def test_limit_at_ceiling_unchanged(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[]))
+        tool = create_zep_search_tool(limit=50)
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        assert client.graph.search.call_args.kwargs["limit"] == 50
+
+    @pytest.mark.asyncio
+    async def test_limit_floor_is_one(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[]))
+        tool = create_zep_search_tool(limit=0)
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        assert client.graph.search.call_args.kwargs["limit"] == 1
+
+
+class TestAutoScopeReranker:
+    @pytest.mark.asyncio
+    async def test_auto_scope_drops_incompatible_reranker(self) -> None:
+        """node_distance / episode_mentions are rejected by Zep for auto scope;
+        the tool must not pass a reranker at all."""
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(context="ctx"))
+        tool = create_zep_search_tool(scope="auto", reranker="node_distance")
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        kwargs = client.graph.search.call_args.kwargs
+        assert kwargs["scope"] == "auto"
+        assert "reranker" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_auto_scope_drops_default_reranker_too(self) -> None:
+        """Auto search ignores reranker entirely; even rrf is omitted."""
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(context="ctx"))
+        tool = create_zep_search_tool(scope="auto")
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        assert "reranker" not in client.graph.search.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_non_auto_scope_keeps_reranker(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[]))
+        tool = create_zep_search_tool(scope="edges", reranker="node_distance")
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        assert client.graph.search.call_args.kwargs["reranker"] == "node_distance"
+
+
+class TestExtendedScopes:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("scope", ["observations", "thread_summaries"])
+    async def test_new_scopes_accepted(self, scope: str) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(return_value=_make_result(edges=[]))
+        tool = create_zep_search_tool(scope=scope)  # type: ignore[arg-type]
+        ctx = _make_ctx(_make_deps(client))
+
+        await tool(ctx, "query")
+
+        assert client.graph.search.call_args.kwargs["scope"] == scope
+
+
 class TestResultFormatting:
     @pytest.mark.asyncio
     async def test_formats_edges(self) -> None:

--- a/integrations/pydantic-ai/python/tests/test_search.py
+++ b/integrations/pydantic-ai/python/tests/test_search.py
@@ -19,12 +19,21 @@ def _make_ctx(deps: ZepDeps) -> MagicMock:
     return ctx
 
 
-def _make_result(edges=None, nodes=None, episodes=None, context=None) -> MagicMock:
+def _make_result(
+    edges=None,
+    nodes=None,
+    episodes=None,
+    context=None,
+    observations=None,
+    thread_summaries=None,
+) -> MagicMock:
     result = MagicMock()
     result.edges = edges
     result.nodes = nodes
     result.episodes = episodes
     result.context = context
+    result.observations = observations
+    result.thread_summaries = thread_summaries
     return result
 
 
@@ -45,6 +54,20 @@ def _episode(content: str) -> MagicMock:
     ep = MagicMock()
     ep.content = content
     return ep
+
+
+def _observation(name: str, summary: str | None = None) -> MagicMock:
+    obs = MagicMock()
+    obs.name = name
+    obs.summary = summary
+    return obs
+
+
+def _thread_summary(summary: str | None, name: str = "thread") -> MagicMock:
+    ts = MagicMock()
+    ts.summary = summary
+    ts.name = name
+    return ts
 
 
 class TestSearchTargeting:
@@ -250,6 +273,41 @@ class TestResultFormatting:
         tool = create_zep_search_tool(scope="auto")
         out = await tool(_make_ctx(_make_deps(client)), "q")
         assert out == "Assembled context block"
+
+    @pytest.mark.asyncio
+    async def test_formats_observations(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(
+            return_value=_make_result(
+                observations=[
+                    _observation("Prefers async updates", "Communication pattern"),
+                    _observation("Ships on Fridays"),
+                ]
+            )
+        )
+        tool = create_zep_search_tool(scope="observations")
+        out = await tool(_make_ctx(_make_deps(client)), "q")
+        assert out != "No results found."
+        assert "Prefers async updates: Communication pattern" in out
+        assert "Ships on Fridays" in out
+
+    @pytest.mark.asyncio
+    async def test_formats_thread_summaries(self) -> None:
+        client = MagicMock()
+        client.graph.search = AsyncMock(
+            return_value=_make_result(
+                thread_summaries=[
+                    _thread_summary("User discussed Q3 roadmap"),
+                    _thread_summary(None, name="onboarding-thread"),
+                ]
+            )
+        )
+        tool = create_zep_search_tool(scope="thread_summaries")
+        out = await tool(_make_ctx(_make_deps(client)), "q")
+        assert out != "No results found."
+        assert "User discussed Q3 roadmap" in out
+        # Falls back to the node name when no summary is present.
+        assert "onboarding-thread" in out
 
     @pytest.mark.asyncio
     async def test_empty_results(self) -> None:


### PR DESCRIPTION
Adds the **`zep-pydantic-ai`** package (`integrations/pydantic-ai/python`) — Zep memory for Pydantic AI.

## Hook (verified against installed `pydantic-ai` 1.107.0)
Built on the **current** API `capabilities=[ProcessHistory(zep_history_processor)]` (not the deprecated `history_processors=` kwarg). The async processor persists the latest user turn via `thread.add_messages(return_context=True)` and prepends Zep's Context Block; it **dedupes on the latest user content** to avoid re-persisting on the once-per-model-request re-invocation in tool-calling runs. `ZepDeps` (via `deps_type`) carries the client/user/thread; `create_zep_search_tool` exposes `graph.search`; `persist_run` writes `result.new_messages()`.

## Deps
`pydantic-ai>=1.107,<2`, `zep-cloud>=3.23.0`. Python ≥3.11.

## Ships
README, SETUP.md (Zep signup), example, 57 mock tests, Makefile, CHANGELOG.

## Validation
ruff + ruff format + mypy + pytest (57 passed); live example smoke test passed. Approach in `integrations/SPIKE_FINDINGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)