### PR TITLE
Add @getzep/zep-vercel-ai integration (Vercel AI SDK)

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -45,6 +45,8 @@ jobs:
               - 'integrations/adk/typescript/**'
             mastra:
               - 'integrations/mastra/typescript/**'
+            vercel-ai:
+              - 'integrations/vercel-ai/typescript/**'
 
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: go

--- a/integrations/vercel-ai/typescript/.gitignore
+++ b/integrations/vercel-ai/typescript/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.tsbuildinfo
+.DS_Store
+coverage/
+npm-debug.log*

--- a/integrations/vercel-ai/typescript/CHANGELOG.md
+++ b/integrations/vercel-ai/typescript/CHANGELOG.md
@@ -6,25 +6,32 @@
 
 - Initial release of `@getzep/zep-vercel-ai` — Zep long-term memory for the
   Vercel AI SDK (v6).
-- `createZepMiddleware` — a `LanguageModelMiddleware` (`specificationVersion:
-  "v3"`) for `wrapLanguageModel`. `transformParams` injects the user's Context
-  Block (`thread.getUserContext`) as a system message on every `generate`/
-  `stream` call; with `persist: true`, `wrapGenerate` records the user+assistant
-  turn via `thread.addMessages` for non-streaming `generateText`. Customizable
-  via `formatContext`, `templateId`, `userName`/`assistantName`, and `logger`.
+- `createZepMiddleware` — a context-injection `LanguageModelMiddleware`
+  (`specificationVersion: "v3"`) for `wrapLanguageModel`. `transformParams`
+  injects the user's Context Block (`thread.getUserContext`) as a system message
+  on each genuine new user turn (detected by the last prompt message being a
+  `user` message), on both `generate`/`stream` calls — so the block is fetched
+  at most once per turn, not once per tool-loop step. Injection only;
+  persistence lives in `createZepOnFinish`. Customizable via `formatContext`,
+  `templateId`, and `logger`.
+- `createZepOnFinish` — builds an AI SDK `onFinish` callback that persists the
+  whole turn (user input + final assistant text) exactly once per turn, for both
+  `generateText` and `streamText`.
 - `getZepContext` and `persistZepTurn` — plain async helpers for the `system:` +
-  `onFinish` pattern, which is the required persistence path for `streamText`.
+  `onFinish` pattern.
 - `createZepTools` — builds `{ zepSearch, zepRemember, zepContext }` model-
   callable tools (AI SDK `tool()` + Zod `inputSchema`) bound to one client and
   binding, plus the standalone factories `createZepSearchTool`,
   `createZepRememberTool`, `createZepContextTool`.
 - `ensureZepUserAndThread` — idempotent helper to provision the Zep user and
   thread before the first turn.
-- `toRoleType`, `resolveGraphTarget`, `truncateForZep`, and `MESSAGE_MAX_CHARS`
-  utilities; `ZepBinding`, `ZepLogger`, `ZepTurn`, and `RoleType` types.
+- `toRoleType`, `resolveGraphTarget`, `truncateForZep`, `MESSAGE_MAX_CHARS`, and
+  `GRAPH_MAX_CHARS` utilities; `ZepBinding`, `ZepLogger`, `ZepTurn`, and
+  `RoleType` types.
 - User-graph (`userId`) and standalone-graph (`graphId`) bindings.
-- 4,096-char message truncation with lengths-only warnings (no content/PII in
-  logs) in both the middleware and the helpers/tools.
+- Truncation with lengths-only warnings (no content/PII in logs), never silent
+  drops: 4,096-char limit on the conversational `thread.addMessages` path and
+  10,000-char limit on the `graph.add` path.
 - Graceful error handling across every layer — a Zep failure is logged and never
   crashes the host call.
 - Mock-based test suite plus a live test gated on `ZEP_API_KEY`.

--- a/integrations/vercel-ai/typescript/CHANGELOG.md
+++ b/integrations/vercel-ai/typescript/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## 0.1.0 (2026-06-17)
+
+### Added
+
+- Initial release of `@getzep/zep-vercel-ai` — Zep long-term memory for the
+  Vercel AI SDK (v6).
+- `createZepMiddleware` — a `LanguageModelMiddleware` (`specificationVersion:
+  "v3"`) for `wrapLanguageModel`. `transformParams` injects the user's Context
+  Block (`thread.getUserContext`) as a system message on every `generate`/
+  `stream` call; with `persist: true`, `wrapGenerate` records the user+assistant
+  turn via `thread.addMessages` for non-streaming `generateText`. Customizable
+  via `formatContext`, `templateId`, `userName`/`assistantName`, and `logger`.
+- `getZepContext` and `persistZepTurn` — plain async helpers for the `system:` +
+  `onFinish` pattern, which is the required persistence path for `streamText`.
+- `createZepTools` — builds `{ zepSearch, zepRemember, zepContext }` model-
+  callable tools (AI SDK `tool()` + Zod `inputSchema`) bound to one client and
+  binding, plus the standalone factories `createZepSearchTool`,
+  `createZepRememberTool`, `createZepContextTool`.
+- `ensureZepUserAndThread` — idempotent helper to provision the Zep user and
+  thread before the first turn.
+- `toRoleType`, `resolveGraphTarget`, `truncateForZep`, and `MESSAGE_MAX_CHARS`
+  utilities; `ZepBinding`, `ZepLogger`, `ZepTurn`, and `RoleType` types.
+- User-graph (`userId`) and standalone-graph (`graphId`) bindings.
+- 4,096-char message truncation with lengths-only warnings (no content/PII in
+  logs) in both the middleware and the helpers/tools.
+- Graceful error handling across every layer — a Zep failure is logged and never
+  crashes the host call.
+- Mock-based test suite plus a live test gated on `ZEP_API_KEY`.
+- Runnable `generateText` and `streamText` examples, README, and SETUP guide.
+
+### Compatibility
+
+- Targets the Vercel AI SDK **v6** (`ai` >= 6, the `v3` middleware/provider
+  interfaces) — **not** compatible with AI SDK v5.
+- `zod` >= 3.25 (peer); Zep V3 (`@getzep/zep-cloud` >= 3.23.0).

--- a/integrations/vercel-ai/typescript/LICENSE
+++ b/integrations/vercel-ai/typescript/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/integrations/vercel-ai/typescript/README.md
+++ b/integrations/vercel-ai/typescript/README.md
@@ -1,0 +1,198 @@
+# Zep Vercel AI SDK Integration
+
+`@getzep/zep-vercel-ai` adds [Zep](https://www.getzep.com) long-term memory to
+the [Vercel AI SDK](https://ai-sdk.dev) (v6). It exposes Zep's temporal Context
+Graph through three layers so you can pick the integration point that fits your
+call:
+
+| Layer | Export | Use when |
+|-------|--------|----------|
+| **Middleware** | `createZepMiddleware` | You want context injected automatically on every model call (and, for `generateText`, the turn persisted automatically). |
+| **Helpers** | `getZepContext`, `persistZepTurn` | You want explicit control — the required pattern for `streamText` (set `system:` + persist in `onFinish`). |
+| **Tools** | `createZepTools` | You want the model to retrieve/persist on demand inside a tool loop. |
+
+All three handle Zep failures gracefully: a Zep outage degrades to "no memory"
+and **never crashes the host call**. Warnings log lengths and counts only —
+never message content or PII.
+
+## Installation
+
+```bash
+npm install @getzep/zep-vercel-ai @getzep/zep-cloud ai zod
+```
+
+`ai` (the Vercel AI SDK, v6) and `zod` are peer dependencies. You'll also want a
+model provider such as `@ai-sdk/openai`. See [SETUP.md](./SETUP.md) for how to
+sign up for Zep and create an API key.
+
+## Quick start (middleware + tools, `generateText`)
+
+```ts
+import { ZepClient } from "@getzep/zep-cloud";
+import { openai } from "@ai-sdk/openai";
+import { generateText, stepCountIs, wrapLanguageModel } from "ai";
+import {
+  createZepMiddleware,
+  createZepTools,
+  ensureZepUserAndThread,
+} from "@getzep/zep-vercel-ai";
+
+const client = new ZepClient({ apiKey: process.env.ZEP_API_KEY! });
+
+// 1. Provision the Zep user + thread before the first turn.
+await ensureZepUserAndThread({ client, userId: "u1", threadId: "t1", firstName: "Jane" });
+
+// 2. Wrap the model: inject the Context Block on every call + persist the turn.
+const model = wrapLanguageModel({
+  model: openai("gpt-4o-mini"),
+  middleware: createZepMiddleware({ client, threadId: "t1", persist: true }),
+});
+
+// 3. Optionally let the model search/store memory explicitly.
+const tools = createZepTools(client, { binding: { userId: "u1", threadId: "t1" } });
+
+const { text } = await generateText({
+  model,
+  tools,
+  stopWhen: stepCountIs(5),
+  prompt: "What do you remember about me?",
+});
+```
+
+A complete, runnable version is in
+[`examples/generate-text.ts`](./examples/generate-text.ts) (`npm run example`).
+
+## Streaming (`streamText`): persist in `onFinish`
+
+**Important:** the AI SDK only calls a middleware's `wrapGenerate` for
+`generateText`, never for `streamText`. So for streaming:
+
+- **Context injection** still works (the middleware does it in `transformParams`,
+  or you can set `system:` yourself with `getZepContext`), but
+- **Persistence does not run via the middleware** — you must persist the
+  completed turn from `onFinish` with `persistZepTurn`.
+
+```ts
+import { streamText } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { getZepContext, persistZepTurn } from "@getzep/zep-vercel-ai";
+
+const userInput = "I just adopted a beagle named Cooper.";
+const context = await getZepContext(client, "t1");
+
+const result = streamText({
+  model: openai("gpt-4o-mini"),
+  system: context ? `Relevant memory:\n${context}` : undefined,
+  prompt: userInput,
+  onFinish: ({ text }) => {
+    // onFinish fires for BOTH streamText and generateText.
+    void persistZepTurn(client, "t1", { user: userInput, assistant: text });
+  },
+});
+
+for await (const chunk of result.textStream) process.stdout.write(chunk);
+```
+
+See [`examples/stream-text.ts`](./examples/stream-text.ts).
+
+## The layers in detail
+
+### `createZepMiddleware({ client, threadId, persist? })`
+
+Returns a Vercel AI SDK `LanguageModelMiddleware` (`specificationVersion: "v3"`)
+for `wrapLanguageModel`.
+
+- `transformParams` fetches the Context Block (`thread.getUserContext`) and
+  prepends it as a `system` message to the provider prompt — on both `generate`
+  and `stream` calls.
+- When `persist: true`, `wrapGenerate` records the user+assistant turn via
+  `thread.addMessages` after a non-streaming `generateText`. (No-op for
+  `streamText` — see the streaming section above.)
+
+Options also include `formatContext` (customize the injected system text),
+`templateId` (custom Context Block layout), `userName` / `assistantName`
+(speaker names on persisted messages), and `logger`. Implementation:
+[`src/middleware.ts`](./src/middleware.ts).
+
+### `getZepContext(client, threadId, options?)` and `persistZepTurn(client, threadId, turn, options?)`
+
+Plain async functions, no framework coupling.
+
+- `getZepContext` returns the prompt-ready Context Block string (or `""`).
+- `persistZepTurn` writes a `{ user?, assistant? }` turn via
+  `thread.addMessages`; pass `{ returnContext: true }` to fold persist +
+  retrieval into one round-trip. Over-long content is truncated to Zep's
+  4,096-char message limit with a lengths-only warning.
+
+Implementation: [`src/helpers.ts`](./src/helpers.ts).
+
+### `createZepTools(client, { binding, ... })`
+
+Returns `{ zepSearch, zepRemember, zepContext }` built with the AI SDK's `tool()`
+and Zod `inputSchema`. Spread them into a `generateText`/`streamText` `tools`
+record so the model can decide when to retrieve or persist.
+
+| Tool | Zep operation | What it does |
+|------|---------------|--------------|
+| `zepSearch` | `graph.search` | Free-text search over the bound graph; returns relevant facts. Scope/limit/reranker/filters are pinned at construction. |
+| `zepRemember` | `thread.addMessages` / `graph.add` | Persists a message (a `role` + bound thread) or a general fact (`graph.add`). |
+| `zepContext` | `thread.getUserContext` | Returns the whole-user-graph Context Block on demand. |
+
+Each tool is also exported as a standalone factory (`createZepSearchTool`,
+`createZepRememberTool`, `createZepContextTool`). Implementation:
+[`src/tools.ts`](./src/tools.ts).
+
+## Binding: user graph vs standalone graph
+
+Tools and `createZepTools` are bound to a graph via a `ZepBinding`:
+
+- **`userId`** targets a **user graph** — the home for personalized agent memory.
+  Use it for a conversational agent that remembers an end user. `zepContext`
+  (and the middleware) also need a `threadId` — the thread scopes relevance;
+  retrieval still spans the whole user graph.
+- **`graphId`** targets a **standalone graph** — shared or domain knowledge (a
+  product knowledge base, runbooks). No user node, no user summary.
+
+If both are set, `userId` wins. If neither is set, tools return a graceful "not
+configured" result instead of throwing.
+
+## Roles
+
+`zepRemember` accepts an arbitrary `role` string and maps it onto Zep's closed
+`RoleType` enum (`user | assistant | system | tool | function | norole`), so
+loose role names like `human` or `ai` are coerced safely; unknown roles fall
+back to `norole`. The mapper is exported as `toRoleType`.
+
+## Ingestion is asynchronous
+
+Zep builds the graph asynchronously — a fact you just stored is not instantly
+retrievable. Design flows for eventual availability; don't read-after-write
+within a single turn. The example waits before recalling.
+
+## Development
+
+```bash
+npm install
+npm run typecheck   # tsc --noEmit (NodeNext + strict)
+npm run lint        # eslint
+npm test            # vitest (mock-based; live test gated on ZEP_API_KEY)
+npm run build       # tsup → dist (ESM + CJS + d.ts)
+```
+
+## Requirements
+
+- Node.js >= 20
+- `ai` >= 6 (peer) — the Vercel AI SDK v6 (this package targets the v3
+  middleware/provider interfaces; it is **not** compatible with AI SDK v5)
+- `zod` >= 3.25 (peer)
+- `@getzep/zep-cloud` >= 3.23.0 (Zep V3)
+
+## Links
+
+- [Zep documentation](https://help.getzep.com)
+- [Vercel AI SDK documentation](https://ai-sdk.dev/docs)
+- [GitHub issues](https://github.com/getzep/zep/issues)
+
+## License
+
+Apache 2.0 — see [LICENSE](./LICENSE).

--- a/integrations/vercel-ai/typescript/README.md
+++ b/integrations/vercel-ai/typescript/README.md
@@ -7,13 +7,19 @@ call:
 
 | Layer | Export | Use when |
 |-------|--------|----------|
-| **Middleware** | `createZepMiddleware` | You want context injected automatically on every model call (and, for `generateText`, the turn persisted automatically). |
-| **Helpers** | `getZepContext`, `persistZepTurn` | You want explicit control — the required pattern for `streamText` (set `system:` + persist in `onFinish`). |
+| **Middleware** | `createZepMiddleware` | You want the Context Block injected automatically as a system message on each new user turn. Injection only — pair with `createZepOnFinish` to persist. |
+| **Helpers** | `getZepContext`, `persistZepTurn`, `createZepOnFinish` | You want explicit control. `createZepOnFinish` persists the whole turn once per turn from `onFinish` (works for both `generateText` and `streamText`). |
 | **Tools** | `createZepTools` | You want the model to retrieve/persist on demand inside a tool loop. |
 
-All three handle Zep failures gracefully: a Zep outage degrades to "no memory"
-and **never crashes the host call**. Warnings log lengths and counts only —
-never message content or PII.
+**Inject via middleware, persist via `onFinish`.** The AI SDK tool loop calls
+the wrapped model once per step, so persisting from a per-step middleware hook
+would fragment a single turn across many writes and record the model's
+intermediate tool-call preamble as a real assistant message. `onFinish` fires
+exactly once per turn with the final assistant text, so persistence lives there.
+
+All three layers handle Zep failures gracefully: a Zep outage degrades to "no
+memory" and **never crashes the host call**. Warnings log lengths and counts
+only — never message content or PII.
 
 ## Installation
 
@@ -33,6 +39,7 @@ import { openai } from "@ai-sdk/openai";
 import { generateText, stepCountIs, wrapLanguageModel } from "ai";
 import {
   createZepMiddleware,
+  createZepOnFinish,
   createZepTools,
   ensureZepUserAndThread,
 } from "@getzep/zep-vercel-ai";
@@ -42,77 +49,89 @@ const client = new ZepClient({ apiKey: process.env.ZEP_API_KEY! });
 // 1. Provision the Zep user + thread before the first turn.
 await ensureZepUserAndThread({ client, userId: "u1", threadId: "t1", firstName: "Jane" });
 
-// 2. Wrap the model: inject the Context Block on every call + persist the turn.
+// 2. Wrap the model: inject the Context Block on each new user turn (inject-only).
 const model = wrapLanguageModel({
   model: openai("gpt-4o-mini"),
-  middleware: createZepMiddleware({ client, threadId: "t1", persist: true }),
+  middleware: createZepMiddleware({ client, threadId: "t1" }),
 });
 
 // 3. Optionally let the model search/store memory explicitly.
 const tools = createZepTools(client, { binding: { userId: "u1", threadId: "t1" } });
 
+// 4. Persist the whole turn once per turn via onFinish.
+const prompt = "What do you remember about me?";
 const { text } = await generateText({
   model,
   tools,
   stopWhen: stepCountIs(5),
-  prompt: "What do you remember about me?",
+  prompt,
+  onFinish: createZepOnFinish({ client, threadId: "t1", user: prompt }),
 });
 ```
 
 A complete, runnable version is in
 [`examples/generate-text.ts`](./examples/generate-text.ts) (`npm run example`).
 
-## Streaming (`streamText`): persist in `onFinish`
+## Streaming (`streamText`)
 
-**Important:** the AI SDK only calls a middleware's `wrapGenerate` for
-`generateText`, never for `streamText`. So for streaming:
-
-- **Context injection** still works (the middleware does it in `transformParams`,
-  or you can set `system:` yourself with `getZepContext`), but
-- **Persistence does not run via the middleware** — you must persist the
-  completed turn from `onFinish` with `persistZepTurn`.
+The same pattern works unchanged for streaming — **inject via middleware,
+persist via `onFinish`**. The middleware's `transformParams` runs for `stream`
+calls too (injecting on each new user turn), and `onFinish` fires once per turn
+with the final assistant text for `streamText` just as it does for
+`generateText`.
 
 ```ts
-import { streamText } from "ai";
+import { streamText, wrapLanguageModel } from "ai";
 import { openai } from "@ai-sdk/openai";
-import { getZepContext, persistZepTurn } from "@getzep/zep-vercel-ai";
+import { createZepMiddleware, createZepOnFinish } from "@getzep/zep-vercel-ai";
 
 const userInput = "I just adopted a beagle named Cooper.";
-const context = await getZepContext(client, "t1");
+
+const model = wrapLanguageModel({
+  model: openai("gpt-4o-mini"),
+  middleware: createZepMiddleware({ client, threadId: "t1" }),
+});
 
 const result = streamText({
-  model: openai("gpt-4o-mini"),
-  system: context ? `Relevant memory:\n${context}` : undefined,
+  model,
   prompt: userInput,
-  onFinish: ({ text }) => {
-    // onFinish fires for BOTH streamText and generateText.
-    void persistZepTurn(client, "t1", { user: userInput, assistant: text });
-  },
+  onFinish: createZepOnFinish({ client, threadId: "t1", user: userInput }),
 });
 
 for await (const chunk of result.textStream) process.stdout.write(chunk);
 ```
 
-See [`examples/stream-text.ts`](./examples/stream-text.ts).
+Prefer to set `system:` yourself instead of using the middleware? Fetch the
+block with `getZepContext` and persist with `persistZepTurn` (or
+`createZepOnFinish`) directly. See [`examples/stream-text.ts`](./examples/stream-text.ts).
 
 ## The layers in detail
 
-### `createZepMiddleware({ client, threadId, persist? })`
+### `createZepMiddleware({ client, threadId })`
 
 Returns a Vercel AI SDK `LanguageModelMiddleware` (`specificationVersion: "v3"`)
-for `wrapLanguageModel`.
+for `wrapLanguageModel`. **Injection only** — it does not persist.
 
 - `transformParams` fetches the Context Block (`thread.getUserContext`) and
   prepends it as a `system` message to the provider prompt — on both `generate`
-  and `stream` calls.
-- When `persist: true`, `wrapGenerate` records the user+assistant turn via
-  `thread.addMessages` after a non-streaming `generateText`. (No-op for
-  `streamText` — see the streaming section above.)
+  and `stream` calls — **only on a genuine new user turn** (detected by the last
+  prompt message being a `user` message). On tool-loop continuation steps (last
+  message is a `tool` result or an `assistant` tool call) it injects nothing, so
+  the Context Block is fetched at most once per turn, not once per step.
 
-Options also include `formatContext` (customize the injected system text),
-`templateId` (custom Context Block layout), `userName` / `assistantName`
-(speaker names on persisted messages), and `logger`. Implementation:
-[`src/middleware.ts`](./src/middleware.ts).
+Persist with `createZepOnFinish` (below). Options also include `formatContext`
+(customize the injected system text), `templateId` (custom Context Block
+layout), and `logger`. Implementation: [`src/middleware.ts`](./src/middleware.ts).
+
+### `createZepOnFinish({ client, threadId, user?, userId?, ... })`
+
+Returns an AI SDK `onFinish` callback that persists the whole turn **once** —
+the user's input plus the final assistant text from the event — via
+`thread.addMessages`. `onFinish` fires exactly once per turn (after the entire
+tool loop completes) for both `generateText` and `streamText`, so this records
+exactly one user message and one assistant message per turn and never writes
+intermediate tool-call preamble. Supply the user side via `user` (a string, or a
+`(event) => string` resolver); the assistant side is taken from `event.text`.
 
 ### `getZepContext(client, threadId, options?)` and `persistZepTurn(client, threadId, turn, options?)`
 
@@ -135,7 +154,7 @@ record so the model can decide when to retrieve or persist.
 | Tool | Zep operation | What it does |
 |------|---------------|--------------|
 | `zepSearch` | `graph.search` | Free-text search over the bound graph; returns relevant facts. Scope/limit/reranker/filters are pinned at construction. |
-| `zepRemember` | `thread.addMessages` / `graph.add` | Persists a message (a `role` + bound thread) or a general fact (`graph.add`). |
+| `zepRemember` | `thread.addMessages` / `graph.add` | Persists a message (a `role` + bound thread; capped at Zep's 4,096-char message limit) or a general fact (`graph.add`; capped at Zep's 10,000-char limit). Over-long content is truncated with a lengths-only warning, never dropped. |
 | `zepContext` | `thread.getUserContext` | Returns the whole-user-graph Context Block on demand. |
 
 Each tool is also exported as a standalone factory (`createZepSearchTool`,
@@ -184,7 +203,7 @@ npm run build       # tsup → dist (ESM + CJS + d.ts)
 - Node.js >= 20
 - `ai` >= 6 (peer) — the Vercel AI SDK v6 (this package targets the v3
   middleware/provider interfaces; it is **not** compatible with AI SDK v5)
-- `zod` >= 3.25 (peer)
+- `zod` 3 or 4 (peer; `^3.25.0 || ^4.0.0`)
 - `@getzep/zep-cloud` >= 3.23.0 (Zep V3)
 
 ## Links

--- a/integrations/vercel-ai/typescript/SETUP.md
+++ b/integrations/vercel-ai/typescript/SETUP.md
@@ -59,15 +59,16 @@ The `generate-text` example
 ([`examples/generate-text.ts`](./examples/generate-text.ts)):
 
 1. Provisions a Zep user and thread.
-2. Wraps the model with `createZepMiddleware` (context injection + persistence).
+2. Wraps the model with `createZepMiddleware` (context injection on each new user
+   turn) and persists the whole turn once via `createZepOnFinish`.
 3. Attaches `createZepTools` so the model can search/store explicitly.
 4. Seeds facts across a couple of turns, waits ~15s for Zep's asynchronous graph
    ingestion, then asks the agent to recall them.
 
-The `stream-text` example shows the streaming persistence pattern: fetch context
-with `getZepContext`, set it as `system`, and persist the completed turn from
-`onFinish` with `persistZepTurn` (because middleware `wrapGenerate` does not fire
-for `streamText`).
+The `stream-text` example shows the same pattern for streaming — inject via the
+middleware, persist the completed turn from `onFinish` with `createZepOnFinish`.
+`onFinish` fires once per turn with the final assistant text for both
+`generateText` and `streamText`.
 
 > **OpenAI Zero Data Retention (ZDR) note.** The `generate-text` example uses the
 > OpenAI Chat Completions API (`openai.chat("gpt-4o-mini")`) instead of the

--- a/integrations/vercel-ai/typescript/SETUP.md
+++ b/integrations/vercel-ai/typescript/SETUP.md
@@ -1,0 +1,95 @@
+# Setup
+
+This guide walks you from zero to a running Vercel AI SDK call with Zep memory.
+
+## 1. Sign up for Zep
+
+1. Go to [https://www.getzep.com](https://www.getzep.com) and create an account.
+2. Open the Zep dashboard and create (or select) a project.
+
+> Zep is a paid product (it has no meaningful free tier). See the Zep site for
+> current plans.
+
+## 2. Create an API key
+
+1. In the Zep dashboard, open your project settings and find the **API Keys**
+   section.
+2. Create a new API key and copy it. You won't be able to view it again.
+
+## 3. Install
+
+```bash
+npm install @getzep/zep-vercel-ai @getzep/zep-cloud ai zod
+```
+
+`ai` (the Vercel AI SDK, v6) and `zod` are peer dependencies. Install a model
+provider too — the examples use OpenAI:
+
+```bash
+npm install @ai-sdk/openai
+```
+
+> This package targets **AI SDK v6** (the `v3` middleware/provider interfaces).
+> It is not compatible with AI SDK v5.
+
+## 4. Configure environment variables
+
+The runnable examples use Zep and an OpenAI model. Set:
+
+```bash
+export ZEP_API_KEY="your-zep-api-key"
+export OPENAI_API_KEY="your-openai-api-key"
+```
+
+Only `ZEP_API_KEY` is required by the integration itself; `OPENAI_API_KEY` is
+needed by the example's model (`openai("gpt-4o-mini")`). Swap in any provider the
+AI SDK supports if you prefer.
+
+## 5. Run the examples
+
+From this package directory:
+
+```bash
+npm install
+npm run example                 # generate-text.ts (middleware + tools)
+npx tsx examples/stream-text.ts # streamText + onFinish persistence
+```
+
+The `generate-text` example
+([`examples/generate-text.ts`](./examples/generate-text.ts)):
+
+1. Provisions a Zep user and thread.
+2. Wraps the model with `createZepMiddleware` (context injection + persistence).
+3. Attaches `createZepTools` so the model can search/store explicitly.
+4. Seeds facts across a couple of turns, waits ~15s for Zep's asynchronous graph
+   ingestion, then asks the agent to recall them.
+
+The `stream-text` example shows the streaming persistence pattern: fetch context
+with `getZepContext`, set it as `system`, and persist the completed turn from
+`onFinish` with `persistZepTurn` (because middleware `wrapGenerate` does not fire
+for `streamText`).
+
+> **OpenAI Zero Data Retention (ZDR) note.** The `generate-text` example uses the
+> OpenAI Chat Completions API (`openai.chat("gpt-4o-mini")`) instead of the
+> default Responses API. The Responses API references server-persisted item IDs
+> across a multi-step tool loop, which ZDR organizations reject ("Items are not
+> persisted for Zero Data Retention organizations"). This is an OpenAI/account
+> constraint, not a Zep issue — using the Chat Completions API (or a non-ZDR key)
+> avoids it.
+
+## 6. Run the tests
+
+```bash
+npm test
+```
+
+Mock-based tests run with no credentials. The live test in
+[`test/live.test.ts`](./test/live.test.ts) runs automatically only when
+`ZEP_API_KEY` is set and exercises the real Zep API.
+
+## Next steps
+
+- Read [README.md](./README.md) for the full layer reference and the user-graph
+  vs standalone-graph binding model.
+- See the [Zep documentation](https://help.getzep.com) for ontology, search
+  scopes, and context customization.

--- a/integrations/vercel-ai/typescript/eslint.config.js
+++ b/integrations/vercel-ai/typescript/eslint.config.js
@@ -1,0 +1,25 @@
+// @ts-check
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      // Allow intentionally-unused identifiers (e.g. the exhaustiveness `never`
+      // guard and destructured-but-ignored values) when prefixed with `_`.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+);

--- a/integrations/vercel-ai/typescript/examples/generate-text.ts
+++ b/integrations/vercel-ai/typescript/examples/generate-text.ts
@@ -1,0 +1,118 @@
+/**
+ * Vercel AI SDK + Zep long-term memory — `generateText` example.
+ *
+ * Demonstrates the full loop:
+ *   1. Provision a Zep user + thread (`ensureZepUserAndThread`).
+ *   2. Wrap the model with `createZepMiddleware` so the user's Context Block is
+ *      injected as a system message on every call, and the non-streaming turn is
+ *      persisted automatically (`persist: true`).
+ *   3. Attach `createZepTools` so the model can also search/store on demand.
+ *   4. Seed a couple of facts across turns, wait for asynchronous ingestion,
+ *      then ask the agent to recall them.
+ *
+ * Prerequisites:
+ *   npm install
+ *   export ZEP_API_KEY="your-zep-api-key"
+ *   export OPENAI_API_KEY="your-openai-api-key"
+ *
+ * Run:
+ *   npm run example
+ */
+
+import { randomUUID } from "node:crypto";
+import { ZepClient } from "@getzep/zep-cloud";
+import { openai } from "@ai-sdk/openai";
+import { generateText, stepCountIs, wrapLanguageModel } from "ai";
+import {
+  createZepMiddleware,
+  createZepTools,
+  ensureZepUserAndThread,
+} from "../src/index.js";
+
+const ZEP_API_KEY = process.env.ZEP_API_KEY;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+if (!ZEP_API_KEY) throw new Error("ZEP_API_KEY is not set.");
+if (!OPENAI_API_KEY) throw new Error("OPENAI_API_KEY is not set.");
+
+const userId = `zep-vercel-example-${randomUUID().slice(0, 8)}`;
+const threadId = `thread-${randomUUID().slice(0, 8)}`;
+
+const SYSTEM =
+  "You are a helpful assistant with long-term memory powered by Zep. " +
+  "Relevant user context is injected for you automatically. Use the " +
+  "zepRemember tool to store new facts the user shares, and zepSearch to " +
+  "look up specific details. Personalize your replies.";
+
+async function main(): Promise<void> {
+  const client = new ZepClient({ apiKey: ZEP_API_KEY });
+
+  console.log("=".repeat(60));
+  console.log("Vercel AI SDK + Zep Memory Example (generateText)");
+  console.log(`  User ID:   ${userId}`);
+  console.log(`  Thread ID: ${threadId}`);
+  console.log("=".repeat(60));
+
+  // 1. Provision identity before the first turn.
+  await ensureZepUserAndThread({
+    client,
+    userId,
+    threadId,
+    firstName: "Alice",
+    lastName: "Smith",
+    email: "alice@example.com",
+  });
+
+  // 2. Wrap the model: inject context on every call + persist non-streaming turns.
+  //    We use the Chat Completions API (`openai.chat`) rather than the default
+  //    Responses API so the multi-step tool loop also works on OpenAI Zero Data
+  //    Retention (ZDR) organizations, which don't persist Responses item IDs.
+  const model = wrapLanguageModel({
+    model: openai.chat("gpt-4o-mini"),
+    middleware: createZepMiddleware({
+      client,
+      threadId,
+      persist: true,
+      userName: "Alice",
+    }),
+  });
+
+  // 3. Tools the model can call to search/store memory explicitly.
+  const tools = createZepTools(client, {
+    binding: { userId, threadId },
+    defaultMessageName: "Alice",
+  });
+
+  async function ask(prompt: string): Promise<void> {
+    console.log(`\nUser:  ${prompt}`);
+    const { text } = await generateText({
+      model,
+      system: SYSTEM,
+      tools,
+      stopWhen: stepCountIs(5),
+      prompt,
+    });
+    console.log(`Agent: ${text}`);
+  }
+
+  // 4a. Seed facts across a short conversation.
+  console.log("\n--- Phase 1: Seeding facts ---");
+  await ask("Hi! Please remember that I live in Portland and love hiking.");
+  await ask("Also remember that I work as a software engineer.");
+
+  // 4b. Wait for asynchronous graph ingestion.
+  const waitSeconds = 15;
+  console.log(`\n--- Waiting ${waitSeconds}s for Zep graph processing ---`);
+  await new Promise((resolve) => setTimeout(resolve, waitSeconds * 1000));
+
+  // 4c. Recall (context is injected by the middleware; the model may also search).
+  console.log("\n--- Phase 2: Recall ---");
+  await ask("What do you remember about where I live and what I do?");
+
+  console.log("\nDone.");
+}
+
+main().catch((error) => {
+  console.error("Example failed:", error);
+  process.exitCode = 1;
+});

--- a/integrations/vercel-ai/typescript/examples/generate-text.ts
+++ b/integrations/vercel-ai/typescript/examples/generate-text.ts
@@ -4,10 +4,12 @@
  * Demonstrates the full loop:
  *   1. Provision a Zep user + thread (`ensureZepUserAndThread`).
  *   2. Wrap the model with `createZepMiddleware` so the user's Context Block is
- *      injected as a system message on every call, and the non-streaming turn is
- *      persisted automatically (`persist: true`).
- *   3. Attach `createZepTools` so the model can also search/store on demand.
- *   4. Seed a couple of facts across turns, wait for asynchronous ingestion,
+ *      injected as a system message on each new user turn (inject-only).
+ *   3. Persist the whole turn once per turn via `createZepOnFinish` on the
+ *      `generateText` call's `onFinish` (fires once with the final assistant
+ *      text, even across a multi-step tool loop).
+ *   4. Attach `createZepTools` so the model can also search/store on demand.
+ *   5. Seed a couple of facts across turns, wait for asynchronous ingestion,
  *      then ask the agent to recall them.
  *
  * Prerequisites:
@@ -25,6 +27,7 @@ import { openai } from "@ai-sdk/openai";
 import { generateText, stepCountIs, wrapLanguageModel } from "ai";
 import {
   createZepMiddleware,
+  createZepOnFinish,
   createZepTools,
   ensureZepUserAndThread,
 } from "../src/index.js";
@@ -63,18 +66,14 @@ async function main(): Promise<void> {
     email: "alice@example.com",
   });
 
-  // 2. Wrap the model: inject context on every call + persist non-streaming turns.
+  // 2. Wrap the model: inject the Context Block on each new user turn (the
+  //    middleware is inject-only; persistence happens in onFinish below).
   //    We use the Chat Completions API (`openai.chat`) rather than the default
   //    Responses API so the multi-step tool loop also works on OpenAI Zero Data
   //    Retention (ZDR) organizations, which don't persist Responses item IDs.
   const model = wrapLanguageModel({
     model: openai.chat("gpt-4o-mini"),
-    middleware: createZepMiddleware({
-      client,
-      threadId,
-      persist: true,
-      userName: "Alice",
-    }),
+    middleware: createZepMiddleware({ client, threadId }),
   });
 
   // 3. Tools the model can call to search/store memory explicitly.
@@ -85,12 +84,15 @@ async function main(): Promise<void> {
 
   async function ask(prompt: string): Promise<void> {
     console.log(`\nUser:  ${prompt}`);
+    // Persist the whole turn once via onFinish — fires a single time per turn
+    // with the final assistant text, even when the tool loop runs many steps.
     const { text } = await generateText({
       model,
       system: SYSTEM,
       tools,
       stopWhen: stepCountIs(5),
       prompt,
+      onFinish: createZepOnFinish({ client, threadId, user: prompt, userName: "Alice" }),
     });
     console.log(`Agent: ${text}`);
   }

--- a/integrations/vercel-ai/typescript/examples/stream-text.ts
+++ b/integrations/vercel-ai/typescript/examples/stream-text.ts
@@ -1,0 +1,87 @@
+/**
+ * Vercel AI SDK + Zep — `streamText` persistence example.
+ *
+ * IMPORTANT: the AI SDK only calls a middleware's `wrapGenerate` for
+ * `generateText`, never for `streamText`. So for streaming:
+ *
+ *   - Context injection still works through the middleware's `transformParams`
+ *     (or you can set `system:` yourself via `getZepContext`), but
+ *   - Persistence must be done from `onFinish` using `persistZepTurn`.
+ *
+ * This example uses the plain helpers (no middleware) to make the streaming
+ * persistence pattern explicit: fetch context with `getZepContext`, set it as
+ * `system`, and persist the completed turn from `onFinish`.
+ *
+ * Prerequisites:
+ *   export ZEP_API_KEY="your-zep-api-key"
+ *   export OPENAI_API_KEY="your-openai-api-key"
+ *
+ * Run:
+ *   npx tsx examples/stream-text.ts
+ */
+
+import { randomUUID } from "node:crypto";
+import { ZepClient } from "@getzep/zep-cloud";
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
+import {
+  ensureZepUserAndThread,
+  getZepContext,
+  persistZepTurn,
+} from "../src/index.js";
+
+const ZEP_API_KEY = process.env.ZEP_API_KEY;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+if (!ZEP_API_KEY) throw new Error("ZEP_API_KEY is not set.");
+if (!OPENAI_API_KEY) throw new Error("OPENAI_API_KEY is not set.");
+
+const userId = `zep-vercel-stream-${randomUUID().slice(0, 8)}`;
+const threadId = `thread-${randomUUID().slice(0, 8)}`;
+
+async function main(): Promise<void> {
+  const client = new ZepClient({ apiKey: ZEP_API_KEY });
+
+  await ensureZepUserAndThread({
+    client,
+    userId,
+    threadId,
+    firstName: "Bob",
+    lastName: "Jones",
+  });
+
+  const userInput = "Hi! I just adopted a beagle named Cooper.";
+
+  // 1. Fetch the Context Block and put it in the system prompt.
+  const context = await getZepContext(client, threadId);
+  const system = context
+    ? `You are a helpful assistant. Relevant long-term memory:\n\n${context}`
+    : "You are a helpful assistant.";
+
+  // 2. Stream the response. Persist the completed turn from onFinish, which
+  //    fires for both streamText and generateText (wrapGenerate does NOT).
+  const result = streamText({
+    model: openai("gpt-4o-mini"),
+    system,
+    prompt: userInput,
+    onFinish: ({ text }) => {
+      // Fire-and-forget; never block the stream on memory persistence.
+      void persistZepTurn(client, threadId, {
+        user: userInput,
+        assistant: text,
+        userName: "Bob",
+      });
+    },
+  });
+
+  process.stdout.write("Agent: ");
+  for await (const chunk of result.textStream) {
+    process.stdout.write(chunk);
+  }
+  process.stdout.write("\n\nDone (turn persisted to Zep via onFinish).\n");
+}
+
+main().catch((error) => {
+  console.error("Example failed:", error);
+  process.exitCode = 1;
+});

--- a/integrations/vercel-ai/typescript/examples/stream-text.ts
+++ b/integrations/vercel-ai/typescript/examples/stream-text.ts
@@ -1,16 +1,18 @@
 /**
- * Vercel AI SDK + Zep — `streamText` persistence example.
+ * Vercel AI SDK + Zep — `streamText` example (middleware + onFinish).
  *
- * IMPORTANT: the AI SDK only calls a middleware's `wrapGenerate` for
- * `generateText`, never for `streamText`. So for streaming:
+ * The same division of labor as the `generateText` example applies to
+ * streaming: **inject via middleware, persist via `onFinish`.**
  *
- *   - Context injection still works through the middleware's `transformParams`
- *     (or you can set `system:` yourself via `getZepContext`), but
- *   - Persistence must be done from `onFinish` using `persistZepTurn`.
+ *   - Context injection runs in the middleware's `transformParams` (it fires for
+ *     `stream` calls too, on each new user turn).
+ *   - Persistence runs from `onFinish`, which fires exactly once per turn with
+ *     the final assistant text — for both `streamText` and `generateText`. (The
+ *     middleware never persists; a per-step hook would fragment the turn.)
  *
- * This example uses the plain helpers (no middleware) to make the streaming
- * persistence pattern explicit: fetch context with `getZepContext`, set it as
- * `system`, and persist the completed turn from `onFinish`.
+ * If you'd rather set `system:` yourself instead of using the middleware, the
+ * plain `getZepContext` helper does that — but the middleware keeps the
+ * streaming and non-streaming paths identical.
  *
  * Prerequisites:
  *   export ZEP_API_KEY="your-zep-api-key"
@@ -23,11 +25,11 @@
 import { randomUUID } from "node:crypto";
 import { ZepClient } from "@getzep/zep-cloud";
 import { openai } from "@ai-sdk/openai";
-import { streamText } from "ai";
+import { streamText, wrapLanguageModel } from "ai";
 import {
+  createZepMiddleware,
+  createZepOnFinish,
   ensureZepUserAndThread,
-  getZepContext,
-  persistZepTurn,
 } from "../src/index.js";
 
 const ZEP_API_KEY = process.env.ZEP_API_KEY;
@@ -52,26 +54,19 @@ async function main(): Promise<void> {
 
   const userInput = "Hi! I just adopted a beagle named Cooper.";
 
-  // 1. Fetch the Context Block and put it in the system prompt.
-  const context = await getZepContext(client, threadId);
-  const system = context
-    ? `You are a helpful assistant. Relevant long-term memory:\n\n${context}`
-    : "You are a helpful assistant.";
+  // 1. Wrap the model: inject the Context Block on each new user turn.
+  const model = wrapLanguageModel({
+    model: openai("gpt-4o-mini"),
+    middleware: createZepMiddleware({ client, threadId }),
+  });
 
   // 2. Stream the response. Persist the completed turn from onFinish, which
-  //    fires for both streamText and generateText (wrapGenerate does NOT).
+  //    fires once for both streamText and generateText.
   const result = streamText({
-    model: openai("gpt-4o-mini"),
-    system,
+    model,
+    system: "You are a helpful assistant.",
     prompt: userInput,
-    onFinish: ({ text }) => {
-      // Fire-and-forget; never block the stream on memory persistence.
-      void persistZepTurn(client, threadId, {
-        user: userInput,
-        assistant: text,
-        userName: "Bob",
-      });
-    },
+    onFinish: createZepOnFinish({ client, threadId, user: userInput, userName: "Bob" }),
   });
 
   process.stdout.write("Agent: ");

--- a/integrations/vercel-ai/typescript/package-lock.json
+++ b/integrations/vercel-ai/typescript/package-lock.json
@@ -1,0 +1,4514 @@
+{
+  "name": "@getzep/zep-vercel-ai",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@getzep/zep-vercel-ai",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@getzep/zep-cloud": "^3.23.0"
+      },
+      "devDependencies": {
+        "@ai-sdk/openai": "^3.0.0",
+        "@eslint/js": "^9.39.4",
+        "@types/node": "^22.0.0",
+        "ai": "^6.0.0",
+        "eslint": "^9.39.4",
+        "tsup": "^8.3.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0",
+        "typescript-eslint": "^8.61.1",
+        "vitest": "^2.1.0",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "ai": "^6.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.133",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.133.tgz",
+      "integrity": "sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.72",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.72.tgz",
+      "integrity": "sha512-ZF545m6pCXLUTERFfRCyfM7WsG4Nu/A+jlXQjSv7w22dGov02ssB0e1kviI3NLIERfRF/U+n2rKbFuUjzYY7CQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.30.tgz",
+      "integrity": "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@getzep/zep-cloud": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@getzep/zep-cloud/-/zep-cloud-3.23.0.tgz",
+      "integrity": "sha512-Fn/r3drLVOT6T+B0hnsIqIxfRx/vBN/6jWH7XU6Yz8FcD08eZKBOdVrf1s+UHjtZaZ3SbXtVQ9OeXjOU8Mq4hw==",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.61.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.207",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.207.tgz",
+      "integrity": "sha512-9rAHnqU+AvxyqO6WgiWj7hQENX6AprHXZWZEdBWwgnA854D2Mje/PiTmbcFqO+2Cck1lII0NLRQJY9lmdSorMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.133",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/integrations/vercel-ai/typescript/package.json
+++ b/integrations/vercel-ai/typescript/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "@getzep/zep-vercel-ai",
+  "version": "0.1.0",
+  "description": "Zep long-term memory for the Vercel AI SDK — a middleware that injects user context, plain persist/retrieve helpers, and model-callable tools over Zep's temporal Context Graph.",
+  "license": "Apache-2.0",
+  "author": "Zep AI, Inc.",
+  "homepage": "https://www.getzep.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/getzep/zep.git",
+    "directory": "integrations/vercel-ai/typescript"
+  },
+  "bugs": {
+    "url": "https://github.com/getzep/zep/issues"
+  },
+  "keywords": [
+    "zep",
+    "vercel",
+    "ai-sdk",
+    "memory",
+    "agent",
+    "llm",
+    "knowledge-graph",
+    "context",
+    "middleware"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "SETUP.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsup",
+    "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "example": "tsx examples/generate-text.ts",
+    "clean": "rm -rf dist"
+  },
+  "peerDependencies": {
+    "ai": "^6.0.0",
+    "zod": "^3.25.0 || ^4.0.0"
+  },
+  "dependencies": {
+    "@getzep/zep-cloud": "^3.23.0"
+  },
+  "devDependencies": {
+    "@ai-sdk/openai": "^3.0.0",
+    "@eslint/js": "^9.39.4",
+    "@types/node": "^22.0.0",
+    "ai": "^6.0.0",
+    "eslint": "^9.39.4",
+    "tsup": "^8.3.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "typescript-eslint": "^8.61.1",
+    "vitest": "^2.1.0",
+    "zod": "^3.25.0"
+  }
+}

--- a/integrations/vercel-ai/typescript/src/helpers.ts
+++ b/integrations/vercel-ai/typescript/src/helpers.ts
@@ -1,4 +1,5 @@
-import type { ZepClient, Zep } from "@getzep/zep-cloud";
+import { Zep } from "@getzep/zep-cloud";
+import type { ZepClient } from "@getzep/zep-cloud";
 import type { ZepLogger, ZepTurn } from "./types.js";
 import {
   MESSAGE_MAX_CHARS,
@@ -63,9 +64,9 @@ export async function getZepContext(
  * Persist a user/assistant turn to Zep via `thread.addMessages`.
  *
  * This both records conversation history and ingests the turn into the bound
- * user graph. Use it from `streamText`/`generateText`'s `onFinish` callback
- * (the recommended persistence path for streaming, where middleware
- * `wrapGenerate` does not fire):
+ * user graph. It is the building block behind {@link createZepOnFinish}; reach
+ * for it directly when you want to persist a turn by hand (e.g. inside your own
+ * `onFinish`, where `text` is the final assistant text for the whole turn):
  *
  * ```ts
  * const result = streamText({
@@ -77,6 +78,9 @@ export async function getZepContext(
  *   },
  * });
  * ```
+ *
+ * For the common case, prefer {@link createZepOnFinish} — it builds this
+ * callback for you and persists the whole turn exactly once.
  *
  * Over-long content is truncated to Zep's 4,096-char message limit with a
  * warning that logs **lengths only** (never content). A Zep failure is logged
@@ -138,6 +142,105 @@ export async function persistZepTurn(
   }
 }
 
+/**
+ * The minimal shape we read off the AI SDK `onFinish` event: the final,
+ * aggregated assistant text for the whole turn. Both `generateText` and
+ * `streamText` pass an `OnFinishEvent` that carries this (and much more); we
+ * intentionally depend only on `text` so the callback works for both without
+ * coupling to the SDK's heavy generic event type.
+ */
+interface ZepOnFinishEvent {
+  /** The final assistant text for the turn (aggregated across all steps). */
+  readonly text: string;
+}
+
+/** Options for {@link createZepOnFinish}. */
+export interface ZepOnFinishOptions {
+  /** A shared, initialized Zep client. The caller owns its lifecycle. */
+  client: ZepClient;
+  /** The Zep thread that receives the persisted turn. */
+  threadId: string;
+  /**
+   * The user ID for the turn. Optional and not required for persistence
+   * (`thread.addMessages` is scoped by `threadId`); accepted for symmetry with
+   * the rest of the API and for callers that want it in scope.
+   */
+  userId?: string;
+  /**
+   * The user's input for this turn — the `onFinish` event carries only the
+   * assistant text, so supply the user side here. Pass the string directly, or
+   * a resolver if you build the callback once and reuse it across turns. When
+   * omitted, only the assistant message is persisted.
+   */
+  user?: string | ((event: ZepOnFinishEvent) => string | undefined);
+  /** Speaker name recorded on the persisted user message (the user's real name). */
+  userName?: string;
+  /** Name recorded on the persisted assistant message. */
+  assistantName?: string;
+  /** Logger for Zep failures. Defaults to `console`. */
+  logger?: ZepLogger;
+}
+
+/**
+ * Build an AI SDK `onFinish` callback that persists the **whole turn once** to
+ * Zep — the user's input plus the final assistant text from the event.
+ *
+ * This is the verified-correct persistence path for the middleware pattern.
+ * `onFinish` fires exactly **once per turn** with the final aggregated
+ * assistant text (after the entire tool loop completes) for **both**
+ * `generateText` and `streamText`. Persisting here — rather than from a
+ * per-step middleware hook — records exactly one user message and one assistant
+ * message per turn, and never writes the model's intermediate tool-call
+ * preamble into the graph.
+ *
+ * ```ts
+ * const userInput = "What do you know about me?";
+ * const { text } = await generateText({
+ *   model,
+ *   prompt: userInput,
+ *   stopWhen: stepCountIs(5),
+ *   onFinish: createZepOnFinish({ client, threadId, user: userInput, userName: "Jane" }),
+ * });
+ * ```
+ *
+ * Persistence is fire-and-forget at the call site (the returned callback awaits
+ * {@link persistZepTurn} internally, which never throws): a Zep outage degrades
+ * to "turn not persisted" and never crashes or blocks the host call. Over-long
+ * content is truncated to Zep's 4,096-char message limit with a lengths-only
+ * warning.
+ *
+ * @param options - The client, thread, and how to source the user message.
+ * @returns An `onFinish` callback for `generateText`/`streamText`.
+ */
+export function createZepOnFinish(
+  options: ZepOnFinishOptions,
+): (event: ZepOnFinishEvent) => Promise<void> {
+  const { client, threadId } = options;
+  const logger = resolveLogger(options.logger);
+
+  return async (event: ZepOnFinishEvent): Promise<void> => {
+    const assistant = event.text?.trim();
+    const user =
+      typeof options.user === "function" ? options.user(event)?.trim() : options.user?.trim();
+
+    if (!user && !assistant) return;
+
+    await persistZepTurn(
+      client,
+      threadId,
+      {
+        ...(user ? { user } : {}),
+        ...(assistant ? { assistant } : {}),
+        ...(options.userName !== undefined ? { userName: options.userName } : {}),
+        ...(options.assistantName !== undefined
+          ? { assistantName: options.assistantName }
+          : {}),
+      },
+      { logger },
+    );
+  };
+}
+
 /** Options for {@link ensureZepUserAndThread}. */
 export interface EnsureIdentityOptions {
   /** A shared, initialized Zep client. */
@@ -173,28 +276,50 @@ export async function ensureZepUserAndThread(
   const logger = resolveLogger(options.logger);
 
   try {
-    try {
-      await client.user.add({
-        userId,
-        ...(options.firstName !== undefined ? { firstName: options.firstName } : {}),
-        ...(options.lastName !== undefined ? { lastName: options.lastName } : {}),
-        ...(options.email !== undefined ? { email: options.email } : {}),
-      });
-    } catch (error) {
-      // A 409/duplicate means the user already exists — that's fine. Re-raise
-      // only if a subsequent thread.create also fails.
-      logger.debug?.(`[zep] user.add: ${errorMessage(error)} (may already exist)`);
+    await client.user.add({
+      userId,
+      ...(options.firstName !== undefined ? { firstName: options.firstName } : {}),
+      ...(options.lastName !== undefined ? { lastName: options.lastName } : {}),
+      ...(options.email !== undefined ? { email: options.email } : {}),
+    });
+  } catch (error) {
+    if (isAlreadyExists(error)) {
+      // A 409 Conflict means the user already exists — that's fine.
+      logger.debug?.("[zep] user.add: user already exists; continuing.");
+    } else {
+      // Anything else (401 auth, network, 5xx) is a real failure we must not
+      // hide. Surface it but keep going — thread.create may still succeed, and
+      // its own error handling decides the final result.
+      logger.warn(`[zep] user.add failed: ${errorMessage(error)}`);
     }
+  }
 
+  try {
     await client.thread.create({ threadId, userId });
     return true;
   } catch (error) {
-    const message = errorMessage(error);
-    // Treat "already exists" style conflicts as success.
-    if (/exist|conflict|409|duplicate/i.test(message)) {
+    if (isAlreadyExists(error)) {
+      // Thread already exists — treat as success.
       return true;
     }
-    logger.warn(`[zep] Failed to ensure user/thread: ${message}`);
+    logger.warn(`[zep] Failed to ensure thread: ${errorMessage(error)}`);
     return false;
   }
+}
+
+/**
+ * Whether a thrown Zep error is a 409 Conflict (resource already exists).
+ *
+ * Gated on the SDK's typed signal — a {@link Zep.ConflictError} or any error
+ * carrying `statusCode === 409` — rather than a loose message regex, so a 401
+ * (bad key) or a network error is never mistaken for "already exists".
+ */
+function isAlreadyExists(error: unknown): boolean {
+  if (error instanceof Zep.ConflictError) return true;
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "statusCode" in error &&
+    (error as { statusCode?: unknown }).statusCode === 409
+  );
 }

--- a/integrations/vercel-ai/typescript/src/helpers.ts
+++ b/integrations/vercel-ai/typescript/src/helpers.ts
@@ -1,0 +1,200 @@
+import type { ZepClient, Zep } from "@getzep/zep-cloud";
+import type { ZepLogger, ZepTurn } from "./types.js";
+import {
+  MESSAGE_MAX_CHARS,
+  errorMessage,
+  resolveLogger,
+  truncateForZep,
+} from "./zep-utils.js";
+
+/**
+ * Retrieve the prompt-ready **Context Block** for a thread via
+ * `thread.getUserContext`.
+ *
+ * The Context Block is an optimized string (user summary + relevant facts and
+ * entities) assembled from the *whole* user graph, with the thread's most recent
+ * messages used only to focus relevance. Inject it into a system message on
+ * every turn.
+ *
+ * This is the plain-function counterpart to {@link createZepMiddleware} — use it
+ * with `streamText`/`generateText` when you want to set `system:` yourself:
+ *
+ * ```ts
+ * const context = await getZepContext(client, threadId);
+ * const result = streamText({
+ *   model,
+ *   system: context ? `Relevant context:\n${context}` : undefined,
+ *   messages,
+ * });
+ * ```
+ *
+ * A Zep failure is logged (no PII) and returns an empty string; it never throws.
+ *
+ * @param client - A shared, initialized Zep client. The caller owns its lifecycle.
+ * @param threadId - The Zep thread whose user context to fetch.
+ * @param options - Optional `templateId` for custom Context Block formatting and
+ *   a `logger` (defaults to `console`).
+ * @returns The Context Block string, or `""` when unavailable.
+ */
+export async function getZepContext(
+  client: ZepClient,
+  threadId: string,
+  options?: { templateId?: string; logger?: ZepLogger },
+): Promise<string> {
+  const logger = resolveLogger(options?.logger);
+  if (!threadId) {
+    logger.warn("[zep-context] No threadId provided; skipping context retrieval.");
+    return "";
+  }
+
+  try {
+    const response = await client.thread.getUserContext(
+      threadId,
+      options?.templateId ? { templateId: options.templateId } : {},
+    );
+    return response.context?.trim() ?? "";
+  } catch (error) {
+    logger.warn(`[zep-context] Failed to retrieve Zep context: ${errorMessage(error)}`);
+    return "";
+  }
+}
+
+/**
+ * Persist a user/assistant turn to Zep via `thread.addMessages`.
+ *
+ * This both records conversation history and ingests the turn into the bound
+ * user graph. Use it from `streamText`/`generateText`'s `onFinish` callback
+ * (the recommended persistence path for streaming, where middleware
+ * `wrapGenerate` does not fire):
+ *
+ * ```ts
+ * const result = streamText({
+ *   model,
+ *   system: await getZepContext(client, threadId),
+ *   messages,
+ *   onFinish: ({ text }) => {
+ *     void persistZepTurn(client, threadId, { user: userInput, assistant: text });
+ *   },
+ * });
+ * ```
+ *
+ * Over-long content is truncated to Zep's 4,096-char message limit with a
+ * warning that logs **lengths only** (never content). A Zep failure is logged
+ * and reported via the boolean return value rather than thrown.
+ *
+ * @param client - A shared, initialized Zep client.
+ * @param threadId - The Zep thread to append messages to.
+ * @param turn - The user and/or assistant content to persist.
+ * @param options - Optional `returnContext` (fold retrieval into the same
+ *   round-trip) and a `logger`.
+ * @returns The Context Block if `returnContext` was set and the call succeeded,
+ *   otherwise `null`. A `null` return after a failure is logged.
+ */
+export async function persistZepTurn(
+  client: ZepClient,
+  threadId: string,
+  turn: ZepTurn,
+  options?: { returnContext?: boolean; logger?: ZepLogger },
+): Promise<string | null> {
+  const logger = resolveLogger(options?.logger);
+  if (!threadId) {
+    logger.warn("[zep-persist] No threadId provided; skipping persist.");
+    return null;
+  }
+
+  const messages: Zep.Message[] = [];
+  const user = turn.user?.trim();
+  const assistant = turn.assistant?.trim();
+
+  if (user) {
+    messages.push({
+      role: "user",
+      content: truncateForZep(user, MESSAGE_MAX_CHARS, "zep-persist", logger),
+      ...(turn.userName !== undefined ? { name: turn.userName } : {}),
+    });
+  }
+  if (assistant) {
+    messages.push({
+      role: "assistant",
+      content: truncateForZep(assistant, MESSAGE_MAX_CHARS, "zep-persist", logger),
+      ...(turn.assistantName !== undefined ? { name: turn.assistantName } : {}),
+    });
+  }
+
+  if (messages.length === 0) {
+    logger.debug?.("[zep-persist] Nothing to persist (empty user and assistant).");
+    return null;
+  }
+
+  try {
+    const response = await client.thread.addMessages(threadId, {
+      messages,
+      ...(options?.returnContext ? { returnContext: true } : {}),
+    });
+    return response.context?.trim() ?? null;
+  } catch (error) {
+    logger.warn(`[zep-persist] Failed to persist turn to Zep: ${errorMessage(error)}`);
+    return null;
+  }
+}
+
+/** Options for {@link ensureZepUserAndThread}. */
+export interface EnsureIdentityOptions {
+  /** A shared, initialized Zep client. */
+  client: ZepClient;
+  /** The Zep user ID. */
+  userId: string;
+  /** The Zep thread ID to create for this conversation. */
+  threadId: string;
+  /** User's first name — pass a real name to help Zep resolve identity. */
+  firstName?: string;
+  /** User's last name. */
+  lastName?: string;
+  /** User's email. */
+  email?: string;
+  /** Logger for failures. Defaults to `console`. */
+  logger?: ZepLogger;
+}
+
+/**
+ * Idempotently create the Zep user and thread for a conversation.
+ *
+ * Zep requires the user and thread to exist before messages are added. Call this
+ * once, out-of-band, before the first turn (the Zep "create user → create thread"
+ * step). Already-existing resources are treated as success. Failures are logged
+ * (no PII) and reported via the return value rather than thrown.
+ *
+ * @returns `true` if the user and thread are ready, `false` if setup failed.
+ */
+export async function ensureZepUserAndThread(
+  options: EnsureIdentityOptions,
+): Promise<boolean> {
+  const { client, userId, threadId } = options;
+  const logger = resolveLogger(options.logger);
+
+  try {
+    try {
+      await client.user.add({
+        userId,
+        ...(options.firstName !== undefined ? { firstName: options.firstName } : {}),
+        ...(options.lastName !== undefined ? { lastName: options.lastName } : {}),
+        ...(options.email !== undefined ? { email: options.email } : {}),
+      });
+    } catch (error) {
+      // A 409/duplicate means the user already exists — that's fine. Re-raise
+      // only if a subsequent thread.create also fails.
+      logger.debug?.(`[zep] user.add: ${errorMessage(error)} (may already exist)`);
+    }
+
+    await client.thread.create({ threadId, userId });
+    return true;
+  } catch (error) {
+    const message = errorMessage(error);
+    // Treat "already exists" style conflicts as success.
+    if (/exist|conflict|409|duplicate/i.test(message)) {
+      return true;
+    }
+    logger.warn(`[zep] Failed to ensure user/thread: ${message}`);
+    return false;
+  }
+}

--- a/integrations/vercel-ai/typescript/src/index.ts
+++ b/integrations/vercel-ai/typescript/src/index.ts
@@ -1,0 +1,80 @@
+/**
+ * `@getzep/zep-vercel-ai` — Zep long-term memory for the
+ * [Vercel AI SDK](https://ai-sdk.dev) (v6).
+ *
+ * Three layers wrap Zep's two real operations — persist and retrieve — over its
+ * temporal Context Graph, so you can pick the integration point that fits your
+ * call:
+ *
+ * 1. **Middleware** — {@link createZepMiddleware} wraps a language model and
+ *    injects the user's Context Block as a system message on every call (and,
+ *    optionally, persists the turn for non-streaming `generateText`).
+ * 2. **Helpers** — {@link getZepContext} and {@link persistZepTurn} are plain
+ *    functions for the `system:` + `onFinish` pattern, which is the required
+ *    persistence path for `streamText` (where middleware `wrapGenerate` does not
+ *    fire).
+ * 3. **Tools** — {@link createZepTools} returns model-callable
+ *    `tool()`s (`zepSearch`, `zepRemember`, `zepContext`) for retrieve/persist
+ *    inside a tool loop.
+ *
+ * Every layer handles Zep failures gracefully — a Zep outage degrades to "no
+ * memory" and never crashes the host call. Warnings log lengths only, never
+ * content/PII.
+ *
+ * @example Middleware + tools with `generateText`
+ * ```ts
+ * import { ZepClient } from "@getzep/zep-cloud";
+ * import { wrapLanguageModel, generateText, stepCountIs } from "ai";
+ * import { openai } from "@ai-sdk/openai";
+ * import {
+ *   createZepMiddleware,
+ *   createZepTools,
+ *   ensureZepUserAndThread,
+ * } from "@getzep/zep-vercel-ai";
+ *
+ * const client = new ZepClient({ apiKey: process.env.ZEP_API_KEY! });
+ * await ensureZepUserAndThread({ client, userId: "u1", threadId: "t1", firstName: "Jane" });
+ *
+ * const model = wrapLanguageModel({
+ *   model: openai("gpt-4o-mini"),
+ *   middleware: createZepMiddleware({ client, threadId: "t1", persist: true }),
+ * });
+ *
+ * const tools = createZepTools(client, { userId: "u1", threadId: "t1" });
+ * const { text } = await generateText({
+ *   model,
+ *   tools,
+ *   stopWhen: stepCountIs(5),
+ *   prompt: "What do you remember about me?",
+ * });
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+export { createZepMiddleware } from "./middleware.js";
+export type { ZepMiddlewareOptions } from "./middleware.js";
+
+export { getZepContext, persistZepTurn, ensureZepUserAndThread } from "./helpers.js";
+export type { EnsureIdentityOptions } from "./helpers.js";
+
+export {
+  createZepTools,
+  createZepSearchTool,
+  createZepRememberTool,
+  createZepContextTool,
+} from "./tools.js";
+export type {
+  ZepTools,
+  ZepToolsOptions,
+  ZepSearchToolOptions,
+  ZepRememberToolOptions,
+  ZepContextToolOptions,
+} from "./tools.js";
+
+export { toRoleType, resolveGraphTarget, truncateForZep, MESSAGE_MAX_CHARS } from "./zep-utils.js";
+
+export type { ZepBinding, ZepLogger, ZepTurn, RoleType } from "./types.js";
+
+/** Package version. */
+export const VERSION = "0.1.0";

--- a/integrations/vercel-ai/typescript/src/index.ts
+++ b/integrations/vercel-ai/typescript/src/index.ts
@@ -7,27 +7,37 @@
  * call:
  *
  * 1. **Middleware** — {@link createZepMiddleware} wraps a language model and
- *    injects the user's Context Block as a system message on every call (and,
- *    optionally, persists the turn for non-streaming `generateText`).
- * 2. **Helpers** — {@link getZepContext} and {@link persistZepTurn} are plain
- *    functions for the `system:` + `onFinish` pattern, which is the required
- *    persistence path for `streamText` (where middleware `wrapGenerate` does not
- *    fire).
+ *    **injects** the user's Context Block as a system message on each genuine
+ *    new user turn. It is context-injection only; pair it with
+ *    {@link createZepOnFinish} to persist.
+ * 2. **Helpers** — {@link getZepContext}, {@link persistZepTurn}, and
+ *    {@link createZepOnFinish} are plain functions for the `system:` +
+ *    `onFinish` pattern. {@link createZepOnFinish} persists the whole turn once
+ *    per turn (the verified-correct path for both `generateText` and
+ *    `streamText`, since `onFinish` fires exactly once with the final assistant
+ *    text).
  * 3. **Tools** — {@link createZepTools} returns model-callable
  *    `tool()`s (`zepSearch`, `zepRemember`, `zepContext`) for retrieve/persist
  *    inside a tool loop.
+ *
+ * The division of labor: **inject via middleware, persist via `onFinish`.** The
+ * AI SDK tool loop calls the wrapped model once per step, so a per-step
+ * middleware persistence hook would fragment one turn across many writes and
+ * record intermediate tool-call preamble as a real assistant message;
+ * `onFinish` fires exactly once per turn with the final text.
  *
  * Every layer handles Zep failures gracefully — a Zep outage degrades to "no
  * memory" and never crashes the host call. Warnings log lengths only, never
  * content/PII.
  *
- * @example Middleware + tools with `generateText`
+ * @example Middleware (inject) + onFinish (persist) + tools with `generateText`
  * ```ts
  * import { ZepClient } from "@getzep/zep-cloud";
  * import { wrapLanguageModel, generateText, stepCountIs } from "ai";
  * import { openai } from "@ai-sdk/openai";
  * import {
  *   createZepMiddleware,
+ *   createZepOnFinish,
  *   createZepTools,
  *   ensureZepUserAndThread,
  * } from "@getzep/zep-vercel-ai";
@@ -37,15 +47,17 @@
  *
  * const model = wrapLanguageModel({
  *   model: openai("gpt-4o-mini"),
- *   middleware: createZepMiddleware({ client, threadId: "t1", persist: true }),
+ *   middleware: createZepMiddleware({ client, threadId: "t1" }),
  * });
  *
- * const tools = createZepTools(client, { userId: "u1", threadId: "t1" });
+ * const tools = createZepTools(client, { binding: { userId: "u1", threadId: "t1" } });
+ * const prompt = "What do you remember about me?";
  * const { text } = await generateText({
  *   model,
  *   tools,
  *   stopWhen: stepCountIs(5),
- *   prompt: "What do you remember about me?",
+ *   prompt,
+ *   onFinish: createZepOnFinish({ client, threadId: "t1", user: prompt }),
  * });
  * ```
  *
@@ -55,8 +67,13 @@
 export { createZepMiddleware } from "./middleware.js";
 export type { ZepMiddlewareOptions } from "./middleware.js";
 
-export { getZepContext, persistZepTurn, ensureZepUserAndThread } from "./helpers.js";
-export type { EnsureIdentityOptions } from "./helpers.js";
+export {
+  getZepContext,
+  persistZepTurn,
+  createZepOnFinish,
+  ensureZepUserAndThread,
+} from "./helpers.js";
+export type { EnsureIdentityOptions, ZepOnFinishOptions } from "./helpers.js";
 
 export {
   createZepTools,
@@ -72,7 +89,13 @@ export type {
   ZepContextToolOptions,
 } from "./tools.js";
 
-export { toRoleType, resolveGraphTarget, truncateForZep, MESSAGE_MAX_CHARS } from "./zep-utils.js";
+export {
+  toRoleType,
+  resolveGraphTarget,
+  truncateForZep,
+  MESSAGE_MAX_CHARS,
+  GRAPH_MAX_CHARS,
+} from "./zep-utils.js";
 
 export type { ZepBinding, ZepLogger, ZepTurn, RoleType } from "./types.js";
 

--- a/integrations/vercel-ai/typescript/src/middleware.ts
+++ b/integrations/vercel-ai/typescript/src/middleware.ts
@@ -1,0 +1,212 @@
+import type { LanguageModelMiddleware } from "ai";
+import type {
+  LanguageModelV3CallOptions,
+  LanguageModelV3Content,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3Message,
+  LanguageModelV3Prompt,
+} from "@ai-sdk/provider";
+import type { ZepClient } from "@getzep/zep-cloud";
+import type { ZepLogger } from "./types.js";
+import { errorMessage, resolveLogger } from "./zep-utils.js";
+import { getZepContext, persistZepTurn } from "./helpers.js";
+
+/** Options for {@link createZepMiddleware}. */
+export interface ZepMiddlewareOptions {
+  /** A shared, initialized Zep client. The caller owns its lifecycle. */
+  client: ZepClient;
+  /**
+   * The Zep thread that scopes relevance and (when `persist` is on) receives
+   * conversation history. The Context Block is still assembled from the *whole*
+   * user graph; the thread only focuses what's relevant right now.
+   */
+  threadId: string;
+  /**
+   * Persist the user+assistant turn after a **non-streaming** `generateText`
+   * call via `wrapGenerate`.
+   *
+   * Defaults to `false`. Note that `wrapGenerate` does **not** fire for
+   * `streamText` — for streaming you must persist via `onFinish` +
+   * {@link persistZepTurn} (see this package's README and the streaming
+   * example). When `persist` is `true` and the middleware is used with
+   * `streamText`, persistence is silently skipped at the SDK level (this is a
+   * documented limitation, not a bug).
+   */
+  persist?: boolean;
+  /**
+   * How to wrap the retrieved Context Block into the injected system message.
+   * Receives the raw Context Block; return the full system message text.
+   * Defaults to a short labeled block.
+   */
+  formatContext?: (context: string) => string;
+  /**
+   * Optional Zep context template ID for custom Context Block formatting.
+   * When omitted, Zep's default Smart Context Assembly layout is used.
+   */
+  templateId?: string;
+  /** Speaker name recorded on the persisted user message (the user's real name). */
+  userName?: string;
+  /** Name recorded on the persisted assistant message. */
+  assistantName?: string;
+  /** Logger for Zep failures. Defaults to `console`. */
+  logger?: ZepLogger;
+}
+
+/** Default system-message wrapper for an injected Context Block. */
+function defaultFormatContext(context: string): string {
+  return (
+    "The following is relevant long-term memory about the user, retrieved from " +
+    "Zep. Use it to personalize and ground your response.\n\n" +
+    context
+  );
+}
+
+/**
+ * Concatenate the text parts of the most recent `user` message in a provider
+ * prompt. Returns `""` when the last message is not a user message or carries no
+ * text (e.g. a tool result). Non-text parts (files) are ignored.
+ */
+function latestUserText(prompt: LanguageModelV3Prompt): string {
+  for (let i = prompt.length - 1; i >= 0; i--) {
+    const message = prompt[i];
+    if (!message) continue;
+    if (message.role === "user") {
+      return message.content
+        .filter((part): part is { type: "text"; text: string } => part.type === "text")
+        .map((part) => part.text)
+        .join("")
+        .trim();
+    }
+    // Stop at the first non-user message from the end — we only persist the
+    // user turn that triggered this generation.
+    if (message.role === "assistant" || message.role === "tool") {
+      return "";
+    }
+  }
+  return "";
+}
+
+/** Concatenate the text content the model generated in a non-streaming result. */
+function assistantText(content: Array<LanguageModelV3Content>): string {
+  return content
+    .filter((part): part is { type: "text"; text: string } => part.type === "text")
+    .map((part) => part.text)
+    .join("")
+    .trim();
+}
+
+/**
+ * Build a Vercel AI SDK {@link LanguageModelMiddleware} that injects a Zep
+ * Context Block into every model call — and, optionally, persists the turn.
+ *
+ * Wrap any language model with it via `wrapLanguageModel`:
+ *
+ * ```ts
+ * import { wrapLanguageModel, generateText } from "ai";
+ * import { openai } from "@ai-sdk/openai";
+ * import { createZepMiddleware } from "@getzep/zep-vercel-ai";
+ *
+ * const model = wrapLanguageModel({
+ *   model: openai("gpt-4o-mini"),
+ *   middleware: createZepMiddleware({ client, threadId, persist: true }),
+ * });
+ *
+ * const { text } = await generateText({ model, prompt: "What do you know about me?" });
+ * ```
+ *
+ * **What it does**
+ *
+ * - `transformParams` fetches the Context Block (`thread.getUserContext`) and
+ *   prepends it as a `system` message to the provider prompt, on both
+ *   `generate` and `stream` calls.
+ * - When `persist` is enabled, `wrapGenerate` records the user+assistant turn
+ *   via `thread.addMessages` after a **non-streaming** `generateText`.
+ *
+ * **Streaming caveat (important)**
+ *
+ * The AI SDK only calls `wrapGenerate` for `generateText`, never for
+ * `streamText`. Context injection still works for streaming (it runs in
+ * `transformParams`), but **persistence does not** — for `streamText` you must
+ * persist the turn yourself from `onFinish` using {@link persistZepTurn}. This
+ * limitation is by design in the SDK; the middleware does not silently pretend
+ * otherwise.
+ *
+ * All Zep failures are caught and logged (lengths only — never content/PII); a
+ * Zep outage degrades to "no context / no persistence" and never crashes the
+ * host call.
+ */
+export function createZepMiddleware(
+  options: ZepMiddlewareOptions,
+): LanguageModelMiddleware {
+  const { client, threadId } = options;
+  const logger = resolveLogger(options.logger);
+  const format = options.formatContext ?? defaultFormatContext;
+  const persist = options.persist ?? false;
+
+  return {
+    specificationVersion: "v3",
+
+    transformParams: async ({
+      params,
+    }: {
+      type: "generate" | "stream";
+      params: LanguageModelV3CallOptions;
+    }): Promise<LanguageModelV3CallOptions> => {
+      try {
+        const context = await getZepContext(client, threadId, {
+          ...(options.templateId !== undefined ? { templateId: options.templateId } : {}),
+          logger,
+        });
+        if (context) {
+          const systemMessage: LanguageModelV3Message = {
+            role: "system",
+            content: format(context),
+          };
+          // Prepend so any existing system instructions follow the memory block.
+          params.prompt.unshift(systemMessage);
+        }
+      } catch (error) {
+        // getZepContext already degrades gracefully; this guards the unshift too.
+        logger.warn(`[zep-middleware] Context injection skipped: ${errorMessage(error)}`);
+      }
+      return params;
+    },
+
+    wrapGenerate: async ({
+      doGenerate,
+      params,
+    }: {
+      doGenerate: () => PromiseLike<LanguageModelV3GenerateResult>;
+      params: LanguageModelV3CallOptions;
+    }): Promise<LanguageModelV3GenerateResult> => {
+      const result = await doGenerate();
+
+      if (persist) {
+        try {
+          const user = latestUserText(params.prompt);
+          const assistant = assistantText(result.content);
+          if (user || assistant) {
+            await persistZepTurn(
+              client,
+              threadId,
+              {
+                ...(user ? { user } : {}),
+                ...(assistant ? { assistant } : {}),
+                ...(options.userName !== undefined ? { userName: options.userName } : {}),
+                ...(options.assistantName !== undefined
+                  ? { assistantName: options.assistantName }
+                  : {}),
+              },
+              { logger },
+            );
+          }
+        } catch (error) {
+          // persistZepTurn already degrades gracefully; double-guard anyway.
+          logger.warn(`[zep-middleware] Persist skipped: ${errorMessage(error)}`);
+        }
+      }
+
+      return result;
+    },
+  };
+}

--- a/integrations/vercel-ai/typescript/src/middleware.ts
+++ b/integrations/vercel-ai/typescript/src/middleware.ts
@@ -1,38 +1,24 @@
 import type { LanguageModelMiddleware } from "ai";
 import type {
   LanguageModelV3CallOptions,
-  LanguageModelV3Content,
-  LanguageModelV3GenerateResult,
   LanguageModelV3Message,
   LanguageModelV3Prompt,
 } from "@ai-sdk/provider";
 import type { ZepClient } from "@getzep/zep-cloud";
 import type { ZepLogger } from "./types.js";
 import { errorMessage, resolveLogger } from "./zep-utils.js";
-import { getZepContext, persistZepTurn } from "./helpers.js";
+import { getZepContext } from "./helpers.js";
 
 /** Options for {@link createZepMiddleware}. */
 export interface ZepMiddlewareOptions {
   /** A shared, initialized Zep client. The caller owns its lifecycle. */
   client: ZepClient;
   /**
-   * The Zep thread that scopes relevance and (when `persist` is on) receives
-   * conversation history. The Context Block is still assembled from the *whole*
-   * user graph; the thread only focuses what's relevant right now.
+   * The Zep thread that scopes relevance for the injected Context Block. The
+   * block is still assembled from the *whole* user graph; the thread only
+   * focuses what's relevant right now.
    */
   threadId: string;
-  /**
-   * Persist the user+assistant turn after a **non-streaming** `generateText`
-   * call via `wrapGenerate`.
-   *
-   * Defaults to `false`. Note that `wrapGenerate` does **not** fire for
-   * `streamText` — for streaming you must persist via `onFinish` +
-   * {@link persistZepTurn} (see this package's README and the streaming
-   * example). When `persist` is `true` and the middleware is used with
-   * `streamText`, persistence is silently skipped at the SDK level (this is a
-   * documented limitation, not a bug).
-   */
-  persist?: boolean;
   /**
    * How to wrap the retrieved Context Block into the injected system message.
    * Receives the raw Context Block; return the full system message text.
@@ -44,10 +30,6 @@ export interface ZepMiddlewareOptions {
    * When omitted, Zep's default Smart Context Assembly layout is used.
    */
   templateId?: string;
-  /** Speaker name recorded on the persisted user message (the user's real name). */
-  userName?: string;
-  /** Name recorded on the persisted assistant message. */
-  assistantName?: string;
   /** Logger for Zep failures. Defaults to `console`. */
   logger?: ZepLogger;
 }
@@ -62,78 +44,74 @@ function defaultFormatContext(context: string): string {
 }
 
 /**
- * Concatenate the text parts of the most recent `user` message in a provider
- * prompt. Returns `""` when the last message is not a user message or carries no
- * text (e.g. a tool result). Non-text parts (files) are ignored.
+ * Decide whether the current provider prompt represents a *genuine new user
+ * turn* — the one moment we want to (re)fetch and inject the Context Block.
+ *
+ * The AI SDK tool loop calls the wrapped model once per step. The first step of
+ * a turn ends with the user's message; every continuation step ends with a
+ * `tool` result (or an `assistant` tool-call message). Injecting on every step
+ * would re-fetch the Context Block N times per turn and stack N system messages
+ * onto the prompt. So we inject only when the LAST message is from the user.
  */
-function latestUserText(prompt: LanguageModelV3Prompt): string {
+function isNewUserTurn(prompt: LanguageModelV3Prompt): boolean {
   for (let i = prompt.length - 1; i >= 0; i--) {
     const message = prompt[i];
     if (!message) continue;
-    if (message.role === "user") {
-      return message.content
-        .filter((part): part is { type: "text"; text: string } => part.type === "text")
-        .map((part) => part.text)
-        .join("")
-        .trim();
-    }
-    // Stop at the first non-user message from the end — we only persist the
-    // user turn that triggered this generation.
-    if (message.role === "assistant" || message.role === "tool") {
-      return "";
-    }
+    return message.role === "user";
   }
-  return "";
-}
-
-/** Concatenate the text content the model generated in a non-streaming result. */
-function assistantText(content: Array<LanguageModelV3Content>): string {
-  return content
-    .filter((part): part is { type: "text"; text: string } => part.type === "text")
-    .map((part) => part.text)
-    .join("")
-    .trim();
+  return false;
 }
 
 /**
  * Build a Vercel AI SDK {@link LanguageModelMiddleware} that injects a Zep
- * Context Block into every model call — and, optionally, persists the turn.
+ * Context Block as a leading `system` message on each genuine new user turn.
  *
- * Wrap any language model with it via `wrapLanguageModel`:
+ * This middleware is **context-injection only**. It does not persist anything —
+ * persistence is handled once per turn from `onFinish` (see
+ * {@link createZepOnFinish}). Wrap any language model with it via
+ * `wrapLanguageModel`, and pair it with `createZepOnFinish` on your
+ * `generateText`/`streamText` call:
  *
  * ```ts
- * import { wrapLanguageModel, generateText } from "ai";
+ * import { wrapLanguageModel, generateText, stepCountIs } from "ai";
  * import { openai } from "@ai-sdk/openai";
- * import { createZepMiddleware } from "@getzep/zep-vercel-ai";
+ * import { createZepMiddleware, createZepOnFinish } from "@getzep/zep-vercel-ai";
  *
  * const model = wrapLanguageModel({
  *   model: openai("gpt-4o-mini"),
- *   middleware: createZepMiddleware({ client, threadId, persist: true }),
+ *   middleware: createZepMiddleware({ client, threadId }),
  * });
  *
- * const { text } = await generateText({ model, prompt: "What do you know about me?" });
+ * const { text } = await generateText({
+ *   model,
+ *   prompt: "What do you know about me?",
+ *   stopWhen: stepCountIs(5),
+ *   onFinish: createZepOnFinish({ client, threadId }),
+ * });
  * ```
  *
  * **What it does**
  *
  * - `transformParams` fetches the Context Block (`thread.getUserContext`) and
- *   prepends it as a `system` message to the provider prompt, on both
- *   `generate` and `stream` calls.
- * - When `persist` is enabled, `wrapGenerate` records the user+assistant turn
- *   via `thread.addMessages` after a **non-streaming** `generateText`.
+ *   prepends it as a `system` message to the provider prompt — on both
+ *   `generate` and `stream` calls — but **only on a genuine new user turn**
+ *   (detected by the last prompt message being a `user` message). On tool-loop
+ *   continuation steps (whose last message is a `tool` result or an `assistant`
+ *   tool call) it injects nothing, so the Context Block is fetched at most once
+ *   per turn rather than once per step.
  *
- * **Streaming caveat (important)**
+ * **Why injection-only**
  *
- * The AI SDK only calls `wrapGenerate` for `generateText`, never for
- * `streamText`. Context injection still works for streaming (it runs in
- * `transformParams`), but **persistence does not** — for `streamText` you must
- * persist the turn yourself from `onFinish` using {@link persistZepTurn}. This
- * limitation is by design in the SDK; the middleware does not silently pretend
- * otherwise.
+ * The AI SDK tool loop calls the wrapped model's `doGenerate` once per step, so
+ * a `wrapGenerate`-based persistence hook would fire once per step and fragment
+ * a single user+assistant turn across multiple `thread.addMessages` calls —
+ * writing the model's intermediate tool-call preamble into the user graph as a
+ * real assistant message. `onFinish` fires exactly once per turn with the final
+ * assistant text (for both `generateText` and `streamText`), so persistence
+ * lives there. See {@link createZepOnFinish}.
  *
  * All Zep failures are caught and logged (lengths only — never content/PII); a
- * Zep outage degrades to "no context / no persistence" and never crashes the
- * host call.
+ * Zep outage degrades to "no context" and never crashes the host call.
  */
 export function createZepMiddleware(
   options: ZepMiddlewareOptions,
@@ -141,7 +119,6 @@ export function createZepMiddleware(
   const { client, threadId } = options;
   const logger = resolveLogger(options.logger);
   const format = options.formatContext ?? defaultFormatContext;
-  const persist = options.persist ?? false;
 
   return {
     specificationVersion: "v3",
@@ -152,6 +129,13 @@ export function createZepMiddleware(
       type: "generate" | "stream";
       params: LanguageModelV3CallOptions;
     }): Promise<LanguageModelV3CallOptions> => {
+      // Only inject on a genuine new user turn. On tool-loop continuation steps
+      // (last message is a tool result or assistant tool call) we skip, so the
+      // Context Block is fetched at most once per turn.
+      if (!isNewUserTurn(params.prompt)) {
+        return params;
+      }
+
       try {
         const context = await getZepContext(client, threadId, {
           ...(options.templateId !== undefined ? { templateId: options.templateId } : {}),
@@ -170,43 +154,6 @@ export function createZepMiddleware(
         logger.warn(`[zep-middleware] Context injection skipped: ${errorMessage(error)}`);
       }
       return params;
-    },
-
-    wrapGenerate: async ({
-      doGenerate,
-      params,
-    }: {
-      doGenerate: () => PromiseLike<LanguageModelV3GenerateResult>;
-      params: LanguageModelV3CallOptions;
-    }): Promise<LanguageModelV3GenerateResult> => {
-      const result = await doGenerate();
-
-      if (persist) {
-        try {
-          const user = latestUserText(params.prompt);
-          const assistant = assistantText(result.content);
-          if (user || assistant) {
-            await persistZepTurn(
-              client,
-              threadId,
-              {
-                ...(user ? { user } : {}),
-                ...(assistant ? { assistant } : {}),
-                ...(options.userName !== undefined ? { userName: options.userName } : {}),
-                ...(options.assistantName !== undefined
-                  ? { assistantName: options.assistantName }
-                  : {}),
-              },
-              { logger },
-            );
-          }
-        } catch (error) {
-          // persistZepTurn already degrades gracefully; double-guard anyway.
-          logger.warn(`[zep-middleware] Persist skipped: ${errorMessage(error)}`);
-        }
-      }
-
-      return result;
     },
   };
 }

--- a/integrations/vercel-ai/typescript/src/tools.ts
+++ b/integrations/vercel-ai/typescript/src/tools.ts
@@ -4,11 +4,13 @@ import { z } from "zod";
 import type { ZepClient, Zep } from "@getzep/zep-cloud";
 import type { ZepBinding, ZepLogger } from "./types.js";
 import {
+  GRAPH_MAX_CHARS,
   MESSAGE_MAX_CHARS,
   errorMessage,
   resolveGraphTarget,
   resolveLogger,
   toRoleType,
+  truncateForZep,
 } from "./zep-utils.js";
 
 /** Options shared by every tool factory. */
@@ -236,20 +238,13 @@ export function createZepRememberTool(options: ZepRememberToolOptions) {
 
       try {
         // Conversational content with a bound thread + user → thread.addMessages.
+        // Capped at Zep's 4,096-char message limit.
         if (role && threadId && binding.userId) {
-          const messageContent =
-            trimmed.length > MESSAGE_MAX_CHARS ? trimmed.slice(0, MESSAGE_MAX_CHARS) : trimmed;
-          if (trimmed.length > MESSAGE_MAX_CHARS) {
-            logger.warn(
-              `[zep-remember] Content length ${trimmed.length} exceeds Zep limit ` +
-                `${MESSAGE_MAX_CHARS}; truncating to ${MESSAGE_MAX_CHARS} characters.`,
-            );
-          }
           await client.thread.addMessages(threadId, {
             messages: [
               {
-                role: toRoleType(role),
-                content: messageContent,
+                role: toRoleType(role, logger),
+                content: truncateForZep(trimmed, MESSAGE_MAX_CHARS, "zep-remember", logger),
                 ...(options.defaultMessageName !== undefined
                   ? { name: options.defaultMessageName }
                   : {}),
@@ -259,8 +254,13 @@ export function createZepRememberTool(options: ZepRememberToolOptions) {
           return { stored: true, message: "Saved to conversation memory." };
         }
 
-        // Everything else → graph.add as text.
-        await client.graph.add({ ...target, type: "text", data: trimmed });
+        // Everything else → graph.add as text. Capped at Zep's 10,000-char
+        // graph.add limit (never silently dropped — truncate with a warning).
+        await client.graph.add({
+          ...target,
+          type: "text",
+          data: truncateForZep(trimmed, GRAPH_MAX_CHARS, "zep-remember", logger),
+        });
         return { stored: true, message: "Saved to long-term memory." };
       } catch (error) {
         logger.warn(`[zep-remember] Failed to persist to Zep: ${errorMessage(error)}`);

--- a/integrations/vercel-ai/typescript/src/tools.ts
+++ b/integrations/vercel-ai/typescript/src/tools.ts
@@ -1,0 +1,392 @@
+import { tool } from "ai";
+import type { ToolSet } from "ai";
+import { z } from "zod";
+import type { ZepClient, Zep } from "@getzep/zep-cloud";
+import type { ZepBinding, ZepLogger } from "./types.js";
+import {
+  MESSAGE_MAX_CHARS,
+  errorMessage,
+  resolveGraphTarget,
+  resolveLogger,
+  toRoleType,
+} from "./zep-utils.js";
+
+/** Options shared by every tool factory. */
+interface BaseToolOptions {
+  /** A shared, initialized Zep client. The caller owns its lifecycle. */
+  client: ZepClient;
+  /** Logger for Zep failures. Defaults to `console`. */
+  logger?: ZepLogger;
+}
+
+/** Options for {@link createZepSearchTool}. */
+export interface ZepSearchToolOptions extends BaseToolOptions {
+  /** The graph to search — a user graph (`userId`) or standalone graph (`graphId`). */
+  binding: ZepBinding;
+  /** Override the tool description shown to the model. */
+  description?: string;
+  /**
+   * Fixed search scope. Defaults to `"edges"` (facts/relationships), the most
+   * useful scope for an agent recalling discrete claims. Pinning a scope hides
+   * it from the model so it cannot choose a less useful one.
+   */
+  scope?: Zep.GraphSearchScope;
+  /** Maximum number of results to retrieve (Zep caps non-auto scopes at 50). */
+  limit?: number;
+  /** Optional reranker (default Zep RRF). */
+  reranker?: Zep.Reranker;
+  /** Optional Zep search filters (entity/edge types, properties, dates). */
+  searchFilters?: Zep.SearchFilters;
+}
+
+/** Options for {@link createZepRememberTool}. */
+export interface ZepRememberToolOptions extends BaseToolOptions {
+  /**
+   * The graph this tool writes to, plus the thread used to record conversation.
+   *
+   * - When `threadId` and `userId` are present, conversational content (a
+   *   `role` is supplied) is persisted via `thread.addMessages` (records history
+   *   *and* ingests into the user graph). Non-conversational data always uses
+   *   `graph.add`.
+   * - When only `graphId` (or `userId` without a thread) is present, everything
+   *   is ingested via `graph.add`.
+   */
+  binding: ZepBinding & { threadId?: string };
+  /** Override the tool description shown to the model. */
+  description?: string;
+  /** Default `name` recorded on conversational messages (e.g. the user's real name). */
+  defaultMessageName?: string;
+}
+
+/** Options for {@link createZepContextTool}. */
+export interface ZepContextToolOptions extends BaseToolOptions {
+  /**
+   * The thread whose Context Block to fetch. The block is assembled from the
+   * **entire user graph**; the thread only scopes relevance.
+   */
+  threadId: string;
+  /** Override the tool description shown to the model. */
+  description?: string;
+  /** Optional Zep context template ID for custom Context Block formatting. */
+  templateId?: string;
+}
+
+const searchInputSchema = z.object({
+  query: z
+    .string()
+    .min(1)
+    .max(400)
+    .describe(
+      "What to look up in long-term memory (max 400 characters). Phrase it as " +
+        "the information you need, e.g. 'where the user lives'.",
+    ),
+});
+
+const rememberInputSchema = z.object({
+  content: z
+    .string()
+    .min(1)
+    .describe("The fact, message, or piece of information to remember."),
+  role: z
+    .string()
+    .optional()
+    .describe(
+      "Who the content is from when it is a conversational message: 'user', " +
+        "'assistant', 'system', 'tool', or 'function'. Omit for general facts.",
+    ),
+});
+
+const contextInputSchema = z.object({});
+
+/** Format a node-like result ("name: summary" or just "name"). */
+function nameAndSummary(n: { name?: string; summary?: string }): string | undefined {
+  if (!n.name) return undefined;
+  return n.summary ? `${n.name}: ${n.summary}` : n.name;
+}
+
+const isNonEmpty = (s: string | undefined): s is string => Boolean(s);
+
+/**
+ * Extract human-readable strings from a Zep search result for the active scope.
+ *
+ * The switch is exhaustive over every {@link Zep.GraphSearchScope}; the `never`
+ * default makes a new SDK scope a compile error rather than a silently-empty
+ * result.
+ */
+function extractResults(
+  result: Zep.GraphSearchResults,
+  scope: Zep.GraphSearchScope,
+): string[] {
+  switch (scope) {
+    case "auto": {
+      const ctx = result.context?.trim();
+      return ctx ? [ctx] : [];
+    }
+    case "edges":
+      return (result.edges ?? []).map((e) => e.fact).filter(isNonEmpty);
+    case "nodes":
+      return (result.nodes ?? []).map(nameAndSummary).filter(isNonEmpty);
+    case "episodes":
+      return (result.episodes ?? []).map((e) => e.content).filter(isNonEmpty);
+    case "thread_summaries":
+      return (result.threadSummaries ?? []).map(nameAndSummary).filter(isNonEmpty);
+    case "observations":
+      return (result.observations ?? []).map(nameAndSummary).filter(isNonEmpty);
+    default: {
+      const _exhaustive: never = scope;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Build a model-callable AI SDK tool that **searches** the bound Zep graph and
+ * returns relevant facts.
+ *
+ * Drop it into `generateText`/`streamText`'s `tools` record so the model can
+ * decide *when* and *what* to recall during a tool loop. Scope, limit, reranker,
+ * and filters are pinned at construction and hidden from the model.
+ *
+ * A Zep failure is logged (no PII) and returned as `found: false` with an empty
+ * list; it never throws.
+ */
+export function createZepSearchTool(options: ZepSearchToolOptions) {
+  const { client, binding } = options;
+  const logger = resolveLogger(options.logger);
+  const target = resolveGraphTarget(binding);
+  const scope: Zep.GraphSearchScope = options.scope ?? "edges";
+
+  return tool({
+    description:
+      options.description ??
+      "Search long-term memory for facts about the user or domain learned in " +
+        "previous turns or conversations. Use this to recall specific details " +
+        "the user shared before.",
+    inputSchema: searchInputSchema,
+    execute: async ({ query }): Promise<{ facts: string[]; found: boolean }> => {
+      const trimmed = query?.trim();
+      if (!trimmed) return { facts: [], found: false };
+      if (!target) {
+        logger.warn("[zep-search] No userId or graphId bound; skipping search.");
+        return { facts: [], found: false };
+      }
+
+      try {
+        const request: Zep.GraphSearchQuery = {
+          ...target,
+          query: trimmed,
+          scope,
+          ...(options.limit !== undefined ? { limit: options.limit } : {}),
+          ...(options.reranker !== undefined ? { reranker: options.reranker } : {}),
+          ...(options.searchFilters !== undefined
+            ? { searchFilters: options.searchFilters }
+            : {}),
+        };
+        const result = await client.graph.search(request);
+        const facts = extractResults(result, scope);
+        return { facts, found: facts.length > 0 };
+      } catch (error) {
+        logger.warn(`[zep-search] Zep graph search failed: ${errorMessage(error)}`);
+        return { facts: [], found: false };
+      }
+    },
+  });
+}
+
+/**
+ * Build a model-callable AI SDK tool that **persists** information into Zep.
+ *
+ * Conversational content (a `role` is provided and a thread + user are bound) is
+ * written with `thread.addMessages`, which records history and ingests into the
+ * user graph. Everything else is ingested with `graph.add` (`type: "text"`).
+ *
+ * Zep ingestion is **asynchronous**: a just-stored fact is not instantly
+ * retrievable. The tool reports success once Zep accepts the data.
+ *
+ * Over-long content is truncated (lengths-only warning, never content). A Zep
+ * failure is logged and surfaced as `stored: false`; it never throws.
+ */
+export function createZepRememberTool(options: ZepRememberToolOptions) {
+  const { client, binding } = options;
+  const logger = resolveLogger(options.logger);
+  const target = resolveGraphTarget(binding);
+  const threadId = binding.threadId;
+
+  return tool({
+    description:
+      options.description ??
+      "Persist a fact, preference, or message to long-term memory so it can be " +
+        "recalled in future turns and future conversations.",
+    inputSchema: rememberInputSchema,
+    execute: async ({
+      content,
+      role,
+    }): Promise<{ stored: boolean; message: string }> => {
+      const trimmed = content?.trim();
+      if (!trimmed) {
+        return { stored: false, message: "Nothing to remember: content was empty." };
+      }
+      if (!target) {
+        logger.warn("[zep-remember] No userId or graphId bound; skipping persist.");
+        return {
+          stored: false,
+          message: "Memory is not configured (no user or graph bound).",
+        };
+      }
+
+      try {
+        // Conversational content with a bound thread + user → thread.addMessages.
+        if (role && threadId && binding.userId) {
+          const messageContent =
+            trimmed.length > MESSAGE_MAX_CHARS ? trimmed.slice(0, MESSAGE_MAX_CHARS) : trimmed;
+          if (trimmed.length > MESSAGE_MAX_CHARS) {
+            logger.warn(
+              `[zep-remember] Content length ${trimmed.length} exceeds Zep limit ` +
+                `${MESSAGE_MAX_CHARS}; truncating to ${MESSAGE_MAX_CHARS} characters.`,
+            );
+          }
+          await client.thread.addMessages(threadId, {
+            messages: [
+              {
+                role: toRoleType(role),
+                content: messageContent,
+                ...(options.defaultMessageName !== undefined
+                  ? { name: options.defaultMessageName }
+                  : {}),
+              },
+            ],
+          });
+          return { stored: true, message: "Saved to conversation memory." };
+        }
+
+        // Everything else → graph.add as text.
+        await client.graph.add({ ...target, type: "text", data: trimmed });
+        return { stored: true, message: "Saved to long-term memory." };
+      } catch (error) {
+        logger.warn(`[zep-remember] Failed to persist to Zep: ${errorMessage(error)}`);
+        return {
+          stored: false,
+          message: "Could not save to memory right now; continuing without it.",
+        };
+      }
+    },
+  });
+}
+
+/**
+ * Build a model-callable AI SDK tool that returns the **Context Block** for the
+ * bound user via `thread.getUserContext`.
+ *
+ * One call returns a prompt-ready string (user summary + relevant facts and
+ * entities) assembled from the *whole* user graph, with the thread's most recent
+ * messages used to focus relevance. It is the tool-callable counterpart to
+ * {@link createZepMiddleware}'s system-message injection — useful when you want
+ * the model to pull in context on demand inside a tool loop.
+ *
+ * A Zep failure is logged (no PII) and returned as `found: false` with an empty
+ * string; it never throws.
+ */
+export function createZepContextTool(options: ZepContextToolOptions) {
+  const { client, threadId } = options;
+  const logger = resolveLogger(options.logger);
+
+  return tool({
+    description:
+      options.description ??
+      "Retrieve everything currently known about the user — a summary plus " +
+        "relevant facts from previous conversations — to ground your response.",
+    inputSchema: contextInputSchema,
+    execute: async (): Promise<{ context: string; found: boolean }> => {
+      if (!threadId) {
+        logger.warn("[zep-context] No threadId bound; skipping context retrieval.");
+        return { context: "", found: false };
+      }
+      try {
+        const response = await client.thread.getUserContext(
+          threadId,
+          options.templateId ? { templateId: options.templateId } : {},
+        );
+        const context = response.context?.trim() ?? "";
+        return { context, found: context.length > 0 };
+      } catch (error) {
+        logger.warn(`[zep-context] Failed to retrieve Zep context: ${errorMessage(error)}`);
+        return { context: "", found: false };
+      }
+    },
+  });
+}
+
+/** Options for {@link createZepTools}. */
+export interface ZepToolsOptions extends Omit<BaseToolOptions, "client"> {
+  /**
+   * Identity + thread binding. For a personalized conversational agent supply
+   * `userId` and `threadId`; for a shared knowledge base supply `graphId`.
+   * `zepContext` requires a `threadId`; without one it returns a graceful empty
+   * result.
+   */
+  binding: ZepBinding & { threadId?: string };
+  /** Pin the search scope (default `"edges"`). */
+  searchScope?: Zep.GraphSearchScope;
+  /** Pin the search result limit. */
+  searchLimit?: number;
+  /** Default speaker name recorded on conversational messages persisted by `zepRemember`. */
+  defaultMessageName?: string;
+}
+
+/**
+ * The Zep tool set, keyed for direct spread into a `generateText`/`streamText`
+ * `tools` record:
+ *
+ * ```ts
+ * const tools = createZepTools(client, { userId, threadId });
+ * await generateText({ model, prompt, tools, stopWhen: stepCountIs(5) });
+ * ```
+ */
+export type ZepTools = ToolSet & {
+  /** Search the bound graph for relevant facts (`graph.search`). */
+  zepSearch: ReturnType<typeof createZepSearchTool>;
+  /** Persist a message or fact (`thread.addMessages` / `graph.add`). */
+  zepRemember: ReturnType<typeof createZepRememberTool>;
+  /** Retrieve the whole-user-graph Context Block (`thread.getUserContext`). */
+  zepContext: ReturnType<typeof createZepContextTool>;
+};
+
+/**
+ * Build the full set of Zep tools bound to a single client and binding.
+ *
+ * Spread the result into a `generateText`/`streamText` `tools` record. Each tool
+ * handles Zep failures gracefully and never throws — a memory outage cannot
+ * crash the host call. `zepContext` is included only when a `threadId` is bound
+ * (it has no meaning without one).
+ *
+ * @param client - A shared, initialized Zep client.
+ * @param options - The binding plus optional search/persist configuration.
+ */
+export function createZepTools(client: ZepClient, options: ZepToolsOptions): ZepTools {
+  const { binding } = options;
+  const logger = resolveLogger(options.logger);
+
+  const tools = {
+    zepSearch: createZepSearchTool({
+      client,
+      binding,
+      ...(options.searchScope !== undefined ? { scope: options.searchScope } : {}),
+      ...(options.searchLimit !== undefined ? { limit: options.searchLimit } : {}),
+      logger,
+    }),
+    zepRemember: createZepRememberTool({
+      client,
+      binding,
+      ...(options.defaultMessageName !== undefined
+        ? { defaultMessageName: options.defaultMessageName }
+        : {}),
+      logger,
+    }),
+    zepContext: createZepContextTool({
+      client,
+      threadId: binding.threadId ?? "",
+      logger,
+    }),
+  };
+  return tools as ZepTools;
+}

--- a/integrations/vercel-ai/typescript/src/types.ts
+++ b/integrations/vercel-ai/typescript/src/types.ts
@@ -1,0 +1,60 @@
+import type { Zep } from "@getzep/zep-cloud";
+
+/**
+ * A binding identifies *which* Zep graph the tools read from and write to.
+ *
+ * Exactly one of {@link userId} or {@link graphId} should be supplied:
+ *
+ * - `userId` targets a **user graph** — the home for personalized agent memory.
+ *   This is the right choice for a conversational agent that remembers an end
+ *   user across sessions. User graphs carry a user summary and fuse every thread
+ *   and business record for that user into one picture.
+ * - `graphId` targets a **standalone graph** — shared or domain knowledge (a
+ *   product knowledge base, runbooks, etc.). Standalone graphs have no user node
+ *   and no user summary.
+ *
+ * If both are supplied, `userId` wins. If neither is supplied a tool surfaces a
+ * graceful result to the model rather than throwing.
+ */
+export interface ZepBinding {
+  /** The Zep user ID whose user graph the tools operate on. */
+  userId?: string;
+  /** The Zep standalone graph ID the tools operate on. */
+  graphId?: string;
+}
+
+/**
+ * Logger interface compatible with `console` and most structured loggers.
+ *
+ * Nothing in this package throws on a Zep failure; it logs a warning through
+ * this interface and degrades gracefully. Defaults to `console`.
+ *
+ * **PII rule:** callers and this package only ever log *lengths and counts*
+ * through `warn`/`debug` — never message content or user data.
+ */
+export interface ZepLogger {
+  warn: (message: string, ...args: unknown[]) => void;
+  debug?: (message: string, ...args: unknown[]) => void;
+}
+
+/** Re-export of Zep's closed role enum for convenience. */
+export type RoleType = Zep.RoleType;
+
+/**
+ * A single conversational turn to persist to Zep: the user's input and the
+ * assistant's reply. Either side may be omitted (e.g. persist only the user
+ * message up front, or only the assistant message after generation).
+ */
+export interface ZepTurn {
+  /** The user's message content for this turn. */
+  user?: string;
+  /** The assistant's reply content for this turn. */
+  assistant?: string;
+  /**
+   * Optional speaker name recorded on the user message (e.g. the end user's
+   * real name). Passing a real name helps Zep resolve identity in the graph.
+   */
+  userName?: string;
+  /** Optional name recorded on the assistant message. */
+  assistantName?: string;
+}

--- a/integrations/vercel-ai/typescript/src/zep-utils.ts
+++ b/integrations/vercel-ai/typescript/src/zep-utils.ts
@@ -25,11 +25,19 @@ const ROLE_ALIASES: Record<string, Zep.RoleType> = {
  * Coerce an arbitrary role string into a valid Zep {@link Zep.RoleType}.
  *
  * @param role - A role string from the host framework (case-insensitive).
+ * @param logger - Optional logger; when supplied, an unknown role coerced to
+ *   `"norole"` is logged at debug with the role **name only** (never content).
  * @returns A valid `RoleType`; defaults to `"norole"` for unknown input.
  */
-export function toRoleType(role: string | undefined): Zep.RoleType {
+export function toRoleType(role: string | undefined, logger?: ZepLogger): Zep.RoleType {
   if (!role) return "norole";
-  return ROLE_ALIASES[role.trim().toLowerCase()] ?? "norole";
+  const mapped = ROLE_ALIASES[role.trim().toLowerCase()];
+  if (mapped === undefined) {
+    // Role name only — no content/PII.
+    logger?.debug?.(`[zep] Unknown role '${role}' coerced to 'norole'.`);
+    return "norole";
+  }
+  return mapped;
 }
 
 /**
@@ -72,9 +80,18 @@ export function resolveLogger(logger: ZepLogger | undefined): ZepLogger {
 
 /**
  * Zep rejects messages longer than 4,096 characters with a 400. We truncate a
- * bit below that to leave headroom for any server-side normalization.
+ * bit below that to leave headroom for any server-side normalization. This
+ * applies to the conversational `thread.addMessages` path.
  */
 export const MESSAGE_MAX_CHARS = 4000;
+
+/**
+ * Zep's `graph.add` endpoint rejects `data` longer than 10,000 characters with
+ * a 400. We truncate a bit below that to leave headroom. This applies to the
+ * non-conversational `graph.add` path (larger documents/business data than the
+ * conversational message limit).
+ */
+export const GRAPH_MAX_CHARS = 9900;
 
 /**
  * Truncate `content` to `maxChars` if it exceeds the limit, logging a warning.

--- a/integrations/vercel-ai/typescript/src/zep-utils.ts
+++ b/integrations/vercel-ai/typescript/src/zep-utils.ts
@@ -1,0 +1,105 @@
+import type { Zep } from "@getzep/zep-cloud";
+import type { ZepBinding, ZepLogger } from "./types.js";
+
+/**
+ * The Zep `RoleType` enum is closed (`user | assistant | system | tool |
+ * function | norole`). Host frameworks often use looser role strings, so we map
+ * common aliases onto the valid set and fall back to `norole` for anything we
+ * don't recognize (rather than letting an invalid role reach the API).
+ */
+const ROLE_ALIASES: Record<string, Zep.RoleType> = {
+  user: "user",
+  human: "user",
+  assistant: "assistant",
+  ai: "assistant",
+  bot: "assistant",
+  model: "assistant",
+  system: "system",
+  developer: "system",
+  tool: "tool",
+  function: "function",
+  norole: "norole",
+};
+
+/**
+ * Coerce an arbitrary role string into a valid Zep {@link Zep.RoleType}.
+ *
+ * @param role - A role string from the host framework (case-insensitive).
+ * @returns A valid `RoleType`; defaults to `"norole"` for unknown input.
+ */
+export function toRoleType(role: string | undefined): Zep.RoleType {
+  if (!role) return "norole";
+  return ROLE_ALIASES[role.trim().toLowerCase()] ?? "norole";
+}
+
+/**
+ * Resolve a {@link ZepBinding} into the mutually-exclusive `userId`/`graphId`
+ * pair that Zep's `graph.add` / `graph.search` accept.
+ *
+ * `userId` takes precedence over `graphId` when both are set, because a user
+ * graph is the richer target (it carries identity and a user summary).
+ *
+ * @returns `{ userId }`, `{ graphId }`, or `null` when neither is bound.
+ */
+export function resolveGraphTarget(
+  binding: ZepBinding,
+): { userId: string } | { graphId: string } | null {
+  if (binding.userId) return { userId: binding.userId };
+  if (binding.graphId) return { graphId: binding.graphId };
+  return null;
+}
+
+/**
+ * Normalize an unknown thrown value into a single-line message safe for logs.
+ *
+ * Never include secrets or PII here — this is intended for error *types* and
+ * messages emitted by the Zep SDK, not user content.
+ */
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return "unknown error";
+  }
+}
+
+/** Resolve the effective logger, defaulting to `console`. */
+export function resolveLogger(logger: ZepLogger | undefined): ZepLogger {
+  return logger ?? console;
+}
+
+/**
+ * Zep rejects messages longer than 4,096 characters with a 400. We truncate a
+ * bit below that to leave headroom for any server-side normalization.
+ */
+export const MESSAGE_MAX_CHARS = 4000;
+
+/**
+ * Truncate `content` to `maxChars` if it exceeds the limit, logging a warning.
+ *
+ * Zep returns a 400 when a message exceeds its 4,096-char limit. Rather than
+ * letting the call fail (or silently dropping data), we truncate to the limit
+ * and warn. The warning contains **only lengths** (never the content itself) to
+ * avoid leaking PII into logs — a hard rule across this package.
+ *
+ * @param content - The text about to be sent to Zep.
+ * @param maxChars - The hard limit for this Zep operation.
+ * @param label - A short tag identifying the call site (e.g. `"zep-middleware"`).
+ * @param logger - Where to emit the truncation warning.
+ * @returns The original string, or a truncated copy when it was too long.
+ */
+export function truncateForZep(
+  content: string,
+  maxChars: number,
+  label: string,
+  logger: ZepLogger,
+): string {
+  if (content.length <= maxChars) return content;
+  logger.warn(
+    `[${label}] Content length ${content.length} exceeds Zep limit ${maxChars}; ` +
+      `truncating to ${maxChars} characters.`,
+  );
+  return content.slice(0, maxChars);
+}

--- a/integrations/vercel-ai/typescript/test/helpers.test.ts
+++ b/integrations/vercel-ai/typescript/test/helpers.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
-import { getZepContext, persistZepTurn, ensureZepUserAndThread } from "../src/index.js";
+import { Zep, ZepError } from "@getzep/zep-cloud";
+import {
+  getZepContext,
+  persistZepTurn,
+  createZepOnFinish,
+  ensureZepUserAndThread,
+} from "../src/index.js";
 import { makeFakeZep, asZep } from "./helpers.js";
 
 describe("getZepContext", () => {
@@ -111,6 +117,96 @@ describe("persistZepTurn", () => {
   });
 });
 
+describe("createZepOnFinish", () => {
+  it("persists the turn exactly once with the final assistant text", async () => {
+    const zep = makeFakeZep();
+    const onFinish = createZepOnFinish({
+      client: asZep(zep),
+      threadId: "t1",
+      user: "What do you know about me?",
+      userName: "Jane",
+    });
+
+    // Simulate the single onFinish event the SDK fires per turn — its `text`
+    // is the FINAL assistant text, not any intermediate tool-call preamble.
+    await onFinish({ text: "You live in Portland and love hiking." });
+
+    expect(zep.thread.addMessages).toHaveBeenCalledTimes(1);
+    const req = zep.thread.addMessages.mock.calls[0]![1];
+    expect(req.messages).toEqual([
+      { role: "user", content: "What do you know about me?", name: "Jane" },
+      { role: "assistant", content: "You live in Portland and love hiking." },
+    ]);
+  });
+
+  it("does not persist intermediate preamble — only the event's final text lands", async () => {
+    // A multi-step tool loop would call doGenerate per step with preamble like
+    // "Let me look that up...", but onFinish is invoked once with the final
+    // answer. The callback persists that single event, never the preamble.
+    const zep = makeFakeZep();
+    const onFinish = createZepOnFinish({
+      client: asZep(zep),
+      threadId: "t1",
+      user: "Find my last order.",
+    });
+
+    await onFinish({ text: "Your last order was a blue mug, shipped Tuesday." });
+
+    expect(zep.thread.addMessages).toHaveBeenCalledTimes(1);
+    const sent = zep.thread.addMessages.mock.calls[0]![1].messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    const assistant = sent.find((m) => m.role === "assistant");
+    expect(assistant?.content).toBe("Your last order was a blue mug, shipped Tuesday.");
+    expect(sent.filter((m) => m.role === "assistant")).toHaveLength(1);
+  });
+
+  it("resolves the user side from a function when provided", async () => {
+    const zep = makeFakeZep();
+    const onFinish = createZepOnFinish({
+      client: asZep(zep),
+      threadId: "t1",
+      user: () => "resolved user input",
+    });
+    await onFinish({ text: "reply" });
+    const req = zep.thread.addMessages.mock.calls[0]![1];
+    expect(req.messages).toEqual([
+      { role: "user", content: "resolved user input" },
+      { role: "assistant", content: "reply" },
+    ]);
+  });
+
+  it("persists assistant-only when no user is supplied", async () => {
+    const zep = makeFakeZep();
+    const onFinish = createZepOnFinish({ client: asZep(zep), threadId: "t1" });
+    await onFinish({ text: "reply only" });
+    const req = zep.thread.addMessages.mock.calls[0]![1];
+    expect(req.messages).toEqual([{ role: "assistant", content: "reply only" }]);
+  });
+
+  it("does nothing when both sides are empty", async () => {
+    const zep = makeFakeZep();
+    const onFinish = createZepOnFinish({ client: asZep(zep), threadId: "t1", user: "  " });
+    await onFinish({ text: "   " });
+    expect(zep.thread.addMessages).not.toHaveBeenCalled();
+  });
+
+  it("never throws when Zep persistence fails", async () => {
+    const zep = makeFakeZep();
+    zep.thread.addMessages.mockRejectedValueOnce(new Error("503"));
+    const warn = vi.fn();
+    const onFinish = createZepOnFinish({
+      client: asZep(zep),
+      threadId: "t1",
+      user: "hi",
+      logger: { warn },
+    });
+    await expect(onFinish({ text: "reply" })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
 describe("ensureZepUserAndThread", () => {
   it("creates the user and thread and returns true", async () => {
     const zep = makeFakeZep();
@@ -132,22 +228,63 @@ describe("ensureZepUserAndThread", () => {
     expect(zep.thread.create).toHaveBeenCalledWith({ threadId: "t1", userId: "u1" });
   });
 
-  it("treats an already-existing user as success", async () => {
+  it("treats a typed 409 Conflict on user.add as success (debug, no warn)", async () => {
     const zep = makeFakeZep();
-    zep.user.add.mockRejectedValueOnce(new Error("user already exists (409)"));
+    zep.user.add.mockRejectedValueOnce(new Zep.ConflictError({}));
+    const warn = vi.fn();
+    const debug = vi.fn();
     const ok = await ensureZepUserAndThread({
       client: asZep(zep),
       userId: "u1",
       threadId: "t1",
-      logger: { warn: vi.fn(), debug: vi.fn() },
+      logger: { warn, debug },
     });
     expect(ok).toBe(true);
     expect(zep.thread.create).toHaveBeenCalledOnce();
+    // A genuine "already exists" is tolerated quietly, not warned.
+    expect(warn).not.toHaveBeenCalled();
+    expect(debug).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces a non-conflict user.add error (e.g. 401) as a warning", async () => {
+    const zep = makeFakeZep();
+    // Not a 409 — must NOT be swallowed as "already exists".
+    zep.user.add.mockRejectedValueOnce(
+      new ZepError({ message: "unauthorized", statusCode: 401 }),
+    );
+    const warn = vi.fn();
+    const ok = await ensureZepUserAndThread({
+      client: asZep(zep),
+      userId: "u1",
+      threadId: "t1",
+      logger: { warn },
+    });
+    // thread.create still succeeds, so identity is ready overall.
+    expect(ok).toBe(true);
+    expect(warn).toHaveBeenCalledOnce();
+    const warnArg = warn.mock.calls[0]![0] as string;
+    expect(warnArg).toContain("user.add failed");
+  });
+
+  it("treats a typed 409 Conflict on thread.create as success", async () => {
+    const zep = makeFakeZep();
+    zep.thread.create.mockRejectedValueOnce(new Zep.ConflictError({}));
+    const warn = vi.fn();
+    const ok = await ensureZepUserAndThread({
+      client: asZep(zep),
+      userId: "u1",
+      threadId: "t1",
+      logger: { warn },
+    });
+    expect(ok).toBe(true);
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("returns false (not throw) when thread creation hard-fails", async () => {
     const zep = makeFakeZep();
-    zep.thread.create.mockRejectedValueOnce(new Error("500 internal"));
+    zep.thread.create.mockRejectedValueOnce(
+      new ZepError({ message: "internal", statusCode: 500 }),
+    );
     const warn = vi.fn();
     const ok = await ensureZepUserAndThread({
       client: asZep(zep),

--- a/integrations/vercel-ai/typescript/test/helpers.test.ts
+++ b/integrations/vercel-ai/typescript/test/helpers.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import { getZepContext, persistZepTurn, ensureZepUserAndThread } from "../src/index.js";
+import { makeFakeZep, asZep } from "./helpers.js";
+
+describe("getZepContext", () => {
+  it("returns the trimmed context block", async () => {
+    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockResolvedValueOnce({ context: "  BLOCK  " });
+    const context = await getZepContext(asZep(zep), "t1");
+    expect(context).toBe("BLOCK");
+    expect(zep.thread.getUserContext).toHaveBeenCalledWith("t1", {});
+  });
+
+  it("passes a templateId when provided", async () => {
+    const zep = makeFakeZep();
+    await getZepContext(asZep(zep), "t1", { templateId: "tmpl-1" });
+    expect(zep.thread.getUserContext).toHaveBeenCalledWith("t1", { templateId: "tmpl-1" });
+  });
+
+  it("returns an empty string and warns when Zep fails", async () => {
+    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockRejectedValueOnce(new Error("boom"));
+    const warn = vi.fn();
+    const context = await getZepContext(asZep(zep), "t1", { logger: { warn } });
+    expect(context).toBe("");
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("skips and warns when threadId is empty", async () => {
+    const zep = makeFakeZep();
+    const warn = vi.fn();
+    const context = await getZepContext(asZep(zep), "", { logger: { warn } });
+    expect(context).toBe("");
+    expect(zep.thread.getUserContext).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("persistZepTurn", () => {
+  it("persists both user and assistant messages", async () => {
+    const zep = makeFakeZep();
+    await persistZepTurn(asZep(zep), "t1", {
+      user: "Hi there",
+      assistant: "Hello!",
+      userName: "Jane",
+    });
+    const [threadId, req] = zep.thread.addMessages.mock.calls[0]!;
+    expect(threadId).toBe("t1");
+    expect(req.messages).toEqual([
+      { role: "user", content: "Hi there", name: "Jane" },
+      { role: "assistant", content: "Hello!" },
+    ]);
+  });
+
+  it("persists only the side that is present", async () => {
+    const zep = makeFakeZep();
+    await persistZepTurn(asZep(zep), "t1", { assistant: "reply only" });
+    const req = zep.thread.addMessages.mock.calls[0]![1];
+    expect(req.messages).toEqual([{ role: "assistant", content: "reply only" }]);
+  });
+
+  it("returns the context block when returnContext is set", async () => {
+    const zep = makeFakeZep();
+    zep.thread.addMessages.mockResolvedValueOnce({ context: "  fresh ctx  " });
+    const ctx = await persistZepTurn(
+      asZep(zep),
+      "t1",
+      { user: "hi" },
+      { returnContext: true },
+    );
+    expect(ctx).toBe("fresh ctx");
+    expect(zep.thread.addMessages.mock.calls[0]![1].returnContext).toBe(true);
+  });
+
+  it("truncates over-long content and warns with lengths only", async () => {
+    const zep = makeFakeZep();
+    const warn = vi.fn();
+    await persistZepTurn(
+      asZep(zep),
+      "t1",
+      { user: "a".repeat(5000) },
+      { logger: { warn } },
+    );
+    const sent = zep.thread.addMessages.mock.calls[0]![1].messages[0].content as string;
+    expect(sent.length).toBe(4000);
+    expect(warn).toHaveBeenCalledOnce();
+    const warnArg = warn.mock.calls[0]![0] as string;
+    expect(warnArg).toContain("5000");
+    expect(warnArg).not.toContain("aaaa");
+  });
+
+  it("returns null without calling Zep when nothing to persist", async () => {
+    const zep = makeFakeZep();
+    const result = await persistZepTurn(asZep(zep), "t1", { user: "  ", assistant: "" });
+    expect(result).toBeNull();
+    expect(zep.thread.addMessages).not.toHaveBeenCalled();
+  });
+
+  it("never throws when Zep fails", async () => {
+    const zep = makeFakeZep();
+    zep.thread.addMessages.mockRejectedValueOnce(new Error("503"));
+    const warn = vi.fn();
+    const result = await persistZepTurn(
+      asZep(zep),
+      "t1",
+      { user: "hi" },
+      { logger: { warn } },
+    );
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("ensureZepUserAndThread", () => {
+  it("creates the user and thread and returns true", async () => {
+    const zep = makeFakeZep();
+    const ok = await ensureZepUserAndThread({
+      client: asZep(zep),
+      userId: "u1",
+      threadId: "t1",
+      firstName: "Jane",
+      lastName: "Smith",
+      email: "jane@example.com",
+    });
+    expect(ok).toBe(true);
+    expect(zep.user.add).toHaveBeenCalledWith({
+      userId: "u1",
+      firstName: "Jane",
+      lastName: "Smith",
+      email: "jane@example.com",
+    });
+    expect(zep.thread.create).toHaveBeenCalledWith({ threadId: "t1", userId: "u1" });
+  });
+
+  it("treats an already-existing user as success", async () => {
+    const zep = makeFakeZep();
+    zep.user.add.mockRejectedValueOnce(new Error("user already exists (409)"));
+    const ok = await ensureZepUserAndThread({
+      client: asZep(zep),
+      userId: "u1",
+      threadId: "t1",
+      logger: { warn: vi.fn(), debug: vi.fn() },
+    });
+    expect(ok).toBe(true);
+    expect(zep.thread.create).toHaveBeenCalledOnce();
+  });
+
+  it("returns false (not throw) when thread creation hard-fails", async () => {
+    const zep = makeFakeZep();
+    zep.thread.create.mockRejectedValueOnce(new Error("500 internal"));
+    const warn = vi.fn();
+    const ok = await ensureZepUserAndThread({
+      client: asZep(zep),
+      userId: "u1",
+      threadId: "t1",
+      logger: { warn },
+    });
+    expect(ok).toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});

--- a/integrations/vercel-ai/typescript/test/helpers.ts
+++ b/integrations/vercel-ai/typescript/test/helpers.ts
@@ -1,0 +1,74 @@
+import { vi } from "vitest";
+import type { ZepClient } from "@getzep/zep-cloud";
+
+/**
+ * A minimal in-memory fake of the Zep client surface the integration uses.
+ * Each method is a vitest mock so tests can assert calls and override returns.
+ */
+export interface FakeZep {
+  thread: {
+    addMessages: ReturnType<typeof vi.fn>;
+    getUserContext: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  graph: {
+    add: ReturnType<typeof vi.fn>;
+    search: ReturnType<typeof vi.fn>;
+  };
+  user: {
+    add: ReturnType<typeof vi.fn>;
+  };
+}
+
+/** Build a fresh fake Zep client with sensible default resolved values. */
+export function makeFakeZep(): FakeZep {
+  return {
+    thread: {
+      addMessages: vi.fn().mockResolvedValue({ context: "ctx" }),
+      getUserContext: vi.fn().mockResolvedValue({ context: "USER CONTEXT BLOCK" }),
+      create: vi.fn().mockResolvedValue({ uuid: "t1" }),
+    },
+    graph: {
+      add: vi.fn().mockResolvedValue({ uuid: "ep1" }),
+      search: vi.fn().mockResolvedValue({ edges: [], nodes: [], episodes: [] }),
+    },
+    user: {
+      add: vi.fn().mockResolvedValue({ userId: "u" }),
+    },
+  };
+}
+
+/** Cast a fake to the `ZepClient` type for passing into the integration. */
+export function asZep(fake: FakeZep): ZepClient {
+  return fake as unknown as ZepClient;
+}
+
+/**
+ * An AI SDK tool with a callable `execute`. We type `execute` deliberately
+ * loosely here: the AI SDK's `Tool` type is generic and heavy, and inferring
+ * its exact input/output through `ReturnType` blows up the type-checker. For
+ * mock tests we only need to call `execute` and inspect the resolved object.
+ */
+interface ExecutableTool {
+  execute?: (...args: never[]) => unknown;
+}
+
+/**
+ * Invoke a tool's `execute` and return its (awaited) structured output.
+ *
+ * Returns a permissive record so tests can read whichever fields the tool
+ * produces (`facts`, `found`, `stored`, `message`, `context`) without threading
+ * the AI SDK's heavy generic `Tool` type through the assertions.
+ */
+export async function run<T extends Record<string, unknown> = Record<string, unknown>>(
+  tool: ExecutableTool,
+  input: Record<string, unknown>,
+): Promise<T> {
+  if (!tool.execute) throw new Error("tool has no execute");
+  const exec = tool.execute as (input: unknown, options: unknown) => unknown;
+  const result = await exec(input, undefined);
+  if (result === undefined || result === null || typeof result !== "object") {
+    throw new Error(`expected a structured tool result, got: ${typeof result}`);
+  }
+  return result as T;
+}

--- a/integrations/vercel-ai/typescript/test/live.test.ts
+++ b/integrations/vercel-ai/typescript/test/live.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { ZepClient } from "@getzep/zep-cloud";
+import { randomUUID } from "node:crypto";
+import {
+  ensureZepUserAndThread,
+  getZepContext,
+  persistZepTurn,
+  createZepTools,
+} from "../src/index.js";
+import { run } from "./helpers.js";
+
+const apiKey = process.env.ZEP_API_KEY;
+
+// These tests hit the real Zep API and only run when ZEP_API_KEY is set.
+// Ingestion is asynchronous, so they assert the calls succeed — not that a
+// just-written fact is instantly retrievable.
+const describeLive = apiKey ? describe : describe.skip;
+
+describeLive("live Zep integration", () => {
+  it("provisions identity, persists, and retrieves without throwing", async () => {
+    const client = new ZepClient({ apiKey });
+    const userId = `zep-vercel-test-${randomUUID()}`;
+    const threadId = `thread-${randomUUID()}`;
+
+    const ready = await ensureZepUserAndThread({
+      client,
+      userId,
+      threadId,
+      firstName: "Test",
+      lastName: "User",
+    });
+    expect(ready).toBe(true);
+
+    const ctx = await persistZepTurn(
+      client,
+      threadId,
+      { user: "My favorite color is teal.", userName: "Test User" },
+      { returnContext: true },
+    );
+    expect(ctx === null || typeof ctx === "string").toBe(true);
+
+    const context = await getZepContext(client, threadId);
+    expect(typeof context).toBe("string");
+
+    const { zepSearch } = createZepTools(client, { binding: { userId, threadId } });
+    const result = await run(zepSearch, { query: "favorite color" });
+    expect(Array.isArray(result.facts)).toBe(true);
+  }, 30_000);
+});

--- a/integrations/vercel-ai/typescript/test/middleware.test.ts
+++ b/integrations/vercel-ai/typescript/test/middleware.test.ts
@@ -1,38 +1,33 @@
 import { describe, it, expect, vi } from "vitest";
-import type {
-  LanguageModelV3CallOptions,
-  LanguageModelV3GenerateResult,
-  LanguageModelV3StreamResult,
-} from "@ai-sdk/provider";
+import type { LanguageModelV3CallOptions, LanguageModelV3Prompt } from "@ai-sdk/provider";
 import { createZepMiddleware } from "../src/index.js";
 import { makeFakeZep, asZep } from "./helpers.js";
 
+const modelStub = {} as never;
+
+/** Build a minimal V3 call-options object from an explicit prompt. */
+function makeParamsFromPrompt(prompt: LanguageModelV3Prompt): LanguageModelV3CallOptions {
+  return { prompt } as LanguageModelV3CallOptions;
+}
+
 /** Build a minimal V3 call-options object with a single user message. */
 function makeParams(userText: string): LanguageModelV3CallOptions {
-  return {
-    prompt: [{ role: "user", content: [{ type: "text", text: userText }] }],
-  } as LanguageModelV3CallOptions;
+  return makeParamsFromPrompt([
+    { role: "user", content: [{ type: "text", text: userText }] },
+  ]);
 }
-
-/** A `doGenerate` stub that resolves to a result whose text content is `text`. */
-function makeDoGenerate(text: string): () => Promise<LanguageModelV3GenerateResult> {
-  return async () =>
-    ({
-      content: [{ type: "text", text }],
-      finishReason: { unified: "stop", raw: "stop" },
-      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      warnings: [],
-    }) as unknown as LanguageModelV3GenerateResult;
-}
-
-const doStreamStub = (async () => ({}) as unknown as LanguageModelV3StreamResult) as () => Promise<LanguageModelV3StreamResult>;
-const modelStub = {} as never;
 
 describe("createZepMiddleware", () => {
   it("uses specificationVersion v3", () => {
     const zep = makeFakeZep();
     const mw = createZepMiddleware({ client: asZep(zep), threadId: "t1" });
     expect(mw.specificationVersion).toBe("v3");
+  });
+
+  it("does not expose a wrapGenerate hook (injection only)", () => {
+    const zep = makeFakeZep();
+    const mw = createZepMiddleware({ client: asZep(zep), threadId: "t1" });
+    expect(mw.wrapGenerate).toBeUndefined();
   });
 
   it("transformParams injects the Context Block as a leading system message", async () => {
@@ -80,90 +75,69 @@ describe("createZepMiddleware", () => {
     const params = makeParams("hi");
     const out = await mw.transformParams!({ type: "generate", params, model: modelStub });
     expect(out.prompt[0]!.role).toBe("user");
-    expect(warn).toHaveBeenCalledOnce();
+    // getZepContext logs the failure; transformParams returns the prompt as-is.
+    expect(warn).toHaveBeenCalled();
   });
 
-  it("wrapGenerate persists the user+assistant turn when persist is enabled", async () => {
+  it("injects on a genuine new user turn but NOT on tool-loop continuation steps", async () => {
     const zep = makeFakeZep();
-    const mw = createZepMiddleware({
-      client: asZep(zep),
-      threadId: "t1",
-      persist: true,
-      userName: "Jane",
-    });
-
-    const params = makeParams("I live in Portland");
-    const result = await mw.wrapGenerate!({
-      doGenerate: makeDoGenerate("Noted!"),
-      doStream: doStreamStub,
-      params,
-      model: modelStub,
-    });
-
-    expect((result.content[0] as { text: string }).text).toBe("Noted!");
-    expect(zep.thread.addMessages).toHaveBeenCalledTimes(1);
-    const req = zep.thread.addMessages.mock.calls[0]![1];
-    expect(req.messages).toEqual([
-      { role: "user", content: "I live in Portland", name: "Jane" },
-      { role: "assistant", content: "Noted!" },
-    ]);
-  });
-
-  it("wrapGenerate truncates an over-long user message and warns (lengths only)", async () => {
-    const zep = makeFakeZep();
-    const warn = vi.fn();
-    const mw = createZepMiddleware({
-      client: asZep(zep),
-      threadId: "t1",
-      persist: true,
-      logger: { warn },
-    });
-
-    const params = makeParams("u".repeat(5000));
-    await mw.wrapGenerate!({
-      doGenerate: makeDoGenerate("ok"),
-      doStream: doStreamStub,
-      params,
-      model: modelStub,
-    });
-
-    const sent = zep.thread.addMessages.mock.calls[0]![1].messages[0].content as string;
-    expect(sent.length).toBe(4000);
-    expect(warn).toHaveBeenCalledOnce();
-    const warnArg = warn.mock.calls[0]![0] as string;
-    expect(warnArg).toContain("5000");
-    expect(warnArg).not.toContain("uuuu");
-  });
-
-  it("wrapGenerate does not persist when persist is disabled (default)", async () => {
-    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockResolvedValue({ context: "CONTEXT BLOCK" });
     const mw = createZepMiddleware({ client: asZep(zep), threadId: "t1" });
-    await mw.wrapGenerate!({
-      doGenerate: makeDoGenerate("hi"),
-      doStream: doStreamStub,
-      params: makeParams("hello"),
-      model: modelStub,
-    });
-    expect(zep.thread.addMessages).not.toHaveBeenCalled();
+
+    // Step 1: the triggering new user turn — last message role is 'user'.
+    const step1 = makeParamsFromPrompt([
+      { role: "user", content: [{ type: "text", text: "Look up my orders." }] },
+    ]);
+    const out1 = await mw.transformParams!({ type: "generate", params: step1, model: modelStub });
+    expect(out1.prompt[0]!.role).toBe("system");
+    expect((out1.prompt[0] as { content: string }).content).toContain("CONTEXT BLOCK");
+
+    // Step 2: continuation step — model emitted a tool call, last message is 'tool'.
+    const step2 = makeParamsFromPrompt([
+      { role: "user", content: [{ type: "text", text: "Look up my orders." }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "c1",
+            toolName: "zepSearch",
+            input: JSON.stringify({ query: "orders" }),
+          },
+        ],
+      } as LanguageModelV3Prompt[number],
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "c1",
+            toolName: "zepSearch",
+            output: { type: "json", value: { facts: [], found: false } },
+          },
+        ],
+      } as LanguageModelV3Prompt[number],
+    ]);
+    const out2 = await mw.transformParams!({ type: "generate", params: step2, model: modelStub });
+    // No injection on the continuation step: prompt is unchanged, no system head.
+    expect(out2.prompt[0]!.role).toBe("user");
+    expect(out2.prompt.some((m) => m.role === "system")).toBe(false);
+
+    // Context fetched exactly once across the whole turn (step 1 only).
+    expect(zep.thread.getUserContext).toHaveBeenCalledTimes(1);
   });
 
-  it("wrapGenerate never throws when Zep persistence fails", async () => {
+  it("does not inject when the last message is an assistant message", async () => {
     const zep = makeFakeZep();
-    zep.thread.addMessages.mockRejectedValueOnce(new Error("503"));
-    const warn = vi.fn();
-    const mw = createZepMiddleware({
-      client: asZep(zep),
-      threadId: "t1",
-      persist: true,
-      logger: { warn },
-    });
-    const result = await mw.wrapGenerate!({
-      doGenerate: makeDoGenerate("done"),
-      doStream: doStreamStub,
-      params: makeParams("q"),
-      model: modelStub,
-    });
-    expect((result.content[0] as { text: string }).text).toBe("done");
-    expect(warn).toHaveBeenCalledOnce();
+    zep.thread.getUserContext.mockResolvedValue({ context: "CONTEXT" });
+    const mw = createZepMiddleware({ client: asZep(zep), threadId: "t1" });
+
+    const params = makeParamsFromPrompt([
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+      { role: "assistant", content: [{ type: "text", text: "partial" }] },
+    ]);
+    const out = await mw.transformParams!({ type: "generate", params, model: modelStub });
+    expect(out.prompt.some((m) => m.role === "system")).toBe(false);
+    expect(zep.thread.getUserContext).not.toHaveBeenCalled();
   });
 });

--- a/integrations/vercel-ai/typescript/test/middleware.test.ts
+++ b/integrations/vercel-ai/typescript/test/middleware.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from "vitest";
+import type {
+  LanguageModelV3CallOptions,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamResult,
+} from "@ai-sdk/provider";
+import { createZepMiddleware } from "../src/index.js";
+import { makeFakeZep, asZep } from "./helpers.js";
+
+/** Build a minimal V3 call-options object with a single user message. */
+function makeParams(userText: string): LanguageModelV3CallOptions {
+  return {
+    prompt: [{ role: "user", content: [{ type: "text", text: userText }] }],
+  } as LanguageModelV3CallOptions;
+}
+
+/** A `doGenerate` stub that resolves to a result whose text content is `text`. */
+function makeDoGenerate(text: string): () => Promise<LanguageModelV3GenerateResult> {
+  return async () =>
+    ({
+      content: [{ type: "text", text }],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      warnings: [],
+    }) as unknown as LanguageModelV3GenerateResult;
+}
+
+const doStreamStub = (async () => ({}) as unknown as LanguageModelV3StreamResult) as () => Promise<LanguageModelV3StreamResult>;
+const modelStub = {} as never;
+
+describe("createZepMiddleware", () => {
+  it("uses specificationVersion v3", () => {
+    const zep = makeFakeZep();
+    const mw = createZepMiddleware({ client: asZep(zep), threadId: "t1" });
+    expect(mw.specificationVersion).toBe("v3");
+  });
+
+  it("transformParams injects the Context Block as a leading system message", async () => {
+    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockResolvedValueOnce({ context: "Jane lives in Portland" });
+    const mw = createZepMiddleware({ client: asZep(zep), threadId: "t1" });
+
+    const params = makeParams("Where do I live?");
+    const out = await mw.transformParams!({ type: "generate", params, model: modelStub });
+
+    expect(out.prompt[0]!.role).toBe("system");
+    expect((out.prompt[0] as { content: string }).content).toContain("Jane lives in Portland");
+    // The original user message is preserved after the injected system message.
+    expect(out.prompt[1]!.role).toBe("user");
+    expect(zep.thread.getUserContext).toHaveBeenCalledWith("t1", {});
+  });
+
+  it("transformParams honors a custom formatContext", async () => {
+    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockResolvedValueOnce({ context: "FACT" });
+    const mw = createZepMiddleware({
+      client: asZep(zep),
+      threadId: "t1",
+      formatContext: (c) => `MEMORY>>>${c}<<<`,
+    });
+    const params = makeParams("hi");
+    const out = await mw.transformParams!({ type: "stream", params, model: modelStub });
+    expect((out.prompt[0] as { content: string }).content).toBe("MEMORY>>>FACT<<<");
+  });
+
+  it("transformParams injects nothing when the context is empty", async () => {
+    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockResolvedValueOnce({ context: "" });
+    const mw = createZepMiddleware({ client: asZep(zep), threadId: "t1" });
+    const params = makeParams("hi");
+    const out = await mw.transformParams!({ type: "generate", params, model: modelStub });
+    expect(out.prompt[0]!.role).toBe("user");
+  });
+
+  it("transformParams degrades gracefully when Zep fails (no system message)", async () => {
+    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockRejectedValueOnce(new Error("down"));
+    const warn = vi.fn();
+    const mw = createZepMiddleware({ client: asZep(zep), threadId: "t1", logger: { warn } });
+    const params = makeParams("hi");
+    const out = await mw.transformParams!({ type: "generate", params, model: modelStub });
+    expect(out.prompt[0]!.role).toBe("user");
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("wrapGenerate persists the user+assistant turn when persist is enabled", async () => {
+    const zep = makeFakeZep();
+    const mw = createZepMiddleware({
+      client: asZep(zep),
+      threadId: "t1",
+      persist: true,
+      userName: "Jane",
+    });
+
+    const params = makeParams("I live in Portland");
+    const result = await mw.wrapGenerate!({
+      doGenerate: makeDoGenerate("Noted!"),
+      doStream: doStreamStub,
+      params,
+      model: modelStub,
+    });
+
+    expect((result.content[0] as { text: string }).text).toBe("Noted!");
+    expect(zep.thread.addMessages).toHaveBeenCalledTimes(1);
+    const req = zep.thread.addMessages.mock.calls[0]![1];
+    expect(req.messages).toEqual([
+      { role: "user", content: "I live in Portland", name: "Jane" },
+      { role: "assistant", content: "Noted!" },
+    ]);
+  });
+
+  it("wrapGenerate truncates an over-long user message and warns (lengths only)", async () => {
+    const zep = makeFakeZep();
+    const warn = vi.fn();
+    const mw = createZepMiddleware({
+      client: asZep(zep),
+      threadId: "t1",
+      persist: true,
+      logger: { warn },
+    });
+
+    const params = makeParams("u".repeat(5000));
+    await mw.wrapGenerate!({
+      doGenerate: makeDoGenerate("ok"),
+      doStream: doStreamStub,
+      params,
+      model: modelStub,
+    });
+
+    const sent = zep.thread.addMessages.mock.calls[0]![1].messages[0].content as string;
+    expect(sent.length).toBe(4000);
+    expect(warn).toHaveBeenCalledOnce();
+    const warnArg = warn.mock.calls[0]![0] as string;
+    expect(warnArg).toContain("5000");
+    expect(warnArg).not.toContain("uuuu");
+  });
+
+  it("wrapGenerate does not persist when persist is disabled (default)", async () => {
+    const zep = makeFakeZep();
+    const mw = createZepMiddleware({ client: asZep(zep), threadId: "t1" });
+    await mw.wrapGenerate!({
+      doGenerate: makeDoGenerate("hi"),
+      doStream: doStreamStub,
+      params: makeParams("hello"),
+      model: modelStub,
+    });
+    expect(zep.thread.addMessages).not.toHaveBeenCalled();
+  });
+
+  it("wrapGenerate never throws when Zep persistence fails", async () => {
+    const zep = makeFakeZep();
+    zep.thread.addMessages.mockRejectedValueOnce(new Error("503"));
+    const warn = vi.fn();
+    const mw = createZepMiddleware({
+      client: asZep(zep),
+      threadId: "t1",
+      persist: true,
+      logger: { warn },
+    });
+    const result = await mw.wrapGenerate!({
+      doGenerate: makeDoGenerate("done"),
+      doStream: doStreamStub,
+      params: makeParams("q"),
+      model: modelStub,
+    });
+    expect((result.content[0] as { text: string }).text).toBe("done");
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});

--- a/integrations/vercel-ai/typescript/test/tools.test.ts
+++ b/integrations/vercel-ai/typescript/test/tools.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createZepTools,
+  createZepSearchTool,
+  createZepRememberTool,
+  createZepContextTool,
+} from "../src/index.js";
+import { makeFakeZep, asZep, run } from "./helpers.js";
+
+describe("createZepSearchTool", () => {
+  it("searches edges by default and returns facts", async () => {
+    const zep = makeFakeZep();
+    zep.graph.search.mockResolvedValueOnce({
+      edges: [{ fact: "Jane lives in Portland" }, { fact: "Jane is an engineer" }],
+    });
+    const tool = createZepSearchTool({ client: asZep(zep), binding: { userId: "u1" } });
+
+    const result = await run(tool, { query: "where does Jane live" });
+
+    expect(result).toEqual({
+      facts: ["Jane lives in Portland", "Jane is an engineer"],
+      found: true,
+    });
+    expect(zep.graph.search).toHaveBeenCalledWith({
+      userId: "u1",
+      query: "where does Jane live",
+      scope: "edges",
+    });
+  });
+
+  it("honors a pinned scope, limit, and graphId binding", async () => {
+    const zep = makeFakeZep();
+    zep.graph.search.mockResolvedValueOnce({
+      nodes: [{ name: "Apollo", summary: "A spacecraft program" }],
+    });
+    const tool = createZepSearchTool({
+      client: asZep(zep),
+      binding: { graphId: "kb-1" },
+      scope: "nodes",
+      limit: 5,
+    });
+
+    const result = await run(tool, { query: "Apollo" });
+
+    expect(result.facts).toEqual(["Apollo: A spacecraft program"]);
+    expect(zep.graph.search).toHaveBeenCalledWith({
+      graphId: "kb-1",
+      query: "Apollo",
+      scope: "nodes",
+      limit: 5,
+    });
+  });
+
+  it("never throws when Zep fails", async () => {
+    const zep = makeFakeZep();
+    zep.graph.search.mockRejectedValueOnce(new Error("timeout"));
+    const warn = vi.fn();
+    const tool = createZepSearchTool({
+      client: asZep(zep),
+      binding: { userId: "u1" },
+      logger: { warn },
+    });
+    const result = await run(tool, { query: "x" });
+    expect(result).toEqual({ facts: [], found: false });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("returns empty when nothing is bound", async () => {
+    const zep = makeFakeZep();
+    const tool = createZepSearchTool({
+      client: asZep(zep),
+      binding: {},
+      logger: { warn: vi.fn() },
+    });
+    const result = await run(tool, { query: "x" });
+    expect(result.found).toBe(false);
+    expect(zep.graph.search).not.toHaveBeenCalled();
+  });
+});
+
+describe("createZepRememberTool", () => {
+  it("persists conversational messages via thread.addMessages", async () => {
+    const zep = makeFakeZep();
+    const tool = createZepRememberTool({
+      client: asZep(zep),
+      binding: { userId: "u1", threadId: "t1" },
+      defaultMessageName: "Jane",
+    });
+
+    const result = await run(tool, { content: "I live in Portland", role: "user" });
+
+    expect(result.stored).toBe(true);
+    expect(zep.thread.addMessages).toHaveBeenCalledTimes(1);
+    const [threadId, req] = zep.thread.addMessages.mock.calls[0]!;
+    expect(threadId).toBe("t1");
+    expect(req.messages[0]).toMatchObject({
+      role: "user",
+      content: "I live in Portland",
+      name: "Jane",
+    });
+    expect(zep.graph.add).not.toHaveBeenCalled();
+  });
+
+  it("persists non-conversational data via graph.add", async () => {
+    const zep = makeFakeZep();
+    const tool = createZepRememberTool({
+      client: asZep(zep),
+      binding: { userId: "u1", threadId: "t1" },
+    });
+
+    const result = await run(tool, { content: "Project Apollo ships Q3" });
+
+    expect(result.stored).toBe(true);
+    expect(zep.graph.add).toHaveBeenCalledWith({
+      userId: "u1",
+      type: "text",
+      data: "Project Apollo ships Q3",
+    });
+    expect(zep.thread.addMessages).not.toHaveBeenCalled();
+  });
+
+  it("routes to graph.add for a standalone graph binding", async () => {
+    const zep = makeFakeZep();
+    const tool = createZepRememberTool({ client: asZep(zep), binding: { graphId: "kb-1" } });
+
+    await run(tool, { content: "Refunds take 5 days", role: "assistant" });
+    expect(zep.graph.add).toHaveBeenCalledWith({
+      graphId: "kb-1",
+      type: "text",
+      data: "Refunds take 5 days",
+    });
+  });
+
+  it("maps unknown roles to a valid Zep RoleType", async () => {
+    const zep = makeFakeZep();
+    const tool = createZepRememberTool({
+      client: asZep(zep),
+      binding: { userId: "u1", threadId: "t1" },
+    });
+    await run(tool, { content: "hi", role: "Human" });
+    expect(zep.thread.addMessages.mock.calls[0]![1].messages[0].role).toBe("user");
+  });
+
+  it("truncates an over-long message to the limit and warns (lengths only)", async () => {
+    const zep = makeFakeZep();
+    const warn = vi.fn();
+    const tool = createZepRememberTool({
+      client: asZep(zep),
+      binding: { userId: "u1", threadId: "t1" },
+      logger: { warn },
+    });
+
+    const result = await run(tool, { content: "a".repeat(5000), role: "user" });
+
+    expect(result.stored).toBe(true);
+    const sent = zep.thread.addMessages.mock.calls[0]![1].messages[0].content as string;
+    expect(sent.length).toBe(4000);
+    expect(warn).toHaveBeenCalledOnce();
+    const warnArg = warn.mock.calls[0]![0] as string;
+    expect(warnArg).toContain("5000");
+    expect(warnArg).toContain("4000");
+    expect(warnArg).not.toContain("aaaa");
+  });
+
+  it("returns stored: false on empty content without calling Zep", async () => {
+    const zep = makeFakeZep();
+    const tool = createZepRememberTool({
+      client: asZep(zep),
+      binding: { userId: "u1", threadId: "t1" },
+    });
+    const result = await run(tool, { content: "   " });
+    expect(result.stored).toBe(false);
+    expect(zep.graph.add).not.toHaveBeenCalled();
+    expect(zep.thread.addMessages).not.toHaveBeenCalled();
+  });
+
+  it("never throws when Zep fails — logs and returns stored: false", async () => {
+    const zep = makeFakeZep();
+    zep.graph.add.mockRejectedValueOnce(new Error("503 upstream"));
+    const warn = vi.fn();
+    const tool = createZepRememberTool({
+      client: asZep(zep),
+      binding: { userId: "u1", threadId: "t1" },
+      logger: { warn },
+    });
+    const result = await run(tool, { content: "remember this" });
+    expect(result.stored).toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("reports not-configured when nothing is bound", async () => {
+    const zep = makeFakeZep();
+    const warn = vi.fn();
+    const tool = createZepRememberTool({ client: asZep(zep), binding: {}, logger: { warn } });
+    const result = await run(tool, { content: "x" });
+    expect(result.stored).toBe(false);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createZepContextTool", () => {
+  it("retrieves the context block via thread.getUserContext", async () => {
+    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockResolvedValueOnce({ context: "FACTS: Jane is in Portland" });
+    const tool = createZepContextTool({ client: asZep(zep), threadId: "t1" });
+
+    const result = await run(tool, {});
+
+    expect(result).toEqual({ context: "FACTS: Jane is in Portland", found: true });
+    expect(zep.thread.getUserContext).toHaveBeenCalledWith("t1", {});
+  });
+
+  it("passes a templateId when provided", async () => {
+    const zep = makeFakeZep();
+    const tool = createZepContextTool({
+      client: asZep(zep),
+      threadId: "t1",
+      templateId: "tmpl-9",
+    });
+    await run(tool, {});
+    expect(zep.thread.getUserContext).toHaveBeenCalledWith("t1", { templateId: "tmpl-9" });
+  });
+
+  it("returns found: false on an empty context", async () => {
+    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockResolvedValueOnce({ context: "   " });
+    const tool = createZepContextTool({ client: asZep(zep), threadId: "t1" });
+    const result = await run(tool, {});
+    expect(result).toEqual({ context: "", found: false });
+  });
+
+  it("never throws when Zep fails", async () => {
+    const zep = makeFakeZep();
+    zep.thread.getUserContext.mockRejectedValueOnce(new Error("boom"));
+    const warn = vi.fn();
+    const tool = createZepContextTool({
+      client: asZep(zep),
+      threadId: "t1",
+      logger: { warn },
+    });
+    const result = await run(tool, {});
+    expect(result).toEqual({ context: "", found: false });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createZepTools", () => {
+  it("returns the three tools and propagates search scope/limit", async () => {
+    const zep = makeFakeZep();
+    zep.graph.search.mockResolvedValueOnce({ episodes: [{ content: "raw text" }] });
+    const { zepSearch, zepRemember, zepContext } = createZepTools(asZep(zep), {
+      binding: { userId: "u1", threadId: "t1" },
+      searchScope: "episodes",
+      searchLimit: 3,
+    });
+
+    expect(typeof zepRemember.execute).toBe("function");
+    expect(typeof zepContext.execute).toBe("function");
+
+    const result = await run(zepSearch, { query: "q" });
+    expect(result.facts).toEqual(["raw text"]);
+    expect(zep.graph.search).toHaveBeenCalledWith({
+      userId: "u1",
+      query: "q",
+      scope: "episodes",
+      limit: 3,
+    });
+  });
+});

--- a/integrations/vercel-ai/typescript/test/tools.test.ts
+++ b/integrations/vercel-ai/typescript/test/tools.test.ts
@@ -141,6 +141,29 @@ describe("createZepRememberTool", () => {
     expect(zep.thread.addMessages.mock.calls[0]![1].messages[0].role).toBe("user");
   });
 
+  it("truncates over-long graph.add data to the 10,000-char limit and warns (lengths only)", async () => {
+    const zep = makeFakeZep();
+    const warn = vi.fn();
+    const tool = createZepRememberTool({
+      client: asZep(zep),
+      binding: { userId: "u1" }, // no thread + no role → graph.add path
+      logger: { warn },
+    });
+
+    // 12,000 chars — over Zep's 10,000-char graph.add limit.
+    const result = await run(tool, { content: "z".repeat(12000) });
+
+    expect(result.stored).toBe(true);
+    const data = zep.graph.add.mock.calls[0]![0].data as string;
+    // Capped below 10,000 (the package leaves headroom).
+    expect(data.length).toBeLessThanOrEqual(10000);
+    expect(data.length).toBeLessThan(12000);
+    expect(warn).toHaveBeenCalledOnce();
+    const warnArg = warn.mock.calls[0]![0] as string;
+    expect(warnArg).toContain("12000");
+    expect(warnArg).not.toContain("zzzz");
+  });
+
   it("truncates an over-long message to the limit and warns (lengths only)", async () => {
     const zep = makeFakeZep();
     const warn = vi.fn();

--- a/integrations/vercel-ai/typescript/test/utils.test.ts
+++ b/integrations/vercel-ai/typescript/test/utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  toRoleType,
+  resolveGraphTarget,
+  truncateForZep,
+  MESSAGE_MAX_CHARS,
+} from "../src/index.js";
+
+describe("toRoleType", () => {
+  it("passes through valid Zep roles", () => {
+    expect(toRoleType("user")).toBe("user");
+    expect(toRoleType("assistant")).toBe("assistant");
+    expect(toRoleType("system")).toBe("system");
+    expect(toRoleType("tool")).toBe("tool");
+    expect(toRoleType("function")).toBe("function");
+  });
+
+  it("maps common aliases", () => {
+    expect(toRoleType("Human")).toBe("user");
+    expect(toRoleType("AI")).toBe("assistant");
+    expect(toRoleType("bot")).toBe("assistant");
+    expect(toRoleType("developer")).toBe("system");
+  });
+
+  it("falls back to norole for unknown or empty input", () => {
+    expect(toRoleType("wizard")).toBe("norole");
+    expect(toRoleType(undefined)).toBe("norole");
+    expect(toRoleType("")).toBe("norole");
+  });
+});
+
+describe("resolveGraphTarget", () => {
+  it("prefers userId over graphId", () => {
+    expect(resolveGraphTarget({ userId: "u", graphId: "g" })).toEqual({ userId: "u" });
+  });
+  it("falls back to graphId", () => {
+    expect(resolveGraphTarget({ graphId: "g" })).toEqual({ graphId: "g" });
+  });
+  it("returns null when nothing is bound", () => {
+    expect(resolveGraphTarget({})).toBeNull();
+  });
+});
+
+describe("truncateForZep", () => {
+  it("returns content unchanged when within the limit", () => {
+    const warn = vi.fn();
+    const content = "x".repeat(100);
+    expect(truncateForZep(content, 100, "test", { warn })).toBe(content);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("truncates to the limit and warns when over", () => {
+    const warn = vi.fn();
+    const result = truncateForZep("y".repeat(150), 100, "test", { warn });
+    expect(result.length).toBe(100);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it("logs only lengths in the warning — never the content (no PII)", () => {
+    const warn = vi.fn();
+    const secret = "SSN-123-45-6789".repeat(50);
+    truncateForZep(secret, 100, "test", { warn });
+    const message = warn.mock.calls[0]![0] as string;
+    expect(message).toContain(String(secret.length));
+    expect(message).toContain("100");
+    expect(message).not.toContain("SSN");
+  });
+
+  it("exposes the documented Zep message limit (<= 4096)", () => {
+    expect(MESSAGE_MAX_CHARS).toBeLessThanOrEqual(4096);
+  });
+});

--- a/integrations/vercel-ai/typescript/test/utils.test.ts
+++ b/integrations/vercel-ai/typescript/test/utils.test.ts
@@ -27,6 +27,21 @@ describe("toRoleType", () => {
     expect(toRoleType(undefined)).toBe("norole");
     expect(toRoleType("")).toBe("norole");
   });
+
+  it("debug-logs the role NAME only when coercing an unknown role to norole", () => {
+    const debug = vi.fn();
+    expect(toRoleType("wizard", { warn: vi.fn(), debug })).toBe("norole");
+    expect(debug).toHaveBeenCalledOnce();
+    const msg = debug.mock.calls[0]![0] as string;
+    expect(msg).toContain("wizard");
+    expect(msg).toContain("norole");
+  });
+
+  it("does not debug-log for a known role", () => {
+    const debug = vi.fn();
+    expect(toRoleType("Human", { warn: vi.fn(), debug })).toBe("user");
+    expect(debug).not.toHaveBeenCalled();
+  });
 });
 
 describe("resolveGraphTarget", () => {

--- a/integrations/vercel-ai/typescript/tsconfig.json
+++ b/integrations/vercel-ai/typescript/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src", "test", "examples"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/integrations/vercel-ai/typescript/tsup.config.ts
+++ b/integrations/vercel-ai/typescript/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  target: "es2022",
+  outDir: "dist",
+});

--- a/integrations/vercel-ai/typescript/vitest.config.ts
+++ b/integrations/vercel-ai/typescript/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    globals: false,
+  },
+});


### PR DESCRIPTION
Adds the **`@getzep/zep-vercel-ai`** package (`integrations/vercel-ai/typescript`) — Zep memory for the Vercel AI SDK.

## Hooks (verified against installed `ai@6.0.207`)
Three composable layers (the SDK is stateless, so it offers several injection points):
- **`createZepMiddleware({ client, threadId })`** — a `wrapLanguageModel` middleware (`specificationVersion: 'v3'`). `transformParams` prepends Zep's Context Block as a system message (works for generate **and** stream); `wrapGenerate` optionally persists the turn for non-streaming `generateText`.
- **`getZepContext` / `persistZepTurn` helpers** — for `streamText`/manual use (`system:` + persist in `onFinish`, which fires for both paths — the documented path since `wrapGenerate` doesn't run under streaming).
- **`createZepTools(client, { userId | graphId })`** — `zepSearch` / `zepRemember` / `zepContext` via the AI SDK `tool()` (Zod `inputSchema`) for in-loop retrieval.

All persist paths truncate to Zep's 4096-char limit and **log lengths only (no PII)**; Zep failures degrade gracefully (never crash the call).

## Deps
`ai@^6` + `zod` as **peer** dependencies (the AI SDK requires a single shared instance), `@getzep/zep-cloud@^3.23.0`. ESM+CJS, NodeNext + strict.

## Ships
README, SETUP.md (Zep signup at getzep.com), `generate-text` (middleware + tool, 3-turn recall) and `stream-text` (`onFinish` persistence) examples, 49 mock tests + a live test, eslint, tsup build.

## Validation
`tsc --noEmit` + eslint + vitest (49 passed, 1 skipped) + tsup build, independently re-verified; live end-to-end smoke test against Zep + OpenAI passed (cross-turn recall confirmed). CI `paths-filter` entry added under the TypeScript lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)