### PR TITLE
ci: grant claude-review write perms so PR reviews can post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write access is required for the action to post its review as inline PR
+      # comments — with read-only the run succeeds but posts nothing (the
+      # claude-code-action GitHub App needs Pull requests + Issues: Read & write).
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Problem
The Claude Code Review workflow (`.github/workflows/claude-code-review.yml`, added in #530) grants only:
```yaml
permissions:
  pull-requests: read
  issues: read
```
The `anthropics/claude-code-action` runs the review but **cannot post its findings** with read-only scope. Observed on PRs #522–#527 and #529 after rebasing them onto the workflow: the `claude-review` run completes `success` (~6 min, 9 turns) but logs **`permission_denials_count: 20`** and **`No buffered inline comments`**, and **zero** comments land on the PRs.

## Docs
Per [Claude Code GitHub Actions](https://code.claude.com/docs/en/github-actions): the action's GitHub App requires *Contents / Issues / Pull requests: Read & write*, and every posting workflow example uses `pull-requests: write` + `issues: write`.

## Fix
Bump `pull-requests` and `issues` to `write` (kept `contents: read` — this is review-only; it doesn't push commits or open PRs).

## After merge
Re-trigger reviews on the open PRs (a re-push / `synchronize`) so they post their findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)