### PR TITLE
fix(ci): pin pypa/gh-action-pypi-publish to commit SHA

### DIFF
--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -111,7 +111,7 @@ jobs:
           name: ${{ needs.detect.outputs.framework }}-python-dist
           path: dist/
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: dist/
 


### PR DESCRIPTION
Resolves CodeQL code-scanning alert [#66](https://github.com/getzep/zep/security/code-scanning/66) (`actions/unpinned-tag`, medium).

`pypa/gh-action-pypi-publish` was referenced by the mutable `release/v1` tag in `.github/workflows/release-integrations.yml`. Pinned it to the full commit SHA `cef221092ed1bacb1cc03d23a2d87d1d172e277b`, which is the current `release/v1` head and equals tag `v1.14.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)