### PR TITLE
docs: rewrite README to scope repo as Zep Cloud examples & integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,7 @@
   </a>
 </p>
 
-<h1 align="center">
-Zep: Agent Memory at Enterprise Scale
-</h1>
-
-<h2 align="center">Examples, Integrations, & More</h2>
-
-<br />
+<h1 align="center">Zep Cloud: Examples & Integrations</h1>
 
 <p align="center">
   <a href="https://discord.gg/W8Kw6bsgXQ"><img
@@ -20,128 +14,76 @@ Zep: Agent Memory at Enterprise Scale
   <a href="https://twitter.com/intent/follow?screen_name=zep_ai" target="_new"><img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/zep_ai"></a>
 </p>
 
-## What is Zep? 💬
+## About This Repository
 
-Zep is an agent memory platform. It captures memory of your users, your business, and the work your agents do, assembles it into token-efficient context, and serves it back in under 200ms—managed, governed, and served at scale.
+This repository is **not** Zep's product or service. It contains **example code, framework
+integrations, and tools** for building agent memory with [Zep Cloud](https://www.getzep.com/),
+Zep's managed agent memory platform.
 
-Zep builds a temporal knowledge graph from chat history, business data, and user interactions. When new information contradicts an existing fact, Zep marks the old fact invalid and records the new one, so agents can ask "what is true now" or "what was true on this date" and get the right answer to either. Every query is filtered by access policies, retention rules, and audit logging at the entity level.
-
-### Three types of memory
-
-- **User memory**: preferences, behaviors, and history
-- **Business memory**: organizational data, customer records, and domain facts
-- **Work memory**: the tasks, episodes, and interactions your agents perform
-
-### How Zep works
-
-1. **Ingest**: Send chat messages, business data, and events to Zep as they occur.
-2. **Construct**: Zep builds a Context Graph connecting entities, facts, and relationships, and tracks how they change over time.
-3. **Retrieve**: Get pre-assembled, token-efficient context in under 200ms, ready for your LLM.
-
-At the center is the **Context Lake**: millions of Context Graphs managed as one governed system, served by Zep's Context Graph Engine.
-
-## Getting Started
-
-### Sign up for Zep Cloud
-
-Visit [www.getzep.com](https://www.getzep.com/) to sign up for Zep Cloud, our managed agent memory service with sub-200ms retrieval, SOC 2 Type II compliance, and a HIPAA BAA. Deploy as a managed Cloud service, Cloud with your own encryption keys (BYOK), or in your own VPC (BYOC). Add agent memory in a few lines of code.
-
-### Find Zep SDKs
-
-Zep offers comprehensive SDKs for multiple languages:
+To use Zep Cloud, sign up at [www.getzep.com](https://www.getzep.com/) and read the
+documentation at [help.getzep.com](https://help.getzep.com). Zep's official SDKs are:
 
 - **Python**: `pip install zep-cloud`
 - **TypeScript/JavaScript**: `npm install @getzep/zep-cloud`
 - **Go**: `go get github.com/getzep/zep-go/v2`
 
-### Get Help
+> Looking for the open-source temporal knowledge graph framework that powers Zep? See
+> [Graphiti](https://github.com/getzep/graphiti).
 
-- **Documentation**: [help.getzep.com](https://help.getzep.com)
-- **Discord Community**: [Join our Discord](https://discord.gg/W8Kw6bsgXQ)
-- **Support**: Visit our help website for comprehensive guides and tutorials
+## Contents
 
-## About This Repository
+| Directory | Description |
+|-----------|-------------|
+| [`examples/`](examples/) | Example apps and snippets in Python, TypeScript, and Go |
+| [`integrations/`](integrations/) | Agent-framework integration packages (ADK, AutoGen, CrewAI, LiveKit) |
+| [`ontology/`](ontology/) | Default ontology definitions |
+| [`plugins/`](plugins/) | Plugins for building with Zep |
+| [`benchmarks/`](benchmarks/) | Memory benchmarks (LoCoMo, LongMemEval) |
+| [`zep-eval-harness/`](zep-eval-harness/) | Evaluation harness for ingestion and retrieval |
+| [`legacy/`](legacy/) | Deprecated Zep Community Edition (unsupported) |
 
-**Note**: This repository is currently a work in progress.
+## Examples
 
-This repository contains examples, integrations, and tools for building agent memory with Zep. Explore the example applications to see how Zep adds memory to agents built with Google ADK, Microsoft AutoGen, CrewAI, LiveKit, and other frameworks.
+The [`examples/`](examples/) directory holds runnable samples per language:
 
-### Repository Structure
+- **[Python](examples/python/)** — quickstart, graph, chat history, context templates, and
+  framework demos (LangGraph, OpenAI Agents SDK, AutoGen, ElevenLabs)
+- **[TypeScript](examples/typescript/)** — graph, memory, users, LangGraph, and graph
+  visualization
+- **[Go](examples/go/)** — conversations, user graph, entity types, chunking
 
-The repository includes:
+## Integrations
 
-- Example applications demonstrating agent memory with Zep
-- Integration packages for popular agent frameworks
-- Code samples for different use cases
-- Development tools and utilities
+Framework integration packages live under [`integrations/`](integrations/), organized
+framework-first then language: `integrations/<framework>/<language>/`. Each package is built,
+tested, and released independently.
+
+- **Available**: Google ADK, Microsoft AutoGen, CrewAI, and LiveKit (Python)
+- **Develop**: `cd integrations/<framework>/python && uv sync --extra dev && uv run pytest`
+- See [`integrations/README.md`](integrations/README.md) for the full list and
+  [`integrations/CLAUDE.md`](integrations/CLAUDE.md) for conventions.
 
 ## Development Setup
 
-This project uses [UV](https://github.com/astral-sh/uv) for Python package management with workspace features.
+This project uses [UV](https://github.com/astral-sh/uv) for Python package management.
 
-### Prerequisites
+```bash
+# Install UV (macOS/Linux)
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
-- Python 3.13+
-- UV package manager
+# Sync the workspace
+uv sync
+```
 
-### Getting Started
-
-1. **Install UV** (if not already installed):
-   ```bash
-   # On macOS and Linux
-   curl -LsSf https://astral.sh/uv/install.sh | sh
-   
-   # On Windows
-   powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
-   ```
-
-2. **Sync the workspace**:
-   ```bash
-   uv sync
-   ```
-
-3. **Activate the virtual environment**:
-   ```bash
-   # On Unix/macOS
-   source .venv/bin/activate
-   
-   # On Windows
-   .venv\Scripts\activate
-   ```
-
-### Integrations
-
-Framework integration packages live under [`integrations/`](integrations/), organized
-framework-first then language: `integrations/<framework>/<language>/`. Each package is
-built, tested, and released independently.
-
-- **Available**: Google ADK, Microsoft AutoGen, CrewAI, and LiveKit (Python).
-- **Develop**: `cd integrations/<framework>/python && uv sync --extra dev && uv run pytest`
-- See [`integrations/README.md`](integrations/README.md) for the full list and
-  [`integrations/CLAUDE.md`](integrations/CLAUDE.md) for structure and conventions.
+Requires Python 3.13+.
 
 ## Contributing
 
-We welcome contributions to help improve Zep and its ecosystem. Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to contribute, including:
+We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines covering code,
+documentation, bug reports, and community examples.
 
-- Code contributions
-- Documentation improvements
-- Bug reports and feature requests
-- Community examples and integrations
+## Community Edition (Deprecated)
 
-## Graphiti: The Knowledge Graph Framework
-
-Zep is powered by [Graphiti](https://github.com/getzep/graphiti), an open-source temporal knowledge graph framework.
-
-Graphiti builds and maintains knowledge graphs while reasoning about state changes over time. Each fact includes `valid_at` and `invalid_at` dates, so agents can see how relationships, preferences, and facts have evolved.
-
-Visit the [Graphiti repository](https://github.com/getzep/graphiti) to learn more about the temporal knowledge graph framework that powers Zep's agent memory.
-
-
-## Community Edition (Legacy)
-
-**Note**: Zep Community Edition is no longer supported and has been deprecated. The Community Edition code has been moved to the `legacy/` folder in this repository.
-
-For current Zep development, we recommend using Zep Cloud or exploring the example projects in this repository.
-
-Read more about this change in our announcement: [Announcing a New Direction for Zep's Open Source Strategy](https://blog.getzep.com/announcing-a-new-direction-for-zeps-open-source-strategy/)
+Zep Community Edition is no longer supported. Its code has been moved to the
+[`legacy/`](legacy/) folder. Read more in
+[Announcing a New Direction for Zep's Open Source Strategy](https://blog.getzep.com/announcing-a-new-direction-for-zeps-open-source-strategy/).


### PR DESCRIPTION
Rewrites `README.md` to make clear this repository is **not** Zep's open-source product but rather example code, framework integrations, and tools for Zep Cloud. Removes the product marketing sections (What is Zep, three memory types, How Zep works, Context Lake) and the verbose Getting Started/Graphiti content. Adds a Contents table mapping the top-level directories plus a per-language Examples breakdown, and trims Development Setup, Contributing, and the Community Edition deprecation note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)