### PR TITLE
ci: pass --comment so claude-review posts findings to PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # --comment makes the plugin post its findings to the PR; without it the
+          # review runs but only prints to the (hidden) terminal and posts nothing.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Problem
The Claude Code Review workflow invokes the `code-review` plugin without `--comment`:
```
prompt: '/code-review:code-review .../pull/<n>'
```
Per the plugin spec, *"If `--comment` was NOT provided, stop here. Do not post any GitHub comments."* So the review runs (and spends tokens, ~$2/PR) but posts nothing — confirmed on #522–#527/#529: runs complete `success` with write perms (post-#531) yet log **"No buffered inline comments"** and leave zero comments.

This was the actual blocker; #531's read→write permission bump was necessary (the plugin needs write to post) but not sufficient on its own.

## Fix
Append `--comment` to the prompt. Keeps #531's `pull-requests: write` / `issues: write`.

## Verify (after merge)
Trigger a fresh `synchronize` on a same-repo PR (push a commit / rebase — a re-run replays the old prompt), then check for a `claude[bot]` review comment via `gh api repos/getzep/zep/pulls/<n>/comments`. (Fork PRs like #511 still won't post — `pull_request` runs from forks get no `CLAUDE_CODE_OAUTH_TOKEN`; that needs a separate trigger.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)