### PR TITLE
ci(claude-review): cap the review step at timeout-minutes: 10

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@9dd8b95a392eb34b6f5fb56cf5a64cb735912d4b # v1
+        # Fail fast if the review hangs instead of letting it sit indefinitely
+        # (the job default is 360 min). A run that stalls is an infra hang, not a
+        # slow review — cap it so the check resolves and can be re-run.
+        timeout-minutes: 10
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'


### PR DESCRIPTION
## What

Adds `timeout-minutes: 10` to the **Run Claude Code Review** step in `.github/workflows/claude-code-review.yml`.

## Why

The step had no timeout, so the job ran at the GitHub default of **360 minutes**. When the action hangs (the Claude step starts, checks out, then stalls with no further output), the check sits `in_progress` indefinitely rather than failing.

This was observed on **PR #522**: a review run sat unchanged for 48 minutes (last update 5 s after start) until it was manually cancelled and re-run — the re-run completed cleanly in 9 minutes. A stalled review is an infra hang, not a slow review.

Capping the step at 10 minutes means a hung run fails fast, the check resolves, and `synchronize`/reopen (or a manual re-run) re-triggers a fresh review. This matches the `timeout-minutes: 10` already used by zep-proprietary's `claude-code-review.yml`.

## Scope

One line (plus an explanatory comment) on the review step. No behavior change for runs that complete normally — a clean review takes well under 10 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)