### PR TITLE
test(integrations): add live integration tests + SETUP guides

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -77,6 +77,10 @@ jobs:
         with:
           package: ${{ matrix.package }}
           python-version: ${{ matrix.python-version }}
+        env:
+          ZEP_API_KEY: ${{ secrets.ZEP_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
   test-typescript:
     runs-on: ubuntu-latest
@@ -94,6 +98,10 @@ jobs:
         with:
           package: ${{ matrix.package }}
           node-version: ${{ matrix.node-version }}
+        env:
+          ZEP_API_KEY: ${{ secrets.ZEP_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
 
   test-go:
     runs-on: ubuntu-latest

--- a/integrations/adk/python/SETUP.md
+++ b/integrations/adk/python/SETUP.md
@@ -1,0 +1,97 @@
+# Setup Guide
+
+This guide walks you from a fresh machine to running the example agent with Zep memory.
+
+## 1. Sign up for Zep and create an API key
+
+1. Go to [https://www.getzep.com](https://www.getzep.com) and create an account.
+2. Open the [Zep dashboard](https://app.getzep.com) and select (or create) a project.
+3. In the project settings, go to **API Keys** and create a new key.
+4. Copy the key — you will set it as `ZEP_API_KEY` below.
+
+Zep is a paid product; see [getzep.com](https://www.getzep.com) for plan details.
+
+## 2. Get a Google API key (for the Gemini model)
+
+The bundled example and live tests drive a Google ADK agent with a Gemini model,
+so a live run needs a Google API key:
+
+1. Create a key at [Google AI Studio](https://aistudio.google.com/app/apikey).
+2. Copy it for `GOOGLE_API_KEY`.
+
+You only need this to run the model. The Zep integration wiring (persisting
+messages, injecting context) works with any ADK-supported model — swap `model=`
+in the example for your provider.
+
+## 3. Install
+
+Using `pip`:
+
+```bash
+pip install zep-adk
+```
+
+Or, to work from the repository with `uv`:
+
+```bash
+git clone https://github.com/getzep/zep.git
+cd zep/integrations/adk/python
+make install        # uv sync --extra dev
+```
+
+Requirements: Python 3.11+, `google-adk>=1.0.0`, `zep-cloud>=3.23.0`.
+
+## 4. Configure environment variables
+
+```bash
+export ZEP_API_KEY="your-zep-api-key"
+export GOOGLE_API_KEY="your-google-api-key"
+```
+
+## 5. Run the example
+
+From the repository:
+
+```bash
+uv run python examples/basic_agent.py
+```
+
+Or, if you installed with `pip`:
+
+```bash
+python examples/basic_agent.py
+```
+
+The example:
+
+1. Seeds facts about a user across two turns in one thread.
+2. Waits for Zep to process the knowledge graph (ingestion is asynchronous).
+3. Starts a **new** thread for the same user and asks recall questions — the
+   agent answers using facts fused into the user's graph from the first thread.
+
+## 6. Run the tests
+
+Mock-based tests (no API keys needed):
+
+```bash
+make test
+```
+
+Live integration test (requires `ZEP_API_KEY` and `GOOGLE_API_KEY`). It runs as a
+standalone script — not under pytest — and exits non-zero if any check fails:
+
+```bash
+uv run python tests/test_integration.py
+```
+
+## Troubleshooting
+
+- **`ZEP_API_KEY is not set`** — export the key (step 4) before running.
+- **`GOOGLE_API_KEY is not set`** — the example uses a Gemini model; export the
+  key, or swap `model=` in the example for an ADK-supported provider you have a
+  key for.
+- **Recall returns nothing** — Zep ingestion is asynchronous; a just-added fact
+  is not instantly retrievable. The example waits for the graph to build;
+  increase the wait if your graph is large or under load.
+- **Authentication errors** — confirm `ZEP_API_KEY` is set in the same shell and
+  belongs to the intended project.

--- a/integrations/adk/python/tests/test_integration.py
+++ b/integrations/adk/python/tests/test_integration.py
@@ -119,89 +119,6 @@ async def send_message(runner: Runner, session_id: str, user_id: str, text: str)
     return " ".join(response_parts).strip()
 
 
-async def recall_until(
-    runner: Runner,
-    session_id: str,
-    user_id: str,
-    message: str,
-    keywords: list[str],
-    *,
-    attempts: int = 3,
-    delay: float = 10.0,
-) -> tuple[str, list[str]]:
-    """Send ``message`` until at least one of ``keywords`` appears in the reply.
-
-    Recall depends on two eventually-consistent, nondeterministic factors: Zep
-    finishing fact extraction/fusion (episodes reporting ``processed`` does not
-    guarantee the edges are immediately searchable), and the model choosing to
-    surface those facts. Retry a few times -- tolerating transient model errors
-    such as Gemini 503s -- so a single lagging attempt does not fail the run.
-    Returns the last response and the matched keywords.
-    """
-    response = ""
-    for attempt in range(1, attempts + 1):
-        try:
-            response = await send_message(runner, session_id, user_id, message)
-        except Exception as exc:
-            logger.warning("Recall attempt %d/%d errored: %s", attempt, attempts, exc)
-            if attempt < attempts:
-                await asyncio.sleep(delay)
-            continue
-        found = [kw for kw in keywords if kw in response.lower()]
-        if found:
-            return response, found
-        if attempt < attempts:
-            logger.info(
-                "Recall attempt %d/%d found none of %s; retrying in %.0fs...",
-                attempt,
-                attempts,
-                keywords,
-                delay,
-            )
-            await asyncio.sleep(delay)
-    return response, []
-
-
-async def wait_for_facts_searchable(
-    zep_client: AsyncZep,
-    user_id: str,
-    required_keywords: list[str],
-    timeout_seconds: int = 90,
-    poll_interval: float = 3.0,
-) -> None:
-    """Poll ``graph.search`` until every required keyword appears in a fact.
-
-    Episodes reporting ``processed`` does not guarantee the extracted edges are
-    immediately searchable. Gate the (quota-limited) model-driven recall steps
-    on the facts actually being retrievable, so each step succeeds on its first
-    model call. This polls Zep search only -- no model calls -- so it is free.
-    """
-    start = time.monotonic()
-    remaining = {kw.lower() for kw in required_keywords}
-    while remaining:
-        try:
-            results = await zep_client.graph.search(
-                user_id=user_id,
-                query="user profile job location hobbies",
-                scope="edges",
-                limit=25,
-            )
-            facts = " ".join((e.fact or "") for e in (results.edges or [])).lower()
-            remaining = {kw for kw in remaining if kw not in facts}
-        except Exception as exc:
-            logger.warning("Fact-readiness search errored: %s", exc)
-        if not remaining:
-            logger.info("All seed facts are searchable.")
-            return
-        if time.monotonic() - start > timeout_seconds:
-            logger.warning(
-                "Timed out waiting for facts to become searchable; missing=%s",
-                sorted(remaining),
-            )
-            return
-        await asyncio.sleep(poll_interval)
-
-
 async def wait_for_episodes_processed(
     zep_client: AsyncZep,
     user_id: str,
@@ -425,11 +342,6 @@ async def main() -> None:
         # ==================================================================
         print("\n[Step 6] Waiting for Zep to process episodes...")
         await wait_for_episodes_processed(zep_client, USER_ID, timeout_seconds=120)
-        await wait_for_facts_searchable(
-            zep_client,
-            USER_ID,
-            ["acme", "data scientist", "portland", "hiking", "photography"],
-        )
 
         # ==================================================================
         # Step 7: Session 2 — cross-thread memory recall
@@ -450,18 +362,20 @@ async def main() -> None:
 
         recall_message = "What do you know about me?"
         print(f"  User:  {recall_message}")
-        recall_keywords = ["acme", "data scientist", "hiking", "photography", "portland"]
-        response2, found_keywords = await recall_until(
-            runner, SESSION_2_ID, USER_ID, recall_message, recall_keywords
-        )
-        print(f"  Agent: {response2}")
-        print(f"  Recall keywords found: {found_keywords}")
+        response2 = await send_message(runner, SESSION_2_ID, USER_ID, recall_message)
+        print(f"  Agent: {response2}\n")
 
         passed &= check(
             "on_user_created hook did NOT fire again for existing user",
             len(hook_calls) == 1,
             f"hook_calls={len(hook_calls)}",
         )
+
+        # Check that the agent recalled at least some seeded facts
+        recall_keywords = ["acme", "data scientist", "hiking", "photography", "portland"]
+        response_lower = response2.lower()
+        found_keywords = [kw for kw in recall_keywords if kw in response_lower]
+        print(f"  Recall keywords found: {found_keywords}")
 
         passed &= check(
             "Agent recalled facts from first conversation",
@@ -505,11 +419,12 @@ async def main() -> None:
             "about my hobbies. Tell me exactly what the search returns."
         )
         print(f"  User:  {search_message}")
+        response3 = await send_message(runner, SESSION_3_ID, USER_ID, search_message)
+        print(f"  Agent: {response3}\n")
+
+        response3_lower = response3.lower()
         hobby_keywords = ["hiking", "photography"]
-        response3, found_hobby_kw = await recall_until(
-            runner, SESSION_3_ID, USER_ID, search_message, hobby_keywords
-        )
-        print(f"  Agent: {response3}")
+        found_hobby_kw = [kw for kw in hobby_keywords if kw in response3_lower]
         print(f"  Hobby keywords found: {found_hobby_kw}")
 
         passed &= check(
@@ -576,11 +491,12 @@ async def main() -> None:
             "about where I live. Tell me exactly what the search returns."
         )
         print(f"  User:  {auto_search_message}")
+        response5 = await send_message(auto_runner, SESSION_5_ID, USER_ID, auto_search_message)
+        print(f"  Agent: {response5}\n")
+
+        response5_lower = response5.lower()
         auto_keywords = ["portland", "oregon"]
-        response5, found_auto_kw = await recall_until(
-            auto_runner, SESSION_5_ID, USER_ID, auto_search_message, auto_keywords
-        )
-        print(f"  Agent: {response5}")
+        found_auto_kw = [kw for kw in auto_keywords if kw in response5_lower]
         print(f"  Auto-scope keywords found: {found_auto_kw}")
 
         passed &= check(

--- a/integrations/adk/python/tests/test_integration.py
+++ b/integrations/adk/python/tests/test_integration.py
@@ -119,6 +119,89 @@ async def send_message(runner: Runner, session_id: str, user_id: str, text: str)
     return " ".join(response_parts).strip()
 
 
+async def recall_until(
+    runner: Runner,
+    session_id: str,
+    user_id: str,
+    message: str,
+    keywords: list[str],
+    *,
+    attempts: int = 3,
+    delay: float = 10.0,
+) -> tuple[str, list[str]]:
+    """Send ``message`` until at least one of ``keywords`` appears in the reply.
+
+    Recall depends on two eventually-consistent, nondeterministic factors: Zep
+    finishing fact extraction/fusion (episodes reporting ``processed`` does not
+    guarantee the edges are immediately searchable), and the model choosing to
+    surface those facts. Retry a few times -- tolerating transient model errors
+    such as Gemini 503s -- so a single lagging attempt does not fail the run.
+    Returns the last response and the matched keywords.
+    """
+    response = ""
+    for attempt in range(1, attempts + 1):
+        try:
+            response = await send_message(runner, session_id, user_id, message)
+        except Exception as exc:
+            logger.warning("Recall attempt %d/%d errored: %s", attempt, attempts, exc)
+            if attempt < attempts:
+                await asyncio.sleep(delay)
+            continue
+        found = [kw for kw in keywords if kw in response.lower()]
+        if found:
+            return response, found
+        if attempt < attempts:
+            logger.info(
+                "Recall attempt %d/%d found none of %s; retrying in %.0fs...",
+                attempt,
+                attempts,
+                keywords,
+                delay,
+            )
+            await asyncio.sleep(delay)
+    return response, []
+
+
+async def wait_for_facts_searchable(
+    zep_client: AsyncZep,
+    user_id: str,
+    required_keywords: list[str],
+    timeout_seconds: int = 90,
+    poll_interval: float = 3.0,
+) -> None:
+    """Poll ``graph.search`` until every required keyword appears in a fact.
+
+    Episodes reporting ``processed`` does not guarantee the extracted edges are
+    immediately searchable. Gate the (quota-limited) model-driven recall steps
+    on the facts actually being retrievable, so each step succeeds on its first
+    model call. This polls Zep search only -- no model calls -- so it is free.
+    """
+    start = time.monotonic()
+    remaining = {kw.lower() for kw in required_keywords}
+    while remaining:
+        try:
+            results = await zep_client.graph.search(
+                user_id=user_id,
+                query="user profile job location hobbies",
+                scope="edges",
+                limit=25,
+            )
+            facts = " ".join((e.fact or "") for e in (results.edges or [])).lower()
+            remaining = {kw for kw in remaining if kw not in facts}
+        except Exception as exc:
+            logger.warning("Fact-readiness search errored: %s", exc)
+        if not remaining:
+            logger.info("All seed facts are searchable.")
+            return
+        if time.monotonic() - start > timeout_seconds:
+            logger.warning(
+                "Timed out waiting for facts to become searchable; missing=%s",
+                sorted(remaining),
+            )
+            return
+        await asyncio.sleep(poll_interval)
+
+
 async def wait_for_episodes_processed(
     zep_client: AsyncZep,
     user_id: str,
@@ -337,6 +420,11 @@ async def main() -> None:
         # ==================================================================
         print("\n[Step 6] Waiting for Zep to process episodes...")
         await wait_for_episodes_processed(zep_client, USER_ID, timeout_seconds=120)
+        await wait_for_facts_searchable(
+            zep_client,
+            USER_ID,
+            ["acme", "data scientist", "portland", "hiking", "photography"],
+        )
 
         # ==================================================================
         # Step 7: Session 2 — cross-thread memory recall
@@ -357,20 +445,18 @@ async def main() -> None:
 
         recall_message = "What do you know about me?"
         print(f"  User:  {recall_message}")
-        response2 = await send_message(runner, SESSION_2_ID, USER_ID, recall_message)
-        print(f"  Agent: {response2}\n")
+        recall_keywords = ["acme", "data scientist", "hiking", "photography", "portland"]
+        response2, found_keywords = await recall_until(
+            runner, SESSION_2_ID, USER_ID, recall_message, recall_keywords
+        )
+        print(f"  Agent: {response2}")
+        print(f"  Recall keywords found: {found_keywords}")
 
         passed &= check(
             "on_user_created hook did NOT fire again for existing user",
             len(hook_calls) == 1,
             f"hook_calls={len(hook_calls)}",
         )
-
-        # Check that the agent recalled at least some seeded facts
-        recall_keywords = ["acme", "data scientist", "hiking", "photography", "portland"]
-        response_lower = response2.lower()
-        found_keywords = [kw for kw in recall_keywords if kw in response_lower]
-        print(f"  Recall keywords found: {found_keywords}")
 
         passed &= check(
             "Agent recalled facts from first conversation",
@@ -414,12 +500,11 @@ async def main() -> None:
             "about my hobbies. Tell me exactly what the search returns."
         )
         print(f"  User:  {search_message}")
-        response3 = await send_message(runner, SESSION_3_ID, USER_ID, search_message)
-        print(f"  Agent: {response3}\n")
-
-        response3_lower = response3.lower()
         hobby_keywords = ["hiking", "photography"]
-        found_hobby_kw = [kw for kw in hobby_keywords if kw in response3_lower]
+        response3, found_hobby_kw = await recall_until(
+            runner, SESSION_3_ID, USER_ID, search_message, hobby_keywords
+        )
+        print(f"  Agent: {response3}")
         print(f"  Hobby keywords found: {found_hobby_kw}")
 
         passed &= check(
@@ -486,12 +571,11 @@ async def main() -> None:
             "about where I live. Tell me exactly what the search returns."
         )
         print(f"  User:  {auto_search_message}")
-        response5 = await send_message(auto_runner, SESSION_5_ID, USER_ID, auto_search_message)
-        print(f"  Agent: {response5}\n")
-
-        response5_lower = response5.lower()
         auto_keywords = ["portland", "oregon"]
-        found_auto_kw = [kw for kw in auto_keywords if kw in response5_lower]
+        response5, found_auto_kw = await recall_until(
+            auto_runner, SESSION_5_ID, USER_ID, auto_search_message, auto_keywords
+        )
+        print(f"  Agent: {response5}")
         print(f"  Auto-scope keywords found: {found_auto_kw}")
 
         passed &= check(

--- a/integrations/adk/python/tests/test_integration.py
+++ b/integrations/adk/python/tests/test_integration.py
@@ -338,10 +338,14 @@ async def main() -> None:
             passed = False
 
         # ==================================================================
-        # Step 6: Wait for Zep to process episodes
+        # Step 6: Wait for Zep to process episodes, then wait a second time
+        # so that graph node/edge extraction (which runs after episode
+        # processing) has time to complete before recall and search.
         # ==================================================================
-        print("\n[Step 6] Waiting for Zep to process episodes...")
-        await wait_for_episodes_processed(zep_client, USER_ID, timeout_seconds=120)
+        print("\n[Step 6] Waiting for Zep to process episodes (pass 1)...")
+        await wait_for_episodes_processed(zep_client, USER_ID, timeout_seconds=180)
+        print("\n[Step 6b] Waiting for graph node/edge extraction (pass 2)...")
+        await wait_for_episodes_processed(zep_client, USER_ID, timeout_seconds=180)
 
         # ==================================================================
         # Step 7: Session 2 — cross-thread memory recall
@@ -602,8 +606,18 @@ async def main() -> None:
         print("RESULT: SOME CHECKS FAILED")
     print("=" * 70)
 
-    sys.exit(0 if passed else 1)
+    assert passed, "One or more integration checks failed — see PASS/FAIL lines above"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_full_lifecycle() -> None:
+    """Pytest entry point for the live ADK integration test."""
+    await main()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except AssertionError:
+        sys.exit(1)

--- a/integrations/adk/python/tests/test_integration.py
+++ b/integrations/adk/python/tests/test_integration.py
@@ -219,7 +219,12 @@ async def wait_for_episodes_processed(
             )
             return
 
-        episodes_resp = await zep_client.graph.episode.get_by_user_id(user_id=user_id, lastn=10)
+        try:
+            episodes_resp = await zep_client.graph.episode.get_by_user_id(user_id=user_id, lastn=10)
+        except Exception as exc:
+            logger.warning("Episode poll failed (%s); retrying.", exc)
+            await asyncio.sleep(poll_interval)
+            continue
         episodes = episodes_resp.episodes or []
 
         if not episodes:

--- a/integrations/adk/typescript/test/live.test.ts
+++ b/integrations/adk/typescript/test/live.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { ZepClient } from "@getzep/zep-cloud";
+import { randomUUID } from "node:crypto";
+import {
+  ZepResourceManager,
+  ZepGraphSearchTool,
+  persistAndInject,
+  defaultLogger,
+} from "../src/index.js";
+import { fakeContext, fakeLlmRequest } from "./helpers.js";
+
+const apiKey = process.env.ZEP_API_KEY;
+
+// These tests hit the real Zep API and only run when ZEP_API_KEY is set.
+// Ingestion is asynchronous, so they assert the calls succeed and return the
+// right shapes — not that a just-written fact is instantly retrievable.
+// (ADK is normally Gemini-driven; here we drive the integration's core
+// persist-and-inject logic directly, so no model key is needed.)
+const describeLive = apiKey ? describe : describe.skip;
+
+describeLive("live Zep integration", () => {
+  it("provisions identity, persists, and injects context without throwing", async () => {
+    const client = new ZepClient({ apiKey });
+    const userId = `zep-adk-test-${randomUUID()}`;
+    const threadId = `thread-${randomUUID()}`;
+    const identity = {
+      userId,
+      threadId,
+      firstName: "Test",
+      lastName: "User",
+      email: `${userId}@example.com`,
+    };
+
+    try {
+      const resources = new ZepResourceManager(client, defaultLogger);
+
+      // First turn: persist the user message and inject the Context Block. The
+      // call creates the Zep user + thread lazily and never throws on a Zep
+      // error (returns undefined instead).
+      const llmRequest = fakeLlmRequest();
+      const injected = await persistAndInject({
+        zep: client,
+        resources,
+        logger: defaultLogger,
+        context: fakeContext({
+          userId,
+          userText: "My favorite color is teal and I live in Portland.",
+          invocationId: "inv-1",
+        }),
+        llmRequest,
+        options: identity,
+      });
+      expect(injected === undefined || typeof injected === "string").toBe(true);
+      if (typeof injected === "string") {
+        expect(JSON.stringify(llmRequest.config?.systemInstruction)).toContain(
+          "ZEP_CONTEXT",
+        );
+      }
+
+      // Same invocation id within the turn is de-duplicated (no re-persist).
+      const duplicate = await persistAndInject({
+        zep: client,
+        resources,
+        logger: defaultLogger,
+        context: fakeContext({
+          userId,
+          userText: "My favorite color is teal and I live in Portland.",
+          invocationId: "inv-1",
+        }),
+        llmRequest: fakeLlmRequest(),
+        options: identity,
+      });
+      expect(duplicate).toBeUndefined();
+
+      // The graph-search tool runs against the user's graph and returns a
+      // string result (formatted facts or a graceful message) without throwing.
+      const searchTool = new ZepGraphSearchTool({ zep: client, userId });
+      const result = await searchTool.runAsync({
+        args: { query: "favorite color" },
+        toolContext: fakeContext({ userId }) as never,
+      });
+      expect(typeof result).toBe("string");
+    } finally {
+      try {
+        await client.user.delete(userId);
+      } catch {
+        // Best-effort cleanup; ignore failures.
+      }
+    }
+  }, 60_000);
+});

--- a/integrations/ag2/python/pyproject.toml
+++ b/integrations/ag2/python/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "pytest-asyncio",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "openai>=1.0.0",
 ]
 
 [build-system]

--- a/integrations/ag2/python/tests/test_integration.py
+++ b/integrations/ag2/python/tests/test_integration.py
@@ -179,6 +179,7 @@ async def main() -> None:
 
         # -- Conversation 2: cross-thread memory recall ----------------------
         print("\n[Step 5] Conversation 2: cross-thread memory recall...")
+        await zep.thread.create(thread_id=THREAD_2, user_id=USER_ID)
         manager2 = ZepMemoryManager(zep, user_id=USER_ID, session_id=THREAD_2)
         context = await manager2.get_memory_context(
             query="What do we know about IntegTest's job, location, and hobbies?"
@@ -270,6 +271,7 @@ async def test_integration_full_lifecycle() -> None:
 
         await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
 
+        await zep.thread.create(thread_id=THREAD_2, user_id=USER_ID)
         manager2 = ZepMemoryManager(zep, user_id=USER_ID, session_id=THREAD_2)
         context = await manager2.get_memory_context(
             query="What do we know about IntegTest's job, location, and hobbies?"

--- a/integrations/ag2/python/tests/test_integration.py
+++ b/integrations/ag2/python/tests/test_integration.py
@@ -1,0 +1,297 @@
+"""
+End-to-end integration test for the Zep AG2 integration.
+
+Exercises the full lifecycle against live Zep and OpenAI:
+
+  1. ``ZepMemoryManager.add_messages`` persists a conversation to a Zep thread.
+  2. Both sides of the conversation are captured on the thread.
+  3. Cross-thread memory recall: a second thread for the same user recalls facts
+     seeded in the first thread (proving recall comes from the user graph).
+  4. A live AG2 agent, enriched with Zep context, recalls those facts in its reply.
+  5. Zep resource verification via the SDK (user metadata, thread messages).
+
+Requires:
+    ZEP_API_KEY and OPENAI_API_KEY environment variables.
+
+Usage:
+    uv run pytest tests/test_integration.py -v -s -m integration
+    # or standalone:
+    uv run python tests/test_integration.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from uuid import uuid4
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Configuration -- skip the whole module when API keys are not available.
+# ---------------------------------------------------------------------------
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+if not ZEP_API_KEY or not OPENAI_API_KEY:
+    pytest.skip(
+        "ZEP_API_KEY and OPENAI_API_KEY required for integration tests",
+        allow_module_level=True,
+    )
+
+from autogen import AssistantAgent, LLMConfig, UserProxyAgent  # noqa: E402
+from zep_cloud.client import AsyncZep  # noqa: E402
+
+from zep_ag2 import ZepMemoryManager, register_all_tools  # noqa: E402
+
+# Unique IDs per run to avoid collisions.
+_suffix = uuid4().hex[:8]
+USER_ID = f"ag2-integ-{_suffix}"
+THREAD_1 = f"ag2-integ-t1-{_suffix}"
+THREAD_2 = f"ag2-integ-t2-{_suffix}"
+
+FIRST_NAME = "IntegTest"
+LAST_NAME = "User"
+EMAIL = f"integtest-{_suffix}@example.com"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("test_integration")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("openai").setLevel(logging.WARNING)
+
+
+def check(description: str, condition: bool, detail: str = "") -> bool:
+    """Print a PASS/FAIL line and return the condition."""
+    status = "PASS" if condition else "FAIL"
+    msg = f"  {status}: {description}"
+    if detail:
+        msg += f" ({detail})"
+    print(msg)
+    return condition
+
+
+async def wait_for_episodes_processed(
+    zep: AsyncZep,
+    user_id: str,
+    timeout_seconds: int = 120,
+    poll_interval: float = 3.0,
+) -> None:
+    """Poll Zep episodes until all are processed or the timeout is reached."""
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > timeout_seconds:
+            logger.warning("Timed out waiting for episode processing; continuing.")
+            return
+        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        episodes = resp.episodes or []
+        if episodes and all(e.processed for e in episodes):
+            logger.info("All %d episodes processed.", len(episodes))
+            return
+        await asyncio.sleep(poll_interval)
+
+
+def build_agent(zep: AsyncZep, thread_id: str) -> tuple[AssistantAgent, UserProxyAgent]:
+    """Build an AG2 assistant/user pair wired to Zep memory on the given thread."""
+    llm_config = LLMConfig({"model": OPENAI_MODEL, "api_key": OPENAI_API_KEY})
+    assistant = AssistantAgent(
+        name="assistant",
+        llm_config=llm_config,
+        system_message=(
+            "You are a helpful assistant with long-term memory. When context from "
+            "Zep is provided, use it to answer questions about the user. Be concise."
+        ),
+    )
+    user_proxy = UserProxyAgent(
+        name="user",
+        human_input_mode="NEVER",
+        code_execution_config=False,
+        is_termination_msg=lambda msg: "TERMINATE" in (msg.get("content") or ""),
+    )
+    register_all_tools(assistant, user_proxy, zep, user_id=USER_ID, session_id=thread_id)
+    return assistant, user_proxy
+
+
+async def main() -> None:
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+    passed = True
+
+    print(f"\n{'=' * 70}")
+    print("Zep AG2 Integration Test")
+    print(f"  User:    {USER_ID}")
+    print(f"  Threads: {THREAD_1}, {THREAD_2}")
+    print(f"{'=' * 70}\n")
+
+    try:
+        # -- One-time Zep setup: create the user and thread out-of-band. ------
+        await zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        await zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        # -- Conversation 1: seed facts via the integration. -----------------
+        print("[Step 1] Conversation 1: seeding facts...")
+        manager1 = ZepMemoryManager(zep, user_id=USER_ID, session_id=THREAD_1)
+        seeds = [
+            ("user", "My name is IntegTest. I work at Acme Corp as a data scientist."),
+            (
+                "assistant",
+                "Nice to meet you, IntegTest -- noted that you're a data scientist at Acme Corp.",
+            ),
+            ("user", "I live in Portland, Oregon and I love hiking and photography."),
+            ("assistant", "Got it -- Portland, Oregon, plus hiking and photography."),
+        ]
+        await manager1.add_messages(
+            [
+                {"role": role, "content": content, "name": FIRST_NAME if role == "user" else None}
+                for role, content in seeds
+            ]
+        )
+        for role, content in seeds:
+            print(f"  {role.capitalize()}: {content}")
+
+        # -- Verify user metadata --------------------------------------------
+        print("\n[Step 2] Verifying Zep user metadata...")
+        user = await zep.user.get(user_id=USER_ID)
+        passed &= check("first_name matches", user.first_name == FIRST_NAME, str(user.first_name))
+        passed &= check("last_name matches", user.last_name == LAST_NAME, str(user.last_name))
+        passed &= check("email matches", user.email == EMAIL, str(user.email))
+
+        # -- Verify thread 1 captured both sides -----------------------------
+        print("\n[Step 3] Verifying thread 1 messages...")
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        user_msgs = [m for m in messages if m.role == "user"]
+        asst_msgs = [m for m in messages if m.role == "assistant"]
+        print(f"  {len(user_msgs)} user, {len(asst_msgs)} assistant messages")
+        passed &= check("Thread 1 has user messages", len(user_msgs) >= 2, f"{len(user_msgs)}")
+        passed &= check("Thread 1 has assistant messages", len(asst_msgs) >= 2, f"{len(asst_msgs)}")
+
+        # -- Wait for graph ingestion ----------------------------------------
+        print("\n[Step 4] Waiting for Zep to process episodes...")
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        # -- Conversation 2: cross-thread memory recall ----------------------
+        print("\n[Step 5] Conversation 2: cross-thread memory recall...")
+        manager2 = ZepMemoryManager(zep, user_id=USER_ID, session_id=THREAD_2)
+        context = await manager2.get_memory_context(
+            query="What do we know about IntegTest's job, location, and hobbies?"
+        )
+        recalled = context.lower()
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        found = [kw for kw in keywords if kw in recalled]
+        print(f"  Recalled keywords (context block): {found}")
+        passed &= check(
+            "Zep context recalls facts from conversation 1",
+            len(found) > 0,
+            f"found={found}",
+        )
+
+        assistant, user_proxy = build_agent(zep, THREAD_2)
+        await manager2.enrich_system_message(assistant, query="IntegTest profile and hobbies")
+        result = user_proxy.initiate_chat(
+            assistant,
+            message=(
+                "Based on what you know about me, where do I work, what is my role, and "
+                "where do I live? Answer in one sentence, then say TERMINATE."
+            ),
+            max_turns=2,
+        )
+        transcript = " ".join(
+            str(m.get("content") or "") for m in (result.chat_history or [])
+        ).lower()
+        agent_found = [kw for kw in keywords if kw in transcript]
+        print(f"  Agent recalled keywords: {agent_found}")
+        passed &= check(
+            "Agent recalled facts from conversation 1",
+            len(agent_found) > 0,
+            f"found={agent_found}",
+        )
+
+    finally:
+        print("\n[Cleanup] Deleting test user...")
+        try:
+            await zep.user.delete(user_id=USER_ID)
+            print(f"  Deleted {USER_ID}")
+        except Exception as exc:
+            print(f"  Warning: could not delete user: {exc}")
+
+    print(f"\n{'=' * 70}")
+    print("RESULT:", "ALL CHECKS PASSED" if passed else "SOME CHECKS FAILED")
+    print("=" * 70)
+    sys.exit(0 if passed else 1)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_full_lifecycle() -> None:
+    """Pytest entry point for the live integration test."""
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+
+    try:
+        await zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        await zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        manager1 = ZepMemoryManager(zep, user_id=USER_ID, session_id=THREAD_1)
+        await manager1.add_messages(
+            [
+                {
+                    "role": "user",
+                    "name": FIRST_NAME,
+                    "content": "My name is IntegTest. I work at Acme Corp as a data scientist.",
+                },
+                {"role": "assistant", "content": "Noted -- a data scientist at Acme Corp."},
+                {
+                    "role": "user",
+                    "name": FIRST_NAME,
+                    "content": "I live in Portland, Oregon and I love hiking and photography.",
+                },
+                {
+                    "role": "assistant",
+                    "content": "Got it -- Portland, Oregon, hiking and photography.",
+                },
+            ]
+        )
+
+        user = await zep.user.get(user_id=USER_ID)
+        assert user.first_name == FIRST_NAME
+        assert user.email == EMAIL
+
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        assert any(m.role == "user" for m in messages)
+        assert any(m.role == "assistant" for m in messages)
+
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        manager2 = ZepMemoryManager(zep, user_id=USER_ID, session_id=THREAD_2)
+        context = await manager2.get_memory_context(
+            query="What do we know about IntegTest's job, location, and hobbies?"
+        )
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        assert any(kw in context.lower() for kw in keywords), f"no recall in context: {context}"
+
+        assistant, user_proxy = build_agent(zep, THREAD_2)
+        await manager2.enrich_system_message(assistant, query="IntegTest profile and hobbies")
+        result = user_proxy.initiate_chat(
+            assistant,
+            message=(
+                "Based on what you know about me, where do I work, what is my role, and "
+                "where do I live? Answer in one sentence, then say TERMINATE."
+            ),
+            max_turns=2,
+        )
+        transcript = " ".join(
+            str(m.get("content") or "") for m in (result.chat_history or [])
+        ).lower()
+        assert any(kw in transcript for kw in keywords), f"no recall in: {transcript}"
+    finally:
+        try:
+            await zep.user.delete(user_id=USER_ID)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/ag2/python/tests/test_integration.py
+++ b/integrations/ag2/python/tests/test_integration.py
@@ -86,7 +86,12 @@ async def wait_for_episodes_processed(
         if time.monotonic() - start > timeout_seconds:
             logger.warning("Timed out waiting for episode processing; continuing.")
             return
-        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        try:
+            resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        except Exception as exc:
+            logger.warning("Episode poll failed (%s); retrying.", exc)
+            await asyncio.sleep(poll_interval)
+            continue
         episodes = resp.episodes or []
         if episodes and all(e.processed for e in episodes):
             logger.info("All %d episodes processed.", len(episodes))

--- a/integrations/autogen/python/SETUP.md
+++ b/integrations/autogen/python/SETUP.md
@@ -1,0 +1,95 @@
+# Setup Guide
+
+This guide walks you from a fresh machine to running the example agent with Zep memory.
+
+## 1. Sign up for Zep and create an API key
+
+1. Go to [https://www.getzep.com](https://www.getzep.com) and create an account.
+2. Open the [Zep dashboard](https://app.getzep.com) and select (or create) a project.
+3. In the project settings, go to **API Keys** and create a new key.
+4. Copy the key — you will set it as `ZEP_API_KEY` below.
+
+Zep is a paid product; see [getzep.com](https://www.getzep.com) for plan details.
+
+## 2. Get an OpenAI API key (for the example)
+
+The integration itself is model-agnostic, but the bundled examples and live
+tests drive the agent with OpenAI. Create a key at
+[platform.openai.com/api-keys](https://platform.openai.com/api-keys) and copy it
+for `OPENAI_API_KEY`.
+
+## 3. Install
+
+Using `pip`:
+
+```bash
+pip install zep-autogen
+```
+
+Or, to work from the repository with `uv`:
+
+```bash
+git clone https://github.com/getzep/zep.git
+cd zep/integrations/autogen/python
+make install        # uv sync --extra dev
+```
+
+Requirements: Python 3.11+, `autogen-agentchat>=0.7.0`,
+`autogen-ext[azure,openai]>=0.7.0`, `zep-cloud>=3.23.0`.
+
+## 4. Configure environment variables
+
+```bash
+export ZEP_API_KEY="your-zep-api-key"
+export OPENAI_API_KEY="your-openai-api-key"
+
+# Optional: override the OpenAI model used by the live test (default: gpt-4o-mini)
+export OPENAI_MODEL="gpt-4o-mini"
+```
+
+## 5. Run the example
+
+From the repository:
+
+```bash
+uv run python examples/autogen_basic.py
+```
+
+Or, if you installed with `pip`:
+
+```bash
+python examples/autogen_basic.py
+```
+
+Other runnable examples live in [`examples/`](examples):
+
+- `autogen_basic.py` — `ZepUserMemory` with automatic context injection
+- `autogen_graph.py` — knowledge-graph memory with a custom ontology
+- `autogen_tools_search.py` — read-only graph search tool
+- `autogen_tools_full.py` — search + add graph data tools
+
+## 6. Run the tests
+
+Mock-based tests (no API keys needed):
+
+```bash
+make test
+```
+
+Live integration test (requires `ZEP_API_KEY` and `OPENAI_API_KEY`):
+
+```bash
+uv run pytest tests/test_integration.py -v -s -m integration
+```
+
+## Troubleshooting
+
+- **`ZepDependencyError` on import** — AutoGen is not installed. Run
+  `pip install zep-autogen` (which pulls `autogen-agentchat` and `autogen-ext`).
+- **Recall returns nothing** — Zep ingestion is asynchronous; a just-added fact
+  is not instantly retrievable. The live test waits for the graph to build;
+  increase the wait if your graph is large or under load.
+- **Raw tool output instead of natural language** — set `reflect_on_tool_use=True`
+  on the agent when using the graph tools.
+- **Authentication errors** — confirm `ZEP_API_KEY` is set in the same shell and
+  belongs to the intended project.

--- a/integrations/autogen/python/tests/test_integration.py
+++ b/integrations/autogen/python/tests/test_integration.py
@@ -89,7 +89,12 @@ async def wait_for_episodes_processed(
         if time.monotonic() - start > timeout_seconds:
             logger.warning("Timed out waiting for episode processing; continuing.")
             return
-        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        try:
+            resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        except Exception as exc:
+            logger.warning("Episode poll failed (%s); retrying.", exc)
+            await asyncio.sleep(poll_interval)
+            continue
         episodes = resp.episodes or []
         if episodes and all(e.processed for e in episodes):
             logger.info("All %d episodes processed.", len(episodes))

--- a/integrations/autogen/python/tests/test_integration.py
+++ b/integrations/autogen/python/tests/test_integration.py
@@ -1,0 +1,258 @@
+"""
+End-to-end integration test for the Zep AutoGen integration.
+
+Exercises the full lifecycle against live Zep and OpenAI:
+
+  1. ``ZepUserMemory.add`` persists user and assistant turns to a Zep thread.
+  2. Both sides of the conversation are captured on the thread.
+  3. Cross-thread memory recall: a second thread for the same user recalls facts
+     seeded in the first thread (proving recall comes from the user graph).
+  4. A live AutoGen agent (``memory=[ZepUserMemory]``) recalls those facts in its
+     reply, with context injected automatically via ``update_context``.
+  5. Zep resource verification via the SDK (user metadata, thread messages).
+
+Requires:
+    ZEP_API_KEY and OPENAI_API_KEY environment variables.
+
+Usage:
+    uv run pytest tests/test_integration.py -v -s -m integration
+    # or standalone:
+    uv run python tests/test_integration.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from uuid import uuid4
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Configuration -- skip the whole module when API keys are not available.
+# ---------------------------------------------------------------------------
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+if not ZEP_API_KEY or not OPENAI_API_KEY:
+    pytest.skip(
+        "ZEP_API_KEY and OPENAI_API_KEY required for integration tests",
+        allow_module_level=True,
+    )
+
+from autogen_agentchat.agents import AssistantAgent  # noqa: E402
+from autogen_core.memory import MemoryContent, MemoryMimeType  # noqa: E402
+from autogen_ext.models.openai import OpenAIChatCompletionClient  # noqa: E402
+from zep_cloud.client import AsyncZep  # noqa: E402
+
+from zep_autogen import ZepUserMemory  # noqa: E402
+
+# Unique IDs per run to avoid collisions.
+_suffix = uuid4().hex[:8]
+USER_ID = f"autogen-integ-{_suffix}"
+THREAD_1 = f"autogen-integ-t1-{_suffix}"
+THREAD_2 = f"autogen-integ-t2-{_suffix}"
+
+FIRST_NAME = "IntegTest"
+LAST_NAME = "User"
+EMAIL = f"integtest-{_suffix}@example.com"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("test_integration")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("openai").setLevel(logging.WARNING)
+
+
+def check(description: str, condition: bool, detail: str = "") -> bool:
+    """Print a PASS/FAIL line and return the condition."""
+    status = "PASS" if condition else "FAIL"
+    msg = f"  {status}: {description}"
+    if detail:
+        msg += f" ({detail})"
+    print(msg)
+    return condition
+
+
+async def wait_for_episodes_processed(
+    zep: AsyncZep,
+    user_id: str,
+    timeout_seconds: int = 120,
+    poll_interval: float = 3.0,
+) -> None:
+    """Poll Zep episodes until all are processed or the timeout is reached."""
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > timeout_seconds:
+            logger.warning("Timed out waiting for episode processing; continuing.")
+            return
+        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        episodes = resp.episodes or []
+        if episodes and all(e.processed for e in episodes):
+            logger.info("All %d episodes processed.", len(episodes))
+            return
+        await asyncio.sleep(poll_interval)
+
+
+def build_agent(zep: AsyncZep, thread_id: str) -> tuple[AssistantAgent, ZepUserMemory]:
+    """Build an AutoGen assistant wired to Zep memory on the given thread."""
+    memory = ZepUserMemory(client=zep, thread_id=thread_id, user_id=USER_ID)
+    agent = AssistantAgent(
+        name="MemoryAwareAssistant",
+        model_client=OpenAIChatCompletionClient(model=OPENAI_MODEL),
+        memory=[memory],
+        system_message=(
+            "You are a helpful assistant with long-term memory. Use any injected "
+            "context to answer questions about the user. Be concise."
+        ),
+    )
+    return agent, memory
+
+
+async def store_turn(
+    memory: ZepUserMemory, content: str, role: str, name: str | None = None
+) -> None:
+    """Persist a single conversation turn to Zep via the integration."""
+    await memory.add(
+        MemoryContent(
+            content=content,
+            mime_type=MemoryMimeType.TEXT,
+            metadata={"type": "message", "role": role, "name": name},
+        )
+    )
+
+
+async def main() -> None:
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+    passed = True
+
+    print(f"\n{'=' * 70}")
+    print("Zep AutoGen Integration Test")
+    print(f"  User:    {USER_ID}")
+    print(f"  Threads: {THREAD_1}, {THREAD_2}")
+    print(f"{'=' * 70}\n")
+
+    try:
+        # -- One-time Zep setup: create the user and thread out-of-band. ------
+        await zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        await zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        # -- Conversation 1: seed facts via the integration. -----------------
+        print("[Step 1] Conversation 1: seeding facts...")
+        _agent1, memory1 = build_agent(zep, THREAD_1)
+        seeds = [
+            "My name is IntegTest. I work at Acme Corp as a data scientist.",
+            "I live in Portland, Oregon and I love hiking and photography.",
+        ]
+        for msg in seeds:
+            print(f"  User:  {msg}")
+            await store_turn(memory1, msg, "user", FIRST_NAME)
+            response = await _agent1.run(task=msg)
+            reply = str(response.messages[-1].content)
+            print(f"  Agent: {reply}\n")
+            await store_turn(memory1, reply, "assistant")
+            passed &= check("Agent returned a non-empty response", len(reply) > 0)
+
+        # -- Verify user metadata --------------------------------------------
+        print("[Step 2] Verifying Zep user metadata...")
+        user = await zep.user.get(user_id=USER_ID)
+        passed &= check("first_name matches", user.first_name == FIRST_NAME, str(user.first_name))
+        passed &= check("last_name matches", user.last_name == LAST_NAME, str(user.last_name))
+        passed &= check("email matches", user.email == EMAIL, str(user.email))
+
+        # -- Verify thread 1 captured both sides -----------------------------
+        print("\n[Step 3] Verifying thread 1 messages...")
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        user_msgs = [m for m in messages if m.role == "user"]
+        asst_msgs = [m for m in messages if m.role == "assistant"]
+        print(f"  {len(user_msgs)} user, {len(asst_msgs)} assistant messages")
+        passed &= check("Thread 1 has user messages", len(user_msgs) >= 2, f"{len(user_msgs)}")
+        passed &= check("Thread 1 has assistant messages", len(asst_msgs) >= 2, f"{len(asst_msgs)}")
+
+        # -- Wait for graph ingestion ----------------------------------------
+        print("\n[Step 4] Waiting for Zep to process episodes...")
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        # -- Conversation 2: cross-thread memory recall ----------------------
+        print("\n[Step 5] Conversation 2: cross-thread memory recall...")
+        await zep.thread.create(thread_id=THREAD_2, user_id=USER_ID)
+        agent2, memory2 = build_agent(zep, THREAD_2)
+        question = "What do you know about me?"
+        await store_turn(memory2, question, "user", FIRST_NAME)
+        response = await agent2.run(task=question)
+        recall = str(response.messages[-1].content).lower()
+        print(f"  Agent: {recall}\n")
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        found = [kw for kw in keywords if kw in recall]
+        print(f"  Recalled keywords: {found}")
+        passed &= check(
+            "Agent recalled facts from conversation 1",
+            len(found) > 0,
+            f"found={found}",
+        )
+
+    finally:
+        print("\n[Cleanup] Deleting test user...")
+        try:
+            await zep.user.delete(user_id=USER_ID)
+            print(f"  Deleted {USER_ID}")
+        except Exception as exc:
+            print(f"  Warning: could not delete user: {exc}")
+
+    print(f"\n{'=' * 70}")
+    print("RESULT:", "ALL CHECKS PASSED" if passed else "SOME CHECKS FAILED")
+    print("=" * 70)
+    sys.exit(0 if passed else 1)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_full_lifecycle() -> None:
+    """Pytest entry point for the live integration test."""
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+
+    try:
+        await zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        await zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        agent1, memory1 = build_agent(zep, THREAD_1)
+        for msg in (
+            "My name is IntegTest. I work at Acme Corp as a data scientist.",
+            "I live in Portland, Oregon and I love hiking and photography.",
+        ):
+            await store_turn(memory1, msg, "user", FIRST_NAME)
+            response = await agent1.run(task=msg)
+            await store_turn(memory1, str(response.messages[-1].content), "assistant")
+
+        user = await zep.user.get(user_id=USER_ID)
+        assert user.first_name == FIRST_NAME
+        assert user.email == EMAIL
+
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        assert any(m.role == "user" for m in messages)
+        assert any(m.role == "assistant" for m in messages)
+
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        await zep.thread.create(thread_id=THREAD_2, user_id=USER_ID)
+        agent2, memory2 = build_agent(zep, THREAD_2)
+        question = "What do you know about me?"
+        await store_turn(memory2, question, "user", FIRST_NAME)
+        response = await agent2.run(task=question)
+        recall = str(response.messages[-1].content).lower()
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        assert any(kw in recall for kw in keywords), f"no recall in: {recall}"
+    finally:
+        try:
+            await zep.user.delete(user_id=USER_ID)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/crewai/python/SETUP.md
+++ b/integrations/crewai/python/SETUP.md
@@ -1,0 +1,92 @@
+# Setup Guide
+
+This guide walks you from a fresh machine to running the example agent with Zep memory.
+
+## 1. Sign up for Zep and create an API key
+
+1. Go to [https://www.getzep.com](https://www.getzep.com) and create an account.
+2. Open the [Zep dashboard](https://app.getzep.com) and select (or create) a project.
+3. In the project settings, go to **API Keys** and create a new key.
+4. Copy the key — you will set it as `ZEP_API_KEY` below.
+
+Zep is a paid product; see [getzep.com](https://www.getzep.com) for plan details.
+
+## 2. Get an OpenAI API key (for the example)
+
+The integration itself is model-agnostic, but the bundled examples and live
+tests drive the CrewAI agent with OpenAI. Create a key at
+[platform.openai.com/api-keys](https://platform.openai.com/api-keys) and copy it
+for `OPENAI_API_KEY`.
+
+## 3. Install
+
+Using `pip`:
+
+```bash
+pip install zep-crewai
+```
+
+Or, to work from the repository with `uv`:
+
+```bash
+git clone https://github.com/getzep/zep.git
+cd zep/integrations/crewai/python
+make install        # uv sync --extra dev
+```
+
+Requirements: Python 3.11+, `crewai>=1.0.0`, `zep-cloud>=3.23.0`.
+
+## 4. Configure environment variables
+
+```bash
+export ZEP_API_KEY="your-zep-api-key"
+export OPENAI_API_KEY="your-openai-api-key"
+
+# Optional: override the OpenAI model used by the live test (default: gpt-4o-mini)
+export OPENAI_MODEL="gpt-4o-mini"
+```
+
+## 5. Run the example
+
+From the repository:
+
+```bash
+uv run python examples/simple_example.py
+```
+
+Or, if you installed with `pip`:
+
+```bash
+python examples/simple_example.py
+```
+
+Other runnable examples live in [`examples/`](examples):
+
+- `simple_example.py` — `ZepStorage` adapter + the Zep search tool
+- `crewai_user.py` — `ZepUserStorage` for per-user conversation + graph memory
+- `crewai_graph.py` — `ZepGraphStorage` for a shared knowledge graph
+- `crewai_tools.py` — search + add tools across a multi-agent crew
+
+## 6. Run the tests
+
+Mock-based tests (no API keys needed):
+
+```bash
+make test
+```
+
+Live integration test (requires `ZEP_API_KEY` and `OPENAI_API_KEY`):
+
+```bash
+uv run pytest tests/test_integration.py -v -s -m integration
+```
+
+## Troubleshooting
+
+- **`ZepDependencyError` on import** — CrewAI is not installed. Run
+  `pip install zep-crewai` (which pulls `crewai`).
+- **Recall returns nothing** — Zep ingestion is asynchronous; a just-added fact
+  is not instantly retrievable. The example and live test wait for the graph to
+  build; increase the wait if your graph is large or under load.
+- **Authentication errors** — confirm `ZEP_API_KEY` is set in the same shell and
+  belongs to the intended project.

--- a/integrations/crewai/python/pyproject.toml
+++ b/integrations/crewai/python/pyproject.toml
@@ -74,7 +74,6 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.mypy]
-python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/integrations/crewai/python/tests/test_integration.py
+++ b/integrations/crewai/python/tests/test_integration.py
@@ -1,0 +1,277 @@
+"""
+End-to-end integration test for the Zep CrewAI integration.
+
+Exercises the full lifecycle against live Zep and OpenAI. CrewAI is synchronous,
+so this test uses the sync ``Zep`` client throughout:
+
+  1. ``ZepUserStorage.save`` persists conversation turns and facts to Zep.
+  2. Both sides of the conversation are captured on the thread.
+  3. After async graph ingestion, ``ZepUserStorage.search`` recalls the seeded
+     facts from the user graph (thread-independent recall).
+  4. A live CrewAI agent equipped with the Zep search tool recalls those facts.
+  5. Zep resource verification via the SDK (user metadata, thread messages).
+
+Requires:
+    ZEP_API_KEY and OPENAI_API_KEY environment variables.
+
+Usage:
+    uv run pytest tests/test_integration.py -v -s -m integration
+    # or standalone:
+    uv run python tests/test_integration.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from uuid import uuid4
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Configuration -- skip the whole module when API keys are not available.
+# ---------------------------------------------------------------------------
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+if not ZEP_API_KEY or not OPENAI_API_KEY:
+    pytest.skip(
+        "ZEP_API_KEY and OPENAI_API_KEY required for integration tests",
+        allow_module_level=True,
+    )
+
+from crewai import Agent, Crew, Process, Task  # noqa: E402
+from zep_cloud.client import Zep  # noqa: E402
+
+from zep_crewai import ZepUserStorage, create_search_tool  # noqa: E402
+
+# Unique IDs per run to avoid collisions.
+_suffix = uuid4().hex[:8]
+USER_ID = f"crewai-integ-{_suffix}"
+THREAD_1 = f"crewai-integ-t1-{_suffix}"
+THREAD_2 = f"crewai-integ-t2-{_suffix}"
+
+FIRST_NAME = "IntegTest"
+LAST_NAME = "User"
+EMAIL = f"integtest-{_suffix}@example.com"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("test_integration")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("openai").setLevel(logging.WARNING)
+
+
+def check(description: str, condition: bool, detail: str = "") -> bool:
+    """Print a PASS/FAIL line and return the condition."""
+    status = "PASS" if condition else "FAIL"
+    msg = f"  {status}: {description}"
+    if detail:
+        msg += f" ({detail})"
+    print(msg)
+    return condition
+
+
+def wait_for_episodes_processed(
+    zep: Zep,
+    user_id: str,
+    timeout_seconds: int = 120,
+    poll_interval: float = 3.0,
+) -> None:
+    """Poll Zep episodes until all are processed or the timeout is reached (sync)."""
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > timeout_seconds:
+            logger.warning("Timed out waiting for episode processing; continuing.")
+            return
+        resp = zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        episodes = resp.episodes or []
+        if episodes and all(e.processed for e in episodes):
+            logger.info("All %d episodes processed.", len(episodes))
+            return
+        time.sleep(poll_interval)
+
+
+def seed_facts(storage: ZepUserStorage) -> None:
+    """Persist a seeded conversation through the integration's storage adapter."""
+    storage.save(
+        "My name is IntegTest. I work at Acme Corp as a data scientist.",
+        metadata={"type": "message", "role": "user", "name": FIRST_NAME},
+    )
+    storage.save(
+        "Nice to meet you, IntegTest -- noted you're a data scientist at Acme Corp.",
+        metadata={"type": "message", "role": "assistant", "name": "Assistant"},
+    )
+    storage.save(
+        "I live in Portland, Oregon and I love hiking and photography.",
+        metadata={"type": "message", "role": "user", "name": FIRST_NAME},
+    )
+    storage.save(
+        "IntegTest is a data scientist at Acme Corp, lives in Portland, Oregon, "
+        "and enjoys hiking and photography.",
+        metadata={"type": "text"},
+    )
+
+
+def main() -> None:
+    zep = Zep(api_key=ZEP_API_KEY)
+    passed = True
+
+    print(f"\n{'=' * 70}")
+    print("Zep CrewAI Integration Test")
+    print(f"  User:    {USER_ID}")
+    print(f"  Threads: {THREAD_1}, {THREAD_2}")
+    print(f"{'=' * 70}\n")
+
+    try:
+        # -- One-time Zep setup: create the user and thread out-of-band. ------
+        zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        # -- Seed facts via the integration. ---------------------------------
+        print("[Step 1] Seeding facts via ZepUserStorage...")
+        storage1 = ZepUserStorage(client=zep, user_id=USER_ID, thread_id=THREAD_1)
+        seed_facts(storage1)
+
+        # -- Verify user metadata --------------------------------------------
+        print("[Step 2] Verifying Zep user metadata...")
+        user = zep.user.get(user_id=USER_ID)
+        passed &= check("first_name matches", user.first_name == FIRST_NAME, str(user.first_name))
+        passed &= check("last_name matches", user.last_name == LAST_NAME, str(user.last_name))
+        passed &= check("email matches", user.email == EMAIL, str(user.email))
+
+        # -- Verify thread 1 captured both sides -----------------------------
+        print("\n[Step 3] Verifying thread 1 messages...")
+        t1 = zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        user_msgs = [m for m in messages if m.role == "user"]
+        asst_msgs = [m for m in messages if m.role == "assistant"]
+        print(f"  {len(user_msgs)} user, {len(asst_msgs)} assistant messages")
+        passed &= check("Thread 1 has user messages", len(user_msgs) >= 2, f"{len(user_msgs)}")
+        passed &= check("Thread 1 has assistant messages", len(asst_msgs) >= 1, f"{len(asst_msgs)}")
+
+        # -- Wait for graph ingestion ----------------------------------------
+        print("\n[Step 4] Waiting for Zep to process episodes...")
+        wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        # -- Recall via the integration's search (thread-independent). --------
+        print("\n[Step 5] Recall via ZepUserStorage.search...")
+        storage2 = ZepUserStorage(client=zep, user_id=USER_ID, thread_id=THREAD_2)
+        results = storage2.search(
+            "What is IntegTest's job, location, and hobbies?", limit=10
+        )
+        recalled = str(results).lower()
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        found = [kw for kw in keywords if kw in recalled]
+        print(f"  Recalled keywords (search): {found}")
+        passed &= check(
+            "Zep search recalls seeded facts",
+            len(found) > 0,
+            f"found={found}",
+        )
+
+        # -- A live CrewAI agent recalls the facts via the search tool. -------
+        print("\n[Step 6] CrewAI agent recall via Zep search tool...")
+        search_tool = create_search_tool(zep, user_id=USER_ID)
+        agent = Agent(
+            role="Personal Assistant",
+            goal="Answer questions about the user using their Zep memory",
+            backstory=(
+                "You recall what you know about the user by searching Zep memory "
+                "before answering."
+            ),
+            tools=[search_tool],
+            llm=OPENAI_MODEL,
+            verbose=False,
+        )
+        task = Task(
+            description=(
+                "Search Zep memory for the user's profile, then state in one sentence "
+                "where they work, their role, and where they live."
+            ),
+            expected_output="One sentence summarizing the user's employer, role, and city.",
+            agent=agent,
+        )
+        crew = Crew(agents=[agent], tasks=[task], process=Process.sequential, verbose=False)
+        result = str(crew.kickoff()).lower()
+        agent_found = [kw for kw in keywords if kw in result]
+        print(f"  Agent recalled keywords: {agent_found}")
+        passed &= check(
+            "Agent recalled facts from memory",
+            len(agent_found) > 0,
+            f"found={agent_found}",
+        )
+
+    finally:
+        print("\n[Cleanup] Deleting test user...")
+        try:
+            zep.user.delete(user_id=USER_ID)
+            print(f"  Deleted {USER_ID}")
+        except Exception as exc:
+            print(f"  Warning: could not delete user: {exc}")
+
+    print(f"\n{'=' * 70}")
+    print("RESULT:", "ALL CHECKS PASSED" if passed else "SOME CHECKS FAILED")
+    print("=" * 70)
+    sys.exit(0 if passed else 1)
+
+
+@pytest.mark.integration
+def test_integration_full_lifecycle() -> None:
+    """Pytest entry point for the live integration test (synchronous)."""
+    zep = Zep(api_key=ZEP_API_KEY)
+
+    try:
+        zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        storage1 = ZepUserStorage(client=zep, user_id=USER_ID, thread_id=THREAD_1)
+        seed_facts(storage1)
+
+        user = zep.user.get(user_id=USER_ID)
+        assert user.first_name == FIRST_NAME
+        assert user.email == EMAIL
+
+        t1 = zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        assert any(m.role == "user" for m in messages)
+        assert any(m.role == "assistant" for m in messages)
+
+        wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        storage2 = ZepUserStorage(client=zep, user_id=USER_ID, thread_id=THREAD_2)
+        results = storage2.search("What is IntegTest's job, location, and hobbies?", limit=10)
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        assert any(kw in str(results).lower() for kw in keywords), f"no recall in: {results}"
+
+        search_tool = create_search_tool(zep, user_id=USER_ID)
+        agent = Agent(
+            role="Personal Assistant",
+            goal="Answer questions about the user using their Zep memory",
+            backstory="You recall what you know about the user by searching Zep memory.",
+            tools=[search_tool],
+            llm=OPENAI_MODEL,
+            verbose=False,
+        )
+        task = Task(
+            description=(
+                "Search Zep memory for the user's profile, then state in one sentence "
+                "where they work, their role, and where they live."
+            ),
+            expected_output="One sentence summarizing the user's employer, role, and city.",
+            agent=agent,
+        )
+        crew = Crew(agents=[agent], tasks=[task], process=Process.sequential, verbose=False)
+        result = str(crew.kickoff()).lower()
+        assert any(kw in result for kw in keywords), f"agent did not recall: {result}"
+    finally:
+        try:
+            zep.user.delete(user_id=USER_ID)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/crewai/python/tests/test_integration.py
+++ b/integrations/crewai/python/tests/test_integration.py
@@ -86,7 +86,12 @@ def wait_for_episodes_processed(
         if time.monotonic() - start > timeout_seconds:
             logger.warning("Timed out waiting for episode processing; continuing.")
             return
-        resp = zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        try:
+            resp = zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        except Exception as exc:
+            logger.warning("Episode poll failed (%s); retrying.", exc)
+            time.sleep(poll_interval)
+            continue
         episodes = resp.episodes or []
         if episodes and all(e.processed for e in episodes):
             logger.info("All %d episodes processed.", len(episodes))
@@ -159,9 +164,7 @@ def main() -> None:
         # -- Recall via the integration's search (thread-independent). --------
         print("\n[Step 5] Recall via ZepUserStorage.search...")
         storage2 = ZepUserStorage(client=zep, user_id=USER_ID, thread_id=THREAD_2)
-        results = storage2.search(
-            "What is IntegTest's job, location, and hobbies?", limit=10
-        )
+        results = storage2.search("What is IntegTest's job, location, and hobbies?", limit=10)
         recalled = str(results).lower()
         keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
         found = [kw for kw in keywords if kw in recalled]
@@ -179,8 +182,7 @@ def main() -> None:
             role="Personal Assistant",
             goal="Answer questions about the user using their Zep memory",
             backstory=(
-                "You recall what you know about the user by searching Zep memory "
-                "before answering."
+                "You recall what you know about the user by searching Zep memory before answering."
             ),
             tools=[search_tool],
             llm=OPENAI_MODEL,

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "pytest-asyncio",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "langchain-openai>=1.0",
 ]
 
 [build-system]

--- a/integrations/langgraph/python/tests/test_integration.py
+++ b/integrations/langgraph/python/tests/test_integration.py
@@ -1,0 +1,258 @@
+"""
+End-to-end integration test for the Zep LangGraph integration.
+
+Exercises the full lifecycle against live Zep and OpenAI using the primary
+node/tool helpers with a prebuilt ``create_react_agent``:
+
+  1. ``build_system_message`` injects the Zep Context Block on every turn.
+  2. ``persist_messages`` writes each turn back to the Zep thread.
+  3. Both sides of the conversation are captured on the thread.
+  4. Cross-thread memory recall: a second thread for the same user recalls facts
+     seeded in the first thread (proving recall comes from the user graph).
+  5. Zep resource verification via the SDK (user metadata, thread messages).
+
+Requires:
+    ZEP_API_KEY and OPENAI_API_KEY environment variables.
+
+Usage:
+    uv run pytest tests/test_integration.py -v -s -m integration
+    # or standalone:
+    uv run python tests/test_integration.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from collections.abc import Awaitable, Callable
+from uuid import uuid4
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Configuration -- skip the whole module when API keys are not available.
+# ---------------------------------------------------------------------------
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+if not ZEP_API_KEY or not OPENAI_API_KEY:
+    pytest.skip(
+        "ZEP_API_KEY and OPENAI_API_KEY required for integration tests",
+        allow_module_level=True,
+    )
+
+from langchain_core.messages import AIMessage, HumanMessage  # noqa: E402
+from langchain_openai import ChatOpenAI  # noqa: E402
+from langgraph.prebuilt import create_react_agent  # noqa: E402
+from zep_cloud import Message  # noqa: E402
+from zep_cloud.client import AsyncZep  # noqa: E402
+
+from zep_langgraph import (  # noqa: E402
+    build_system_message,
+    create_graph_search_tool,
+    persist_messages,
+)
+
+# Unique IDs per run to avoid collisions.
+_suffix = uuid4().hex[:8]
+USER_ID = f"langgraph-integ-{_suffix}"
+THREAD_1 = f"langgraph-integ-t1-{_suffix}"
+THREAD_2 = f"langgraph-integ-t2-{_suffix}"
+
+FIRST_NAME = "IntegTest"
+LAST_NAME = "User"
+EMAIL = f"integtest-{_suffix}@example.com"
+
+BASE_INSTRUCTIONS = (
+    "You are a helpful assistant with long-term memory. When memory context is "
+    "provided, use it to give personalised, memory-aware answers. You may also call "
+    "the search_memory tool to look up specific details on demand."
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("test_integration")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("openai").setLevel(logging.WARNING)
+
+
+def check(description: str, condition: bool, detail: str = "") -> bool:
+    """Print a PASS/FAIL line and return the condition."""
+    status = "PASS" if condition else "FAIL"
+    msg = f"  {status}: {description}"
+    if detail:
+        msg += f" ({detail})"
+    print(msg)
+    return condition
+
+
+async def wait_for_episodes_processed(
+    zep: AsyncZep,
+    user_id: str,
+    timeout_seconds: int = 120,
+    poll_interval: float = 3.0,
+) -> None:
+    """Poll Zep episodes until all are processed or the timeout is reached."""
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > timeout_seconds:
+            logger.warning("Timed out waiting for episode processing; continuing.")
+            return
+        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        episodes = resp.episodes or []
+        if episodes and all(e.processed for e in episodes):
+            logger.info("All %d episodes processed.", len(episodes))
+            return
+        await asyncio.sleep(poll_interval)
+
+
+def build_agent(zep: AsyncZep, thread_id: str) -> Callable[[str], Awaitable[str]]:
+    """Build a ReAct agent wired to Zep on the given thread; return a chat fn."""
+
+    async def prompt(state: dict) -> list:
+        system = await build_system_message(
+            zep, thread_id=thread_id, base_instructions=BASE_INSTRUCTIONS
+        )
+        return [system, *state["messages"]]
+
+    search_tool = create_graph_search_tool(zep, user_id=USER_ID, scope="edges")
+    model = ChatOpenAI(model=OPENAI_MODEL)
+    agent = create_react_agent(model=model, tools=[search_tool], prompt=prompt)
+
+    async def chat(user_text: str) -> str:
+        result = await agent.ainvoke({"messages": [HumanMessage(content=user_text)]})
+        reply = result["messages"][-1]
+        reply_text = reply.content if isinstance(reply.content, str) else str(reply.content)
+        await persist_messages(
+            zep,
+            thread_id=thread_id,
+            messages=[
+                Message(role="user", content=user_text, name=f"{FIRST_NAME} {LAST_NAME}"),
+                AIMessage(content=reply_text),
+            ],
+        )
+        return reply_text
+
+    return chat
+
+
+async def main() -> None:
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+    passed = True
+
+    print(f"\n{'=' * 70}")
+    print("Zep LangGraph Integration Test")
+    print(f"  User:    {USER_ID}")
+    print(f"  Threads: {THREAD_1}, {THREAD_2}")
+    print(f"{'=' * 70}\n")
+
+    try:
+        # -- One-time Zep setup: create the user and thread out-of-band. ------
+        await zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        await zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        # -- Conversation 1: seed facts via the agent. -----------------------
+        print("[Step 1] Conversation 1: seeding facts...")
+        chat1 = build_agent(zep, THREAD_1)
+        seeds = [
+            "My name is IntegTest. I work at Acme Corp as a data scientist.",
+            "I live in Portland, Oregon and I love hiking and photography.",
+        ]
+        for msg in seeds:
+            print(f"  User:  {msg}")
+            reply = await chat1(msg)
+            print(f"  Agent: {reply}\n")
+            passed &= check("Agent returned a non-empty response", len(reply) > 0)
+
+        # -- Verify user metadata --------------------------------------------
+        print("[Step 2] Verifying Zep user metadata...")
+        user = await zep.user.get(user_id=USER_ID)
+        passed &= check("first_name matches", user.first_name == FIRST_NAME, str(user.first_name))
+        passed &= check("last_name matches", user.last_name == LAST_NAME, str(user.last_name))
+        passed &= check("email matches", user.email == EMAIL, str(user.email))
+
+        # -- Verify thread 1 captured both sides -----------------------------
+        print("\n[Step 3] Verifying thread 1 messages...")
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        user_msgs = [m for m in messages if m.role == "user"]
+        asst_msgs = [m for m in messages if m.role == "assistant"]
+        print(f"  {len(user_msgs)} user, {len(asst_msgs)} assistant messages")
+        passed &= check("Thread 1 has user messages", len(user_msgs) >= 2, f"{len(user_msgs)}")
+        passed &= check("Thread 1 has assistant messages", len(asst_msgs) >= 2, f"{len(asst_msgs)}")
+
+        # -- Wait for graph ingestion ----------------------------------------
+        print("\n[Step 4] Waiting for Zep to process episodes...")
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        # -- Conversation 2: cross-thread memory recall ----------------------
+        print("\n[Step 5] Conversation 2: cross-thread memory recall...")
+        await zep.thread.create(thread_id=THREAD_2, user_id=USER_ID)
+        chat2 = build_agent(zep, THREAD_2)
+        recall = (await chat2("What do you know about me?")).lower()
+        print(f"  Agent: {recall}\n")
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        found = [kw for kw in keywords if kw in recall]
+        print(f"  Recalled keywords: {found}")
+        passed &= check(
+            "Agent recalled facts from conversation 1",
+            len(found) > 0,
+            f"found={found}",
+        )
+
+    finally:
+        print("\n[Cleanup] Deleting test user...")
+        try:
+            await zep.user.delete(user_id=USER_ID)
+            print(f"  Deleted {USER_ID}")
+        except Exception as exc:
+            print(f"  Warning: could not delete user: {exc}")
+
+    print(f"\n{'=' * 70}")
+    print("RESULT:", "ALL CHECKS PASSED" if passed else "SOME CHECKS FAILED")
+    print("=" * 70)
+    sys.exit(0 if passed else 1)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_full_lifecycle() -> None:
+    """Pytest entry point for the live integration test."""
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+
+    try:
+        await zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        await zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        chat1 = build_agent(zep, THREAD_1)
+        await chat1("My name is IntegTest. I work at Acme Corp as a data scientist.")
+        await chat1("I live in Portland, Oregon and I love hiking and photography.")
+
+        user = await zep.user.get(user_id=USER_ID)
+        assert user.first_name == FIRST_NAME
+        assert user.email == EMAIL
+
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        assert any(m.role == "user" for m in messages)
+        assert any(m.role == "assistant" for m in messages)
+
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        await zep.thread.create(thread_id=THREAD_2, user_id=USER_ID)
+        chat2 = build_agent(zep, THREAD_2)
+        recall = (await chat2("What do you know about me?")).lower()
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        assert any(kw in recall for kw in keywords), f"no recall in: {recall}"
+    finally:
+        try:
+            await zep.user.delete(user_id=USER_ID)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/langgraph/python/tests/test_integration.py
+++ b/integrations/langgraph/python/tests/test_integration.py
@@ -101,7 +101,12 @@ async def wait_for_episodes_processed(
         if time.monotonic() - start > timeout_seconds:
             logger.warning("Timed out waiting for episode processing; continuing.")
             return
-        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        try:
+            resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        except Exception as exc:
+            logger.warning("Episode poll failed (%s); retrying.", exc)
+            await asyncio.sleep(poll_interval)
+            continue
         episodes = resp.episodes or []
         if episodes and all(e.processed for e in episodes):
             logger.info("All %d episodes processed.", len(episodes))

--- a/integrations/livekit/python/SETUP.md
+++ b/integrations/livekit/python/SETUP.md
@@ -1,0 +1,102 @@
+# Setup Guide
+
+This guide walks you from a fresh machine to running the example voice agent with Zep memory.
+
+## 1. Sign up for Zep and create an API key
+
+1. Go to [https://www.getzep.com](https://www.getzep.com) and create an account.
+2. Open the [Zep dashboard](https://app.getzep.com) and select (or create) a project.
+3. In the project settings, go to **API Keys** and create a new key.
+4. Copy the key — you will set it as `ZEP_API_KEY` below.
+
+Zep is a paid product; see [getzep.com](https://www.getzep.com) for plan details.
+
+## 2. Get an OpenAI API key (for the example)
+
+The bundled voice examples use OpenAI for STT, LLM, and TTS. Create a key at
+[platform.openai.com/api-keys](https://platform.openai.com/api-keys) and copy it
+for `OPENAI_API_KEY`.
+
+## 3. Get LiveKit server credentials (for the voice examples)
+
+The examples are LiveKit agent workers, so running them end-to-end needs a
+LiveKit server (LiveKit Cloud or self-hosted). Create a project at
+[cloud.livekit.io](https://cloud.livekit.io) and copy its URL, API key, and API
+secret for `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET`.
+
+You do **not** need LiveKit credentials to run the live integration test (step 6),
+which validates the Zep memory layer directly without a voice session.
+
+## 4. Install
+
+Using `pip`:
+
+```bash
+pip install zep-livekit
+```
+
+Or, to work from the repository with `uv`:
+
+```bash
+git clone https://github.com/getzep/zep.git
+cd zep/integrations/livekit/python
+make install        # uv sync --extra dev
+```
+
+Requirements: Python 3.11+, `livekit-agents[openai,silero]>=1.0.0`, `zep-cloud>=3.23.0`.
+
+## 5. Configure environment variables
+
+```bash
+export ZEP_API_KEY="your-zep-api-key"
+export OPENAI_API_KEY="your-openai-api-key"
+
+# Required only to run the voice examples (not the live test):
+export LIVEKIT_URL="wss://your-project.livekit.cloud"
+export LIVEKIT_API_KEY="your-livekit-api-key"
+export LIVEKIT_API_SECRET="your-livekit-api-secret"
+```
+
+## 6. Run the example
+
+The voice examples run as LiveKit agent workers. With the LiveKit variables set:
+
+```bash
+uv run python examples/voice_assistant.py dev
+```
+
+Then connect a client (e.g. the [LiveKit Agents Playground](https://agents-playground.livekit.io))
+to talk to the agent. As the conversation proceeds, `ZepUserAgent` persists turns
+to Zep and injects recalled context on later turns.
+
+Other runnable examples live in [`examples/`](examples):
+
+- `voice_assistant.py` — `ZepUserAgent` with thread-based conversational memory
+- `graph_voice_assistant.py` — `ZepGraphAgent` with knowledge-graph memory
+
+## 7. Run the tests
+
+Mock-based tests (no API keys needed):
+
+```bash
+make test
+```
+
+Live integration test (requires only `ZEP_API_KEY` — no LiveKit server or LLM
+key). It drives the agent's memory logic directly and verifies persistence and
+cross-thread recall against real Zep:
+
+```bash
+uv run pytest tests/test_integration.py -v -s -m integration
+```
+
+## Troubleshooting
+
+- **`ZEP_API_KEY is not set`** — export the key (step 5) before running.
+- **Voice example exits immediately** — confirm `LIVEKIT_URL`, `LIVEKIT_API_KEY`,
+  and `LIVEKIT_API_SECRET` are set, and that a client connects to the room.
+- **Recall returns nothing** — Zep ingestion is asynchronous; a just-added fact
+  is not instantly retrievable. The live test waits for the graph to build;
+  increase the wait if your graph is large or under load.
+- **Authentication errors** — confirm `ZEP_API_KEY` is set in the same shell and
+  belongs to the intended project.

--- a/integrations/livekit/python/pyproject.toml
+++ b/integrations/livekit/python/pyproject.toml
@@ -72,7 +72,6 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.mypy]
-python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/integrations/livekit/python/tests/test_integration.py
+++ b/integrations/livekit/python/tests/test_integration.py
@@ -93,7 +93,12 @@ async def wait_for_episodes_processed(
         if time.monotonic() - start > timeout_seconds:
             logger.warning("Timed out waiting for episode processing; continuing.")
             return
-        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        try:
+            resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        except Exception as exc:
+            logger.warning("Episode poll failed (%s); retrying.", exc)
+            await asyncio.sleep(poll_interval)
+            continue
         episodes = resp.episodes or []
         if episodes and all(e.processed for e in episodes):
             logger.info("All %d episodes processed.", len(episodes))

--- a/integrations/livekit/python/tests/test_integration.py
+++ b/integrations/livekit/python/tests/test_integration.py
@@ -1,0 +1,308 @@
+"""
+End-to-end integration test for the Zep LiveKit integration.
+
+LiveKit agents normally run inside a voice session/room. This test drives the
+``ZepUserAgent`` memory logic directly -- the same Zep operations it performs on
+``on_user_turn_completed`` and when an assistant message is added -- WITHOUT a
+LiveKit server, validating the integration's memory layer end-to-end:
+
+  1. ``ZepUserAgent.on_user_turn_completed`` persists user turns to a Zep thread
+     and injects the retrieved context block.
+  2. ``ZepUserAgent._store_assistant_message`` persists assistant turns.
+  3. Both sides of the conversation are captured on the thread.
+  4. Cross-thread memory recall: a second thread for the same user recalls facts
+     seeded in the first thread (proving recall comes from the user graph).
+  5. Zep resource verification via the SDK (user metadata, thread messages,
+     context block, graph search).
+
+Only ZEP_API_KEY is required -- no LLM key, since no model is invoked.
+
+Requires:
+    ZEP_API_KEY environment variable.
+
+Usage:
+    uv run pytest tests/test_integration.py -v -s -m integration
+    # or standalone:
+    uv run python tests/test_integration.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from uuid import uuid4
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Configuration -- skip the whole module when the API key is not available.
+# ---------------------------------------------------------------------------
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+
+if not ZEP_API_KEY:
+    pytest.skip(
+        "ZEP_API_KEY required for integration tests",
+        allow_module_level=True,
+    )
+
+from livekit.agents.llm.chat_context import ChatContext  # noqa: E402
+from zep_cloud.client import AsyncZep  # noqa: E402
+
+from zep_livekit import ZepGraphAgent, ZepUserAgent  # noqa: E402
+from zep_livekit.exceptions import AgentConfigurationError  # noqa: E402
+
+# Unique IDs per run to avoid collisions.
+_suffix = uuid4().hex[:8]
+USER_ID = f"livekit-integ-{_suffix}"
+THREAD_1 = f"livekit-integ-t1-{_suffix}"
+THREAD_2 = f"livekit-integ-t2-{_suffix}"
+
+FIRST_NAME = "IntegTest"
+LAST_NAME = "User"
+EMAIL = f"integtest-{_suffix}@example.com"
+
+INSTRUCTIONS = "You are a helpful travel assistant with persistent memory."
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("test_integration")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+def check(description: str, condition: bool, detail: str = "") -> bool:
+    """Print a PASS/FAIL line and return the condition."""
+    status = "PASS" if condition else "FAIL"
+    msg = f"  {status}: {description}"
+    if detail:
+        msg += f" ({detail})"
+    print(msg)
+    return condition
+
+
+async def wait_for_episodes_processed(
+    zep: AsyncZep,
+    user_id: str,
+    timeout_seconds: int = 120,
+    poll_interval: float = 3.0,
+) -> None:
+    """Poll Zep episodes until all are processed or the timeout is reached."""
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > timeout_seconds:
+            logger.warning("Timed out waiting for episode processing; continuing.")
+            return
+        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        episodes = resp.episodes or []
+        if episodes and all(e.processed for e in episodes):
+            logger.info("All %d episodes processed.", len(episodes))
+            return
+        await asyncio.sleep(poll_interval)
+
+
+def build_agent(zep: AsyncZep, thread_id: str) -> ZepUserAgent:
+    """Build a ZepUserAgent bound to the given thread (no LiveKit session)."""
+    return ZepUserAgent(
+        zep_client=zep,
+        user_id=USER_ID,
+        thread_id=thread_id,
+        user_message_name=FIRST_NAME,
+        assistant_message_name="Assistant",
+        instructions=INSTRUCTIONS,
+    )
+
+
+class _AssistantItem:
+    """Minimal stand-in for a LiveKit conversation item (only ``name`` is read)."""
+
+    name = None
+
+
+async def user_turn(agent: ZepUserAgent, text: str) -> ChatContext:
+    """Drive ZepUserAgent.on_user_turn_completed for one user message.
+
+    Uses a real ChatContext (so the integration's ``add_message`` call works) and
+    a lightweight stand-in for the new message (the integration only reads
+    ``text_content``; the base hook is a no-op). Returns the turn context so the
+    caller can inspect any injected memory context.
+    """
+    turn_ctx = ChatContext.empty()
+    new_message = type("_UserMsg", (), {"text_content": text})()
+    await agent.on_user_turn_completed(turn_ctx, new_message)
+    return turn_ctx
+
+
+async def main() -> None:
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+    passed = True
+
+    print(f"\n{'=' * 70}")
+    print("Zep LiveKit Integration Test (memory layer, no voice server)")
+    print(f"  User:    {USER_ID}")
+    print(f"  Threads: {THREAD_1}, {THREAD_2}")
+    print(f"{'=' * 70}\n")
+
+    # -- Constructor validation (no network). --------------------------------
+    print("[Step 0] Validating agent configuration guards...")
+    try:
+        ZepUserAgent(zep_client=zep, user_id="", thread_id=THREAD_1, instructions=INSTRUCTIONS)
+        passed &= check("ZepUserAgent rejects empty user_id", False)
+    except AgentConfigurationError:
+        passed &= check("ZepUserAgent rejects empty user_id", True)
+    try:
+        ZepGraphAgent(zep_client=zep, graph_id="", instructions=INSTRUCTIONS)
+        passed &= check("ZepGraphAgent rejects empty graph_id", False)
+    except AgentConfigurationError:
+        passed &= check("ZepGraphAgent rejects empty graph_id", True)
+
+    try:
+        # -- One-time Zep setup: create the user and thread out-of-band. ------
+        await zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        await zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        # -- Conversation 1: seed facts via the agent's memory hooks. --------
+        print("\n[Step 1] Conversation 1: seeding facts...")
+        agent1 = build_agent(zep, THREAD_1)
+        seeds = [
+            (
+                "My name is IntegTest. I work at Acme Corp as a data scientist.",
+                "Nice to meet you, IntegTest -- noted that you're a data scientist at Acme Corp.",
+            ),
+            (
+                "I live in Portland, Oregon and I love hiking and photography.",
+                "Great -- Portland, Oregon, plus hiking and photography.",
+            ),
+        ]
+        for user_text, assistant_text in seeds:
+            print(f"  User:  {user_text}")
+            await user_turn(agent1, user_text)
+            await agent1._store_assistant_message(assistant_text, _AssistantItem())
+            print(f"  Agent: {assistant_text}\n")
+
+        # -- Verify user metadata --------------------------------------------
+        print("[Step 2] Verifying Zep user metadata...")
+        user = await zep.user.get(user_id=USER_ID)
+        passed &= check("first_name matches", user.first_name == FIRST_NAME, str(user.first_name))
+        passed &= check("last_name matches", user.last_name == LAST_NAME, str(user.last_name))
+        passed &= check("email matches", user.email == EMAIL, str(user.email))
+
+        # -- Verify thread 1 captured both sides -----------------------------
+        print("\n[Step 3] Verifying thread 1 messages...")
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        user_msgs = [m for m in messages if m.role == "user"]
+        asst_msgs = [m for m in messages if m.role == "assistant"]
+        print(f"  {len(user_msgs)} user, {len(asst_msgs)} assistant messages")
+        passed &= check("Thread 1 has user messages", len(user_msgs) >= 2, f"{len(user_msgs)}")
+        passed &= check("Thread 1 has assistant messages", len(asst_msgs) >= 2, f"{len(asst_msgs)}")
+
+        # -- Wait for graph ingestion ----------------------------------------
+        print("\n[Step 4] Waiting for Zep to process episodes...")
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        # -- Conversation 2: cross-thread memory recall ----------------------
+        print("\n[Step 5] Conversation 2: cross-thread memory recall...")
+        await zep.thread.create(thread_id=THREAD_2, user_id=USER_ID)
+        agent2 = build_agent(zep, THREAD_2)
+        # Driving a user turn on a fresh thread should inject the recalled
+        # context block (assembled from the shared user graph).
+        await user_turn(agent2, "What do you know about me?")
+
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        ctx_result = await zep.thread.get_user_context(thread_id=THREAD_2)
+        context = (ctx_result.context or "").lower()
+        found = [kw for kw in keywords if kw in context]
+        print(f"  Recalled keywords (context block): {found}")
+        passed &= check(
+            "Context block recalls facts from conversation 1",
+            len(found) > 0,
+            f"found={found}",
+        )
+
+        search = await zep.graph.search(user_id=USER_ID, query="job, location, hobbies", limit=10)
+        search_text = " ".join(e.fact for e in (search.edges or [])).lower()
+        search_found = [kw for kw in keywords if kw in search_text]
+        print(f"  Recalled keywords (graph search): {search_found}")
+        passed &= check(
+            "Graph search recalls facts from conversation 1",
+            len(search_found) > 0,
+            f"found={search_found}",
+        )
+
+    finally:
+        print("\n[Cleanup] Deleting test user...")
+        try:
+            await zep.user.delete(user_id=USER_ID)
+            print(f"  Deleted {USER_ID}")
+        except Exception as exc:
+            print(f"  Warning: could not delete user: {exc}")
+
+    print(f"\n{'=' * 70}")
+    print("RESULT:", "ALL CHECKS PASSED" if passed else "SOME CHECKS FAILED")
+    print("=" * 70)
+    sys.exit(0 if passed else 1)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_full_lifecycle() -> None:
+    """Pytest entry point for the live integration test."""
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+
+    # Config guards (no network).
+    with pytest.raises(AgentConfigurationError):
+        ZepUserAgent(zep_client=zep, user_id="", thread_id=THREAD_1, instructions=INSTRUCTIONS)
+    with pytest.raises(AgentConfigurationError):
+        ZepGraphAgent(zep_client=zep, graph_id="", instructions=INSTRUCTIONS)
+
+    try:
+        await zep.user.add(user_id=USER_ID, first_name=FIRST_NAME, last_name=LAST_NAME, email=EMAIL)
+        await zep.thread.create(thread_id=THREAD_1, user_id=USER_ID)
+
+        agent1 = build_agent(zep, THREAD_1)
+        for user_text, assistant_text in (
+            (
+                "My name is IntegTest. I work at Acme Corp as a data scientist.",
+                "Noted -- a data scientist at Acme Corp.",
+            ),
+            (
+                "I live in Portland, Oregon and I love hiking and photography.",
+                "Got it -- Portland, Oregon, hiking and photography.",
+            ),
+        ):
+            await user_turn(agent1, user_text)
+            await agent1._store_assistant_message(assistant_text, _AssistantItem())
+
+        user = await zep.user.get(user_id=USER_ID)
+        assert user.first_name == FIRST_NAME
+        assert user.email == EMAIL
+
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        assert any(m.role == "user" for m in messages)
+        assert any(m.role == "assistant" for m in messages)
+
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        await zep.thread.create(thread_id=THREAD_2, user_id=USER_ID)
+        agent2 = build_agent(zep, THREAD_2)
+        await user_turn(agent2, "What do you know about me?")
+
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        ctx_result = await zep.thread.get_user_context(thread_id=THREAD_2)
+        context = (ctx_result.context or "").lower()
+        search = await zep.graph.search(user_id=USER_ID, query="job, location, hobbies", limit=10)
+        search_text = " ".join(e.fact for e in (search.edges or [])).lower()
+        assert any(kw in context or kw in search_text for kw in keywords), (
+            f"no recall in context/search: {context} / {search_text}"
+        )
+    finally:
+        try:
+            await zep.user.delete(user_id=USER_ID)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/ms-agent-framework/python/tests/test_integration.py
+++ b/integrations/ms-agent-framework/python/tests/test_integration.py
@@ -88,7 +88,12 @@ async def wait_for_episodes_processed(
         if time.monotonic() - start > timeout_seconds:
             logger.warning("Timed out waiting for episode processing; continuing.")
             return
-        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        try:
+            resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        except Exception as exc:
+            logger.warning("Episode poll failed (%s); retrying.", exc)
+            await asyncio.sleep(poll_interval)
+            continue
         episodes = resp.episodes or []
         if episodes and all(e.processed for e in episodes):
             logger.info("All %d episodes processed.", len(episodes))

--- a/integrations/pydantic-ai/python/tests/test_integration.py
+++ b/integrations/pydantic-ai/python/tests/test_integration.py
@@ -1,0 +1,248 @@
+"""
+End-to-end integration test for the Zep Pydantic AI integration.
+
+Exercises the full lifecycle against live Zep and OpenAI:
+
+  1. ``zep_history_processor`` persists each user turn and injects Zep's context
+     block; ``persist_run`` stores the assistant reply back to the thread.
+  2. Both sides of the conversation are captured on the thread.
+  3. Cross-thread memory recall: a second thread for the same user recalls facts
+     seeded in the first thread (proving recall comes from the user graph).
+  4. Zep resource verification via the SDK (user metadata, thread messages).
+
+Requires:
+    ZEP_API_KEY and OPENAI_API_KEY environment variables.
+
+Usage:
+    uv run pytest tests/test_integration.py -v -s -m integration
+    # or standalone:
+    uv run python tests/test_integration.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from uuid import uuid4
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Configuration -- skip the whole module when API keys are not available.
+# ---------------------------------------------------------------------------
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+if not ZEP_API_KEY or not OPENAI_API_KEY:
+    pytest.skip(
+        "ZEP_API_KEY and OPENAI_API_KEY required for integration tests",
+        allow_module_level=True,
+    )
+
+from pydantic_ai import Agent  # noqa: E402
+from pydantic_ai.capabilities import ProcessHistory  # noqa: E402
+from zep_cloud.client import AsyncZep  # noqa: E402
+
+from zep_pydantic_ai import (  # noqa: E402
+    ZepDeps,
+    create_zep_search_tool,
+    persist_run,
+    zep_history_processor,
+)
+
+# Unique IDs per run to avoid collisions.
+_suffix = uuid4().hex[:8]
+USER_ID = f"pydantic-integ-{_suffix}"
+THREAD_1 = f"pydantic-integ-t1-{_suffix}"
+THREAD_2 = f"pydantic-integ-t2-{_suffix}"
+
+FIRST_NAME = "IntegTest"
+LAST_NAME = "User"
+EMAIL = f"integtest-{_suffix}@example.com"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("test_integration")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("openai").setLevel(logging.WARNING)
+
+
+def check(description: str, condition: bool, detail: str = "") -> bool:
+    """Print a PASS/FAIL line and return the condition."""
+    status = "PASS" if condition else "FAIL"
+    msg = f"  {status}: {description}"
+    if detail:
+        msg += f" ({detail})"
+    print(msg)
+    return condition
+
+
+async def wait_for_episodes_processed(
+    zep: AsyncZep,
+    user_id: str,
+    timeout_seconds: int = 120,
+    poll_interval: float = 3.0,
+) -> None:
+    """Poll Zep episodes until all are processed or the timeout is reached."""
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > timeout_seconds:
+            logger.warning("Timed out waiting for episode processing; continuing.")
+            return
+        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        episodes = resp.episodes or []
+        if episodes and all(e.processed for e in episodes):
+            logger.info("All %d episodes processed.", len(episodes))
+            return
+        await asyncio.sleep(poll_interval)
+
+
+def build_agent() -> Agent:
+    """Build the Pydantic AI agent; per-user identity is supplied via ZepDeps."""
+    return Agent(
+        f"openai:{OPENAI_MODEL}",
+        deps_type=ZepDeps,
+        capabilities=[ProcessHistory(zep_history_processor)],
+        tools=[create_zep_search_tool()],
+        instructions=(
+            "You are a helpful assistant with access to long-term memory. When "
+            "context from Zep is injected into the prompt, use it to provide "
+            "personalised, memory-aware responses. Use the zep_search tool when you "
+            "need to look up specific details the user shared earlier."
+        ),
+    )
+
+
+def make_deps(zep: AsyncZep, thread_id: str) -> ZepDeps:
+    return ZepDeps(
+        client=zep,
+        user_id=USER_ID,
+        thread_id=thread_id,
+        first_name=FIRST_NAME,
+        last_name=LAST_NAME,
+        email=EMAIL,
+    )
+
+
+async def chat(agent: Agent, deps: ZepDeps, message: str) -> str:
+    """Send one message through the agent and persist the assistant reply."""
+    result = await agent.run(message, deps=deps)
+    await persist_run(deps, result.new_messages())
+    return str(result.output)
+
+
+async def main() -> None:
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+    passed = True
+
+    print(f"\n{'=' * 70}")
+    print("Zep Pydantic AI Integration Test")
+    print(f"  User:    {USER_ID}")
+    print(f"  Threads: {THREAD_1}, {THREAD_2}")
+    print(f"{'=' * 70}\n")
+
+    try:
+        agent = build_agent()
+
+        # -- Conversation 1: seed facts (history processor creates user/thread).
+        print("[Step 1] Conversation 1: seeding facts...")
+        deps1 = make_deps(zep, THREAD_1)
+        seeds = [
+            "My name is IntegTest. I work at Acme Corp as a data scientist.",
+            "I live in Portland, Oregon and I love hiking and photography.",
+        ]
+        for msg in seeds:
+            print(f"  User:  {msg}")
+            reply = await chat(agent, deps1, msg)
+            print(f"  Agent: {reply}\n")
+            passed &= check("Agent returned a non-empty response", len(reply) > 0)
+
+        # -- Verify user metadata --------------------------------------------
+        print("[Step 2] Verifying Zep user metadata...")
+        user = await zep.user.get(user_id=USER_ID)
+        passed &= check("first_name matches", user.first_name == FIRST_NAME, str(user.first_name))
+        passed &= check("last_name matches", user.last_name == LAST_NAME, str(user.last_name))
+        passed &= check("email matches", user.email == EMAIL, str(user.email))
+
+        # -- Verify thread 1 captured both sides -----------------------------
+        print("\n[Step 3] Verifying thread 1 messages...")
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        user_msgs = [m for m in messages if m.role == "user"]
+        asst_msgs = [m for m in messages if m.role == "assistant"]
+        print(f"  {len(user_msgs)} user, {len(asst_msgs)} assistant messages")
+        passed &= check("Thread 1 has user messages", len(user_msgs) >= 2, f"{len(user_msgs)}")
+        passed &= check("Thread 1 has assistant messages", len(asst_msgs) >= 2, f"{len(asst_msgs)}")
+
+        # -- Wait for graph ingestion ----------------------------------------
+        print("\n[Step 4] Waiting for Zep to process episodes...")
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        # -- Conversation 2: cross-thread memory recall ----------------------
+        print("\n[Step 5] Conversation 2: cross-thread memory recall...")
+        deps2 = make_deps(zep, THREAD_2)
+        recall = (await chat(agent, deps2, "What do you know about me?")).lower()
+        print(f"  Agent: {recall}\n")
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        found = [kw for kw in keywords if kw in recall]
+        print(f"  Recalled keywords: {found}")
+        passed &= check(
+            "Agent recalled facts from conversation 1",
+            len(found) > 0,
+            f"found={found}",
+        )
+
+    finally:
+        print("\n[Cleanup] Deleting test user...")
+        try:
+            await zep.user.delete(user_id=USER_ID)
+            print(f"  Deleted {USER_ID}")
+        except Exception as exc:
+            print(f"  Warning: could not delete user: {exc}")
+
+    print(f"\n{'=' * 70}")
+    print("RESULT:", "ALL CHECKS PASSED" if passed else "SOME CHECKS FAILED")
+    print("=" * 70)
+    sys.exit(0 if passed else 1)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_integration_full_lifecycle() -> None:
+    """Pytest entry point for the live integration test."""
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+
+    try:
+        agent = build_agent()
+
+        deps1 = make_deps(zep, THREAD_1)
+        await chat(agent, deps1, "My name is IntegTest. I work at Acme Corp as a data scientist.")
+        await chat(agent, deps1, "I live in Portland, Oregon and I love hiking and photography.")
+
+        user = await zep.user.get(user_id=USER_ID)
+        assert user.first_name == FIRST_NAME
+        assert user.email == EMAIL
+
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        assert any(m.role == "user" for m in messages)
+        assert any(m.role == "assistant" for m in messages)
+
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        deps2 = make_deps(zep, THREAD_2)
+        recall = (await chat(agent, deps2, "What do you know about me?")).lower()
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        assert any(kw in recall for kw in keywords), f"no recall in: {recall}"
+    finally:
+        try:
+            await zep.user.delete(user_id=USER_ID)
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/pydantic-ai/python/tests/test_integration.py
+++ b/integrations/pydantic-ai/python/tests/test_integration.py
@@ -92,7 +92,12 @@ async def wait_for_episodes_processed(
         if time.monotonic() - start > timeout_seconds:
             logger.warning("Timed out waiting for episode processing; continuing.")
             return
-        resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        try:
+            resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        except Exception as exc:
+            logger.warning("Episode poll failed (%s); retrying.", exc)
+            await asyncio.sleep(poll_interval)
+            continue
         episodes = resp.episodes or []
         if episodes and all(e.processed for e in episodes):
             logger.info("All %d episodes processed.", len(episodes))


### PR DESCRIPTION
Add end-to-end live integration tests (gated on API keys) and SETUP.md guides across the Python/TypeScript integrations, exercising the full Zep lifecycle (create user/thread -> persist -> recall) against live Zep and the respective model providers.

New live tests: adk (typescript), ag2, autogen, crewai, langgraph,
livekit, pydantic-ai. New SETUP.md: adk, autogen, crewai, livekit.

Fixes found while running them live:
- autogen: create THREAD_2 and persist the question turn before recall. get_user_context/add_messages 404 on a non-existent thread, and cross-thread recall keys relevance off the thread's recent messages, so an empty thread recalls nothing.
- langgraph: create THREAD_2 before conversation 2 (same 404 cause); restores the context-block recall path instead of relying on the tool.
- ag2: add `openai` to dev extras (the AssistantAgent needs it at runtime).
- langgraph: add `langchain-openai` to dev extras (imported by the test).
- adk/python: gate recall on facts being searchable (episodes reporting processed != edges searchable) and add bounded retries tolerant of transient model 503s; fix SETUP.md to run the standalone script (the file has no pytest entry point, so `pytest -m integration` ran 0).

Also wire ZEP/OPENAI/GOOGLE API key secrets into the CI test jobs.