### PR TITLE
fix(integrations): add Apache-2.0 license metadata to Python packages

### DIFF
--- a/integrations/adk/python/pyproject.toml
+++ b/integrations/adk/python/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.2.1"
 description = "Google ADK integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
 dependencies = [
     "google-adk>=1.0.0",
     "typing-extensions>=4.0.0",

--- a/integrations/autogen/python/pyproject.toml
+++ b/integrations/autogen/python/pyproject.toml
@@ -4,6 +4,7 @@ version = "1.1.1"
 description = "Autogen integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
 dependencies = [
     "autogen-agentchat>=0.7.0",
     "autogen-ext[azure,openai]>=0.7.0",

--- a/integrations/crewai/python/pyproject.toml
+++ b/integrations/crewai/python/pyproject.toml
@@ -4,6 +4,7 @@ version = "1.1.2"
 description = "CrewAI integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
 dependencies = [
     "crewai>=1.0.0",
     "aiohttp>=3.8.0",

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "LangGraph integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
 dependencies = [
     "langchain-core>=1.0",
     "langgraph>=1.2.5",

--- a/integrations/livekit/python/pyproject.toml
+++ b/integrations/livekit/python/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 description = "LiveKit integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
 dependencies = [
     "livekit-agents[openai,silero]>=1.0.0",
     "zep-cloud>=3.23.0",

--- a/integrations/ms-agent-framework/python/pyproject.toml
+++ b/integrations/ms-agent-framework/python/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Microsoft Agent Framework integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
 dependencies = [
     "agent-framework-core>=1.8.1",
     "zep-cloud>=3.23.0",

--- a/integrations/pydantic-ai/python/pyproject.toml
+++ b/integrations/pydantic-ai/python/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Pydantic AI integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
 dependencies = [
     "pydantic-ai>=1.107,<2",
     "zep-cloud>=3.23.0",


### PR DESCRIPTION
## Summary

- Add `license = "Apache-2.0"` to seven Python integration `pyproject.toml` files that were missing PEP 621 license metadata
- Aligns with `zep-ag2` (already declared) and the repository root `LICENSE`
- Improves wheel/PyPI package metadata completeness for consumers and package indexes

## Packages updated

- `zep-adk`
- `zep-autogen`
- `zep-crewai`
- `zep-langgraph`
- `zep-livekit`
- `zep-ms-agent-framework`
- `zep-pydantic-ai`

`zep-ag2` already had the correct license field and was left unchanged.

## Context

Upstream `getzep/zep` has GitHub Issues disabled; tracked as [sourabhligade/zep#1](https://github.com/sourabhligade/zep/issues/1) on the contributor fork. Same class of fix as [getzep/zep-python#304](https://github.com/getzep/zep-python/issues/304).

## Test plan

- [x] Verified all `integrations/*/python/pyproject.toml` files declare `license = "Apache-2.0"`
- [x] `pytest` unit tests pass for `zep-adk`, `zep-crewai`, `zep-ag2` (integration tests skipped; need live API)
- [x] `go test ./...` passes for `mcp/zep-mcp-server`
- [x] `pytest` passes for `benchmarks/locomo/tests`
- [ ] CI green on this PR
