### PR TITLE
fix(mcp): validate search_graph inputs before Zep API calls

### DIFF
--- a/mcp/zep-mcp-server/internal/handlers/search.go
+++ b/mcp/zep-mcp-server/internal/handlers/search.go
@@ -14,7 +14,11 @@ import (
 // HandleSearchGraph handles the search_graph tool using the new MCP SDK signature
 func HandleSearchGraph(client *zepclient.Client) mcp.ToolHandlerFor[SearchGraphInput, any] {
 	return func(ctx context.Context, req *mcp.CallToolRequest, input SearchGraphInput) (*mcp.CallToolResult, any, error) {
-		// Apply defaults
+		if err := input.Validate(); err != nil {
+			return nil, nil, err
+		}
+
+		// Apply defaults (after validation so explicit out-of-range limits are rejected)
 		if input.Scope == "" {
 			input.Scope = "edges"
 		}

--- a/mcp/zep-mcp-server/internal/handlers/types.go
+++ b/mcp/zep-mcp-server/internal/handlers/types.go
@@ -1,5 +1,20 @@
 package handlers
 
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Search input validation bounds (enforced before calling the Zep API).
+const (
+	searchQueryMaxLen = 2000
+	searchLimitMin    = 1
+	searchLimitMax    = 100
+	searchMinScoreMin = 0.0
+	searchMinScoreMax = 1.0
+)
+
 // Input and output types for MCP tool handlers
 // These types are used to automatically generate JSON schemas
 
@@ -15,6 +30,31 @@ type SearchGraphInput struct {
 	CenterNodeUUID string   `json:"center_node_uuid,omitempty" jsonschema:"Node UUID to rerank around for node_distance reranking"`
 	NodeLabels     []string `json:"node_labels,omitempty" jsonschema:"Filter results by node labels"`
 	EdgeTypes      []string `json:"edge_types,omitempty" jsonschema:"Filter results by edge types"`
+}
+
+// Validate checks SearchGraphInput before it is sent to the downstream API.
+// Errors use the same fmt.Errorf patterns as internal/transform.ValidateRequired.
+func (input SearchGraphInput) Validate() error {
+	query := strings.TrimSpace(input.Query)
+	if query == "" {
+		return fmt.Errorf("query cannot be empty")
+	}
+	if utf8.RuneCountInString(input.Query) > searchQueryMaxLen {
+		return fmt.Errorf("query exceeds maximum length of %d characters", searchQueryMaxLen)
+	}
+
+	// MinFactRating is the minimum score field (min_fact_rating). Zero means omitted.
+	// Values outside [0, 1] are rejected (covers negative and >1.0).
+	if input.MinFactRating < searchMinScoreMin || input.MinFactRating > searchMinScoreMax {
+		return fmt.Errorf("min_fact_rating must be between %v and %v", searchMinScoreMin, searchMinScoreMax)
+	}
+
+	// Limit 0 means use handler default; an explicit limit must be in [1, 100].
+	if input.Limit != 0 && (input.Limit < searchLimitMin || input.Limit > searchLimitMax) {
+		return fmt.Errorf("limit must be between %d and %d", searchLimitMin, searchLimitMax)
+	}
+
+	return nil
 }
 
 // GetUserContextInput defines the input parameters for get_user_context

--- a/mcp/zep-mcp-server/internal/handlers/types_test.go
+++ b/mcp/zep-mcp-server/internal/handlers/types_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -90,5 +91,138 @@ func TestListThreadsInput(t *testing.T) {
 
 	if input.UserID != "user123" {
 		t.Errorf("Expected UserID 'user123', got '%s'", input.UserID)
+	}
+}
+
+// TestSearchGraphInputValidate verifies search input validation rules.
+func TestSearchGraphInputValidate(t *testing.T) {
+	longQuery := strings.Repeat("a", searchQueryMaxLen+1)
+	maxQuery := strings.Repeat("b", searchQueryMaxLen)
+
+	tests := []struct {
+		name    string
+		input   SearchGraphInput
+		wantErr bool
+		errSub  string // substring expected in error when wantErr is true
+	}{
+		// valid cases
+		{
+			name:    "valid minimal query",
+			input:   SearchGraphInput{UserID: "u1", Query: "hello"},
+			wantErr: false,
+		},
+		{
+			name:    "valid query with surrounding whitespace",
+			input:   SearchGraphInput{UserID: "u1", Query: "  hello  "},
+			wantErr: false,
+		},
+		{
+			name:    "valid query at max length",
+			input:   SearchGraphInput{UserID: "u1", Query: maxQuery},
+			wantErr: false,
+		},
+		{
+			name:    "valid limit omitted (zero uses handler default)",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", Limit: 0},
+			wantErr: false,
+		},
+		{
+			name:    "valid limit at minimum boundary",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", Limit: searchLimitMin},
+			wantErr: false,
+		},
+		{
+			name:    "valid limit at maximum boundary",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", Limit: searchLimitMax},
+			wantErr: false,
+		},
+		{
+			name:    "valid min_fact_rating omitted (zero)",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", MinFactRating: 0},
+			wantErr: false,
+		},
+		{
+			name:    "valid min_fact_rating at minimum boundary",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", MinFactRating: searchMinScoreMin},
+			wantErr: false,
+		},
+		{
+			name:    "valid min_fact_rating at maximum boundary",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", MinFactRating: searchMinScoreMax},
+			wantErr: false,
+		},
+		{
+			name:    "valid min_fact_rating mid range",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", MinFactRating: 0.5},
+			wantErr: false,
+		},
+		// invalid query
+		{
+			name:    "empty query",
+			input:   SearchGraphInput{UserID: "u1", Query: ""},
+			wantErr: true,
+			errSub:  "query cannot be empty",
+		},
+		{
+			name:    "whitespace only query",
+			input:   SearchGraphInput{UserID: "u1", Query: "   \t\n  "},
+			wantErr: true,
+			errSub:  "query cannot be empty",
+		},
+		{
+			name:    "query exceeds max length",
+			input:   SearchGraphInput{UserID: "u1", Query: longQuery},
+			wantErr: true,
+			errSub:  "query exceeds maximum length",
+		},
+		// invalid limit (explicit values only; 0 is allowed as default sentinel)
+		{
+			name:    "limit below minimum",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", Limit: -1},
+			wantErr: true,
+			errSub:  "limit must be between",
+		},
+		{
+			name:    "limit zero is default sentinel not error",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", Limit: 0},
+			wantErr: false,
+		},
+		{
+			name:    "limit above maximum",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", Limit: searchLimitMax + 1},
+			wantErr: true,
+			errSub:  "limit must be between",
+		},
+		// invalid min_fact_rating (MinScore-equivalent field on SearchGraphInput)
+		{
+			name:    "min_fact_rating below minimum",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", MinFactRating: -0.01},
+			wantErr: true,
+			errSub:  "min_fact_rating must be between",
+		},
+		{
+			name:    "min_fact_rating above maximum",
+			input:   SearchGraphInput{UserID: "u1", Query: "q", MinFactRating: 1.01},
+			wantErr: true,
+			errSub:  "min_fact_rating must be between",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() error = nil, wantErr true")
+				}
+				if tt.errSub != "" && !strings.Contains(err.Error(), tt.errSub) {
+					t.Errorf("Validate() error = %q, want substring %q", err.Error(), tt.errSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Validate() unexpected error = %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds defensive input validation to the Go MCP server `search_graph` handler so malformed or abusive tool arguments are rejected **before** they reach the Zep API.

This closes a validation gap where `SearchGraphInput` fields were passed through with no bounds checking, empty-string checks, or max-length enforcement.

## Security rationale

The MCP server is an untrusted boundary: clients (agents, IDEs, scripts) can send arbitrary tool arguments. Without local validation:

1. **Empty / whitespace-only queries** waste API quota and can surface confusing downstream errors.
2. **Oversized queries** (>2000 characters) increase request payload size and can stress embedding/search backends.
3. **Out-of-range `limit`** (negative or very large) can cause unintended expensive scans or invalid API calls.
4. **Out-of-range `min_fact_rating`** (the score threshold field on this tool) can send nonsensical filter values to the API.

Failing fast with clear `fmt.Errorf` messages matches existing handler/transform error patterns and keeps bad inputs out of the network path.

## Changes

### `SearchGraphInput.Validate()` — `mcp/zep-mcp-server/internal/handlers/types.go`

New method enforces:

| Rule | Behavior |
|------|----------|
| Empty / whitespace-only `query` | rejected (`query cannot be empty`) |
| `query` > 2000 runes | rejected (`query exceeds maximum length of 2000 characters`) |
| Explicit `limit` outside 1–100 | rejected (`limit must be between 1 and 100`); `0` remains the "use default" sentinel |
| `min_fact_rating` outside [0.0, 1.0] | rejected (`min_fact_rating must be between 0 and 1`); `0` still means omitted |

Constants: `searchQueryMaxLen`, `searchLimitMin/Max`, `searchMinScoreMin/Max` (lines 10–16 in `types.go`).

Error style mirrors `internal/transform.ValidateRequired` (`fmt.Errorf("... cannot be empty")`, etc.).

### Handler wiring — `mcp/zep-mcp-server/internal/handlers/search.go`

`HandleSearchGraph` now calls `input.Validate()` **before** applying defaults and building `zep.GraphSearchQuery` (lines 17–19), so explicit out-of-range limits are rejected rather than being overwritten by defaults.

## Graph handler (`graph.go`) check

There is **no** `internal/handlers/graph.go` in this package. Graph search is implemented only in:

- `search.go` — `HandleSearchGraph` (the tool fixed here)
- Read-only graph entity handlers (`nodes.go`, `edges.go`, `episodes.go`, `node_detail.go`, `edge_detail.go`, `episode_detail.go`, `node_edges.go`, `episode_mentions.go`) which take UUIDs/IDs/limits only and do not accept free-text search queries or score thresholds

So the validation gap was specific to `search_graph`, not a missing parallel `graph.go` file.

## Tests added

All in existing `mcp/zep-mcp-server/internal/handlers/types_test.go` via new `TestSearchGraphInputValidate` (table-driven, same style as `TestGetUserInputValidation`):

**Valid**
- `valid minimal query`
- `valid query with surrounding whitespace`
- `valid query at max length` (2000 chars)
- `valid limit omitted (zero uses handler default)`
- `valid limit at minimum boundary` (1)
- `valid limit at maximum boundary` (100)
- `valid min_fact_rating omitted (zero)`
- `valid min_fact_rating at minimum boundary` (0.0)
- `valid min_fact_rating at maximum boundary` (1.0)
- `valid min_fact_rating mid range` (0.5)
- `limit zero is default sentinel not error`

**Invalid**
- `empty query`
- `whitespace only query`
- `query exceeds max length` (2001 chars)
- `limit below minimum` (-1)
- `limit above maximum` (101)
- `min_fact_rating below minimum` (-0.01)
- `min_fact_rating above maximum` (1.01)

## Verification

```bash
cd mcp/zep-mcp-server && go test ./...
```

All packages pass locally.

## Test plan

- [x] `go test ./...` under `mcp/zep-mcp-server` passes
- [x] Empty/whitespace query rejected before API call
- [x] Query length boundary at 2000 / 2001
- [x] Limit boundaries: 0 (default ok), 1, 100 ok; -1, 101 rejected
- [x] `min_fact_rating` boundaries: 0, 1 ok; -0.01, 1.01 rejected
- [ ] CI green on this PR