### PR TITLE
Switch npm integration releases to trusted publishing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -23,7 +23,8 @@ the `package` input; the Python action also derives the import name
 ### `release-integrations.yml` — package releases
 Triggered by a published GitHub release or manual dispatch. Routes by language:
 - **Python → PyPI** (test → build → publish via trusted publishing / OIDC).
-- **TypeScript → npm** (`npm ci` → build → test → `npm publish`, using `NPM_TOKEN`).
+- **TypeScript → npm** (`npm ci` → build → test → `npm publish`, via trusted
+  publishing / OIDC).
 
 **Tag scheme:** `zep-<framework>-<language>-v<version>` — e.g. `zep-adk-python-v0.2.0`,
 `zep-mastra-typescript-v0.1.0`. Manual dispatch takes `framework` + `language` inputs.
@@ -41,18 +42,31 @@ settings with repository `getzep/zep`, workflow `release-integrations.yml`, and 
 as desired). No secret needed — trusted publishing uses OIDC.
 
 ### npm
-Add an `NPM_TOKEN` secret (an automation token with publish rights) for TypeScript packages.
+For each TypeScript package (e.g. `@getzep/zep-adk`): add a GitHub Actions trusted
+publisher in the npm package settings:
+
+- Organization or user: `getzep`
+- Repository: `zep`
+- Workflow filename: `release-integrations.yml`
+- Environment name: `release`
+- Allowed actions: `npm publish`
+
+No secret is needed — trusted publishing uses OIDC. npm requires the package to already
+exist before configuring a trusted publisher, so new package names need a one-time initial
+publish by a maintainer with npm access before switching subsequent releases to this
+workflow.
 
 ## Adding a new package
 
 1. Create `integrations/<framework>/<language>/` per [`../../integrations/CLAUDE.md`](../../integrations/CLAUDE.md).
 2. Add a `paths-filter` entry under the matching language in `test-integrations.yml`
    (e.g. `pydantic-ai: ['integrations/pydantic-ai/python/**']`).
-3. Python: configure PyPI trusted publishing. TypeScript: ensure `NPM_TOKEN` is set.
+3. Python: configure PyPI trusted publishing. TypeScript: configure npm trusted publishing.
 4. Release by tagging `zep-<framework>-<language>-v<version>` (or the Go module-path tag).
 
 ## Troubleshooting
 
 - **Package not detected:** verify the `paths-filter` entry matches the package directory.
 - **Tests fail on PR:** check dependencies and language/version compatibility.
-- **Release fails:** confirm PyPI trusted publishing (env `release`) or `NPM_TOKEN` is set.
+- **Release fails:** confirm PyPI or npm trusted publishing is configured with environment
+  `release`.

--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -120,6 +120,9 @@ jobs:
     if: needs.detect.outputs.language == 'typescript'
     needs: detect
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://www.npmjs.com/package/@getzep/zep-${{ needs.detect.outputs.framework }}
     defaults:
       run:
         working-directory: integrations/${{ needs.detect.outputs.framework }}/typescript
@@ -128,8 +131,10 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+      - name: Install npm with OIDC support
+        run: npm install -g npm@latest
       - name: Check package exists
         run: |
           if [ ! -f package.json ]; then
@@ -143,5 +148,3 @@ jobs:
           npm test
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/integrations/adk/typescript/package-lock.json
+++ b/integrations/adk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getzep/zep-adk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getzep/zep-adk",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@getzep/zep-cloud": "^3.23.0",

--- a/integrations/adk/typescript/package.json
+++ b/integrations/adk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getzep/zep-adk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Zep long-term memory integration for Google ADK (TypeScript) agents",
   "license": "Apache-2.0",
   "author": "Zep AI",

--- a/integrations/mastra/typescript/package-lock.json
+++ b/integrations/mastra/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getzep/zep-mastra",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getzep/zep-mastra",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@getzep/zep-cloud": "^3.23.0",

--- a/integrations/mastra/typescript/package.json
+++ b/integrations/mastra/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getzep/zep-mastra",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Zep long-term memory tools for Mastra agents — persist, search, and retrieve user context from Zep's temporal Context Graph.",
   "license": "Apache-2.0",
   "author": "Zep AI, Inc.",

--- a/integrations/vercel-ai/typescript/package-lock.json
+++ b/integrations/vercel-ai/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@getzep/zep-vercel-ai",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@getzep/zep-vercel-ai",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@getzep/zep-cloud": "^3.23.0"

--- a/integrations/vercel-ai/typescript/package.json
+++ b/integrations/vercel-ai/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getzep/zep-vercel-ai",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Zep long-term memory for the Vercel AI SDK — a middleware that injects user context, plain persist/retrieve helpers, and model-callable tools over Zep's temporal Context Graph.",
   "license": "Apache-2.0",
   "author": "Zep AI, Inc.",


### PR DESCRIPTION
## Summary

- Switch TypeScript integration publishing from `NPM_TOKEN` to npm trusted publishing/OIDC.
- Run npm releases through the existing `release` GitHub environment and Node 24 with latest npm.
- Bump `@getzep/zep-adk`, `@getzep/zep-mastra`, and `@getzep/zep-vercel-ai` from `0.1.0` to `0.1.1`.
- Update workflow docs with the npm trusted publisher settings and the one-time bootstrap publish caveat.

## Motivation / context

The TypeScript integration release jobs were failing because the repo does not have an `NPM_TOKEN` secret. npm trusted publishing avoids long-lived publish tokens, matching the PyPI trusted publishing setup already used for Python packages.

## Impact

After the npm packages exist and each package is configured with a trusted publisher, manual `release-integrations.yml` runs can publish TypeScript integrations without an npm token.

## Testing

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-integrations.yml"); puts "workflow yaml ok"'`
- `npm ci && npm run build --if-present && npm run lint --if-present && npm run typecheck --if-present && npm test` in `integrations/adk/typescript`
- `npm ci && npm run build --if-present && npm run lint --if-present && npm run typecheck --if-present && npm test` in `integrations/mastra/typescript`
- `npm ci && npm run build --if-present && npm run lint --if-present && npm run typecheck --if-present && npm test` in `integrations/vercel-ai/typescript`

## Risks / follow-ups

npm requires packages to already exist before trusted publishing can be configured. The first publish for `@getzep/zep-adk`, `@getzep/zep-mastra`, and `@getzep/zep-vercel-ai` still needs to be bootstrapped manually by a maintainer with npm `@getzep` publish access, then trusted publishing can be configured for subsequent workflow releases.
