### PR TITLE
fix(integrations/google-adk): add py.typed sentinel for PEP 561 compliance

### DIFF
--- a/integrations/adk/python/pyproject.toml
+++ b/integrations/adk/python/pyproject.toml
@@ -32,6 +32,7 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/zep_adk"]
+# py.typed sentinel is included automatically from the package directory (PEP 561)
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Add an empty `py.typed` marker file to `integrations/adk/python/src/zep_adk/`, enabling downstream `mypy`/`pyright` consumers to resolve types from the installed package inline — no stubs required.

## What changed

| File | Change |
|------|--------|
| `integrations/adk/python/src/zep_adk/py.typed` | New empty sentinel file (PEP 561) |
| `integrations/adk/python/pyproject.toml` | Added clarifying comment in `[tool.hatch.build.targets.wheel]` |

## Why

[PEP 561](https://peps.python.org/pep-0561/) requires a `py.typed` marker for a package to be considered a *typed package*. Without it, mypy and pyright skip inline type checking and fall back to stubs or `Any`. The `zep-adk` package already has full type annotations and a strict mypy config (`disallow_untyped_defs = true`) — the marker just makes that signal legible to downstream consumers.

## Impact

- **No logic changes** — empty marker file only.
- **No new dependencies.**
- **CI should pass as-is** — hatchling auto-includes all files within the declared package directory (`src/zep_adk`), so no build configuration changes are required.
- Downstream users who `pip install zep-adk` will immediately benefit from inline type resolution.

## Related

- PEP 561: https://peps.python.org/pep-0561/
- Hatchling docs on package inclusion: https://hatch.pypa.io/latest/config/build/