### PR TITLE
docs(integrations): standardize README and example models on gpt-5-mini

### DIFF
--- a/integrations/ag2/python/README.md
+++ b/integrations/ag2/python/README.md
@@ -23,7 +23,7 @@ async def main():
     zep = AsyncZep(api_key=os.environ["ZEP_API_KEY"])
 
     llm_config = LLMConfig(
-        {"model": "gpt-4o-mini", "api_key": os.environ["OPENAI_API_KEY"]}
+        {"model": "gpt-5-mini", "api_key": os.environ["OPENAI_API_KEY"]}
     )
 
     assistant = AssistantAgent(

--- a/integrations/ag2/python/examples/ag2_basic.py
+++ b/integrations/ag2/python/examples/ag2_basic.py
@@ -31,7 +31,7 @@ async def main() -> None:
     session_id = f"thread_{uuid.uuid4().hex[:16]}"
 
     # Configure AG2 agents
-    llm_config = LLMConfig({"model": "gpt-4o-mini", "api_key": os.environ["OPENAI_API_KEY"]})
+    llm_config = LLMConfig({"model": "gpt-5-mini", "api_key": os.environ["OPENAI_API_KEY"]})
 
     assistant = AssistantAgent(
         name="assistant",

--- a/integrations/ag2/python/examples/ag2_graph.py
+++ b/integrations/ag2/python/examples/ag2_graph.py
@@ -23,7 +23,7 @@ async def main() -> None:
     graph_id = "company_knowledge_base"
 
     # Configure AG2 agents
-    llm_config = LLMConfig({"model": "gpt-4o-mini", "api_key": os.environ["OPENAI_API_KEY"]})
+    llm_config = LLMConfig({"model": "gpt-5-mini", "api_key": os.environ["OPENAI_API_KEY"]})
 
     assistant = AssistantAgent(
         name="knowledge_assistant",

--- a/integrations/ag2/python/examples/ag2_tools_full.py
+++ b/integrations/ag2/python/examples/ag2_tools_full.py
@@ -32,7 +32,7 @@ async def main() -> None:
     except Exception as e:
         print(f"Setup: {e}")
 
-    llm_config = LLMConfig({"model": "gpt-4o-mini", "api_key": os.environ["OPENAI_API_KEY"]})
+    llm_config = LLMConfig({"model": "gpt-5-mini", "api_key": os.environ["OPENAI_API_KEY"]})
 
     researcher = AssistantAgent(
         name="researcher",

--- a/integrations/ag2/python/examples/ag2_tools_search.py
+++ b/integrations/ag2/python/examples/ag2_tools_search.py
@@ -22,7 +22,7 @@ async def main() -> None:
     zep = AsyncZep(api_key=os.environ["ZEP_API_KEY"])
     user_id = "user_alice"
 
-    llm_config = LLMConfig({"model": "gpt-4o-mini", "api_key": os.environ["OPENAI_API_KEY"]})
+    llm_config = LLMConfig({"model": "gpt-5-mini", "api_key": os.environ["OPENAI_API_KEY"]})
 
     assistant = AssistantAgent(
         name="researcher",

--- a/integrations/autogen/python/README.md
+++ b/integrations/autogen/python/README.md
@@ -68,7 +68,7 @@ async def main():
     # Create agent with tools and reflection
     agent = AssistantAgent(
         name="KnowledgeAssistant",
-        model_client=OpenAIChatCompletionClient(model="gpt-4o-mini"),
+        model_client=OpenAIChatCompletionClient(model="gpt-5-mini"),
         tools=[search_tool, add_tool],
         system_message="You can search and add information to knowledge bases.",
         reflect_on_tool_use=True,  # Enables natural language responses

--- a/integrations/crewai/python/README.md
+++ b/integrations/crewai/python/README.md
@@ -105,7 +105,7 @@ agent = Agent(
     role="Knowledge Assistant",
     goal="Manage and retrieve information efficiently",
     tools=[search_tool, add_tool],
-    llm="gpt-4o-mini"
+    llm="gpt-5-mini"
 )
 ```
 

--- a/integrations/crewai/python/examples/crewai_graph.py
+++ b/integrations/crewai/python/examples/crewai_graph.py
@@ -153,7 +153,7 @@ def main():
         search tool to query the knowledge graph for technology and company facts.""",
         tools=[search_tool],
         verbose=True,
-        llm="gpt-4o-mini",
+        llm="gpt-5-mini",
     )
 
     recruiter = Agent(
@@ -165,7 +165,7 @@ def main():
         to query the knowledge graph.""",
         tools=[search_tool],
         verbose=True,
-        llm="gpt-4o-mini",
+        llm="gpt-5-mini",
     )
 
     # Create tasks that leverage the graph knowledge

--- a/integrations/crewai/python/examples/crewai_tools.py
+++ b/integrations/crewai/python/examples/crewai_tools.py
@@ -71,7 +71,7 @@ def main():
         knowledge base where you can store and retrieve information specific to him.""",
         tools=[user_search_tool, user_add_tool],
         verbose=True,
-        llm="gpt-4o-mini",
+        llm="gpt-5-mini",
     )
 
     knowledge_curator = Agent(
@@ -82,7 +82,7 @@ def main():
         benefits everyone.""",
         tools=[graph_search_tool, graph_add_tool],
         verbose=True,
-        llm="gpt-4o-mini",
+        llm="gpt-5-mini",
     )
 
     research_analyst = Agent(
@@ -92,7 +92,7 @@ def main():
         knowledge to provide comprehensive insights and recommendations.""",
         tools=[user_search_tool, graph_search_tool],  # Read-only access to both
         verbose=True,
-        llm="gpt-4o-mini",
+        llm="gpt-5-mini",
     )
 
     # Task 1: Store Bob's personal information

--- a/integrations/crewai/python/examples/crewai_user.py
+++ b/integrations/crewai/python/examples/crewai_user.py
@@ -156,7 +156,7 @@ def main():
         Use the Zep memory search tool to recall Alice's history and preferences.""",
         tools=[search_tool],
         verbose=True,
-        llm="gpt-4o-mini",
+        llm="gpt-5-mini",
     )
 
     resource_planner = Agent(
@@ -168,7 +168,7 @@ def main():
         team's composition and current projects.""",
         tools=[search_tool],
         verbose=True,
-        llm="gpt-4o-mini",
+        llm="gpt-5-mini",
     )
 
     # Create tasks that leverage user-specific memory

--- a/integrations/langgraph/python/README.md
+++ b/integrations/langgraph/python/README.md
@@ -44,7 +44,7 @@ async def prompt(state):
     return [system, *state["messages"]]
 
 agent = create_react_agent(
-    model=ChatOpenAI(model="gpt-5"),
+    model=ChatOpenAI(model="gpt-5-mini"),
     tools=[create_graph_search_tool(zep, user_id="user-1")],
     prompt=prompt,
 )

--- a/integrations/langgraph/python/examples/react_agent.py
+++ b/integrations/langgraph/python/examples/react_agent.py
@@ -86,8 +86,8 @@ async def main() -> None:
     # --- On-demand graph search over the user's personal graph. ---
     search_tool = create_graph_search_tool(zep, user_id=USER_ID, scope="edges")
 
-    # gpt-5 is a reasoning model and rejects an explicit ``temperature``; omit it.
-    model = ChatOpenAI(model="gpt-5")
+    # gpt-5 family models are reasoning models and reject an explicit ``temperature``; omit it.
+    model = ChatOpenAI(model="gpt-5-mini")
     agent = create_react_agent(model=model, tools=[search_tool], prompt=prompt)
 
     async def chat(user_text: str) -> str:

--- a/integrations/livekit/python/README.md
+++ b/integrations/livekit/python/README.md
@@ -82,7 +82,7 @@ async def entrypoint(ctx: agents.JobContext):
     # Create session with providers
     session = agents.AgentSession(
         stt=openai.STT(),
-        llm=openai.LLM(model="gpt-4o-mini"),
+        llm=openai.LLM(model="gpt-5-mini"),
         tts=openai.TTS(),
         vad=silero.VAD.load(),
     )
@@ -176,7 +176,7 @@ async def entrypoint(ctx: agents.JobContext):
     # Create session
     session = agents.AgentSession(
         stt=openai.STT(),
-        llm=openai.LLM(model="gpt-4o-mini"),
+        llm=openai.LLM(model="gpt-5-mini"),
         tts=openai.TTS(),
         vad=silero.VAD.load(),
     )

--- a/integrations/mastra/typescript/README.md
+++ b/integrations/mastra/typescript/README.md
@@ -45,7 +45,7 @@ const agent = new Agent({
   id: "memory-agent",
   name: "Memory Agent",
   instructions: "You have long-term memory about the user. Use it to personalize replies.",
-  model: "openai/gpt-4o-mini",
+  model: "openai/gpt-5-mini",
   inputProcessors: [inputProcessor],
   outputProcessors: [outputProcessor],
 });
@@ -158,7 +158,7 @@ const agent = new Agent({
   id: "memory-agent",
   name: "Memory Agent",
   instructions: "You have long-term memory. Store and recall user facts.",
-  model: "openai/gpt-4o-mini",
+  model: "openai/gpt-5-mini",
   tools: { zepRemember, zepSearch, zepContext },
 });
 ```

--- a/integrations/mastra/typescript/examples/basic-agent.ts
+++ b/integrations/mastra/typescript/examples/basic-agent.ts
@@ -76,7 +76,7 @@ async function main(): Promise<void> {
       "You are a helpful assistant with long-term memory about the user, " +
       "injected automatically into your context. Personalize your replies " +
       "using what you know about the user.",
-    model: "openai/gpt-4o-mini",
+    model: "openai/gpt-5-mini",
     inputProcessors: [inputProcessor],
     outputProcessors: [outputProcessor],
   });

--- a/integrations/ms-agent-framework/python/README.md
+++ b/integrations/ms-agent-framework/python/README.md
@@ -28,7 +28,7 @@ from zep_ms_agent_framework import ZepContextProvider
 zep = AsyncZep(api_key="your-zep-api-key")
 
 agent = Agent(
-    OpenAIChatClient(model="gpt-4o-mini"),
+    OpenAIChatClient(model="gpt-5-mini"),
     instructions="You are a helpful assistant with long-term memory.",
     context_providers=[
         ZepContextProvider(

--- a/integrations/ms-agent-framework/python/examples/basic_agent.py
+++ b/integrations/ms-agent-framework/python/examples/basic_agent.py
@@ -33,7 +33,7 @@ from zep_ms_agent_framework import ZepContextProvider
 # ---------------------------------------------------------------------------
 ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
-OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5-mini")
 
 if not ZEP_API_KEY:
     raise SystemExit("ZEP_API_KEY is not set.")

--- a/integrations/pydantic-ai/python/README.md
+++ b/integrations/pydantic-ai/python/README.md
@@ -29,7 +29,7 @@ deps = ZepDeps(
 )
 
 agent = Agent(
-    "openai:gpt-4o-mini",
+    "openai:gpt-5-mini",
     deps_type=ZepDeps,
     capabilities=zep_capabilities(deps),
     tools=[create_zep_search_tool()],
@@ -219,7 +219,7 @@ persists the assistant's reply once the run completes -- no explicit
 from zep_pydantic_ai import zep_capabilities
 
 agent = Agent(
-    "openai:gpt-4o-mini",
+    "openai:gpt-5-mini",
     deps_type=ZepDeps,
     capabilities=zep_capabilities(deps),
 )

--- a/integrations/pydantic-ai/python/examples/basic_agent.py
+++ b/integrations/pydantic-ai/python/examples/basic_agent.py
@@ -72,7 +72,7 @@ async def main() -> None:
     )
 
     agent = Agent(
-        "openai:gpt-4o-mini",
+        "openai:gpt-5-mini",
         deps_type=ZepDeps,
         capabilities=zep_capabilities(deps),
         tools=[create_zep_search_tool()],

--- a/integrations/vercel-ai/typescript/README.md
+++ b/integrations/vercel-ai/typescript/README.md
@@ -54,7 +54,7 @@ await ensureZepUserAndThread({ client, userId: "u1", threadId: "t1", firstName: 
 // 2. Wrap the model: inject the Context Block on each new user turn AND
 //    guarantee the turn is persisted — no onFinish wiring needed.
 const model = wrapLanguageModel({
-  model: openai("gpt-4o-mini"),
+  model: openai("gpt-5-mini"),
   middleware: createZepMiddleware({ client, threadId: "t1", persist: true }),
 });
 
@@ -77,7 +77,7 @@ middleware stays injection-only) and pair it with `createZepOnFinish`:
 
 ```ts
 const model = wrapLanguageModel({
-  model: openai("gpt-4o-mini"),
+  model: openai("gpt-5-mini"),
   middleware: createZepMiddleware({ client, threadId: "t1" }), // injection only
 });
 
@@ -109,7 +109,7 @@ import { openai } from "@ai-sdk/openai";
 import { createZepMiddleware } from "@getzep/zep-vercel-ai";
 
 const model = wrapLanguageModel({
-  model: openai("gpt-4o-mini"),
+  model: openai("gpt-5-mini"),
   middleware: createZepMiddleware({ client, threadId: "t1", persist: true }),
 });
 

--- a/integrations/vercel-ai/typescript/examples/generate-text.ts
+++ b/integrations/vercel-ai/typescript/examples/generate-text.ts
@@ -77,7 +77,7 @@ async function main(): Promise<void> {
   //    Responses API so the multi-step tool loop also works on OpenAI Zero Data
   //    Retention (ZDR) organizations, which don't persist Responses item IDs.
   const model = wrapLanguageModel({
-    model: openai.chat("gpt-4o-mini"),
+    model: openai.chat("gpt-5-mini"),
     middleware: createZepMiddleware({ client, threadId }),
   });
 

--- a/integrations/vercel-ai/typescript/examples/stream-text.ts
+++ b/integrations/vercel-ai/typescript/examples/stream-text.ts
@@ -59,7 +59,7 @@ async function main(): Promise<void> {
 
   // 1. Wrap the model: inject the Context Block on each new user turn.
   const model = wrapLanguageModel({
-    model: openai("gpt-4o-mini"),
+    model: openai("gpt-5-mini"),
     middleware: createZepMiddleware({ client, threadId }),
   });
 


### PR DESCRIPTION
OpenAI is [retiring GPT-4o-generation models from ChatGPT](https://openai.com/index/retiring-gpt-4o-and-older-models/) and steering migrations to the gpt-5 family, so `gpt-4o-mini` no longer belongs in quickstarts. This standardizes every integration README and runnable example on `gpt-5-mini` — the like-for-like small-model successor, already used in the ms-agent-framework package docstrings — replacing both the widespread `gpt-4o-mini` and langgraph's lone `gpt-5`. Deliberately untouched: the ADK packages (`gemini-2.5-flash`), the livekit voice examples (pinned `gpt-5-nano` for latency), env-overridable integration-test model defaults, and ag2's `manual_test.py` (pairs the model with an explicit `temperature`, which gpt-5 reasoning models reject).

Note: this PR originally went the other direction (langgraph `gpt-5` → `gpt-4o-mini` for consistency); the retirement announcement flipped the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)