### PR TITLE
Add DaoXE OpenAI-compatible AsyncOpenAI example (Python)

### DIFF
--- a/examples/python/daoxe-openai-compat/.env.example
+++ b/examples/python/daoxe-openai-compat/.env.example
@@ -1,0 +1,10 @@
+# Zep Cloud — https://app.getzep.com
+ZEP_API_KEY=your_zep_api_key_here
+
+# DaoXE — https://daoxe.com (multi-model, multi-protocol API gateway)
+# Use an exact model ID from your DaoXE account catalog (account-scoped; not a fixed public list).
+DAOXE_API_KEY=your_daoxe_api_key_here
+DAOXE_MODEL=your_account_model_id_here
+
+# Optional override (defaults to https://daoxe.com/v1 for OpenAI Chat Completions)
+# DAOXE_BASE_URL=https://daoxe.com/v1

--- a/examples/python/daoxe-openai-compat/README.md
+++ b/examples/python/daoxe-openai-compat/README.md
@@ -1,0 +1,71 @@
+# Zep + DaoXE (OpenAI-compatible Chat Completions)
+
+Minimal Python example: **AsyncZep** long-term memory with an **AsyncOpenAI** client pointed at [DaoXE](https://daoxe.com).
+
+```python
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI(
+    api_key=os.environ["DAOXE_API_KEY"],
+    base_url="https://daoxe.com/v1",
+)
+```
+
+## Why this example
+
+Many Zep samples already use the OpenAI Python SDK for the LLM turn. DaoXE is a **multi-model, multi-protocol** API gateway. This sample shows the same migration path used elsewhere in the ecosystem:
+
+| Piece | Value |
+| --- | --- |
+| Chat Completions base | `https://daoxe.com/v1` |
+| Auth | `DAOXE_API_KEY` |
+| Model | `DAOXE_MODEL` (exact ID from **your** DaoXE account catalog) |
+| Memory | Zep Cloud (`ZEP_API_KEY`) via `zep-cloud` |
+
+DaoXE also supports other protocols (including **OpenAI Responses** and **Anthropic Messages / Claude protocol**) and multiple model families. This folder only covers OpenAI SDK + custom `base_url` so it stays consistent with existing OpenAI-style Zep examples — it is **not** OpenAI-only.
+
+> **Availability:** DaoXE is **not offered in mainland China**. Use account-visible model IDs from your own DaoXE dashboard/catalog. If you cannot reach `daoxe.com`, follow regional endpoint guidance on the DaoXE site (do not hardcode alternate hosts in application code without checking current docs).
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+Fill in `.env`:
+
+| Variable | Source |
+| --- | --- |
+| `ZEP_API_KEY` | [app.getzep.com](https://app.getzep.com) |
+| `DAOXE_API_KEY` | [daoxe.com](https://daoxe.com) dashboard |
+| `DAOXE_MODEL` | Exact model ID from your DaoXE account (catalog / `GET /v1/models`) |
+| `DAOXE_BASE_URL` | Optional; defaults to `https://daoxe.com/v1` |
+
+Model IDs are **account-scoped** and change over time. Prefer env vars over hardcoding keys or model names.
+
+## Run
+
+```bash
+python daoxe_zep_memory.py
+```
+
+What it does:
+
+1. Creates a Zep user and seeds a short prior conversation (walking tours in Lisbon).
+2. Opens a live thread and asks a follow-up that should use retrieved memory.
+3. Streams the assistant reply from DaoXE via `AsyncOpenAI(... base_url=https://daoxe.com/v1)`.
+4. Writes both user and assistant turns back into the Zep thread.
+
+## Notes
+
+- Prefer models in your catalog that stream Chat Completions reliably.
+- For Anthropic Messages / Claude protocol clients, use DaoXE’s Messages endpoints instead of this OpenAI SDK sample.
+- More DaoXE client snippets: https://github.com/seven7763/DaoXE-AI
+
+## Learn more
+
+- [Zep Cloud docs](https://help.getzep.com)
+- [DaoXE](https://daoxe.com)

--- a/examples/python/daoxe-openai-compat/daoxe_zep_memory.py
+++ b/examples/python/daoxe-openai-compat/daoxe_zep_memory.py
@@ -1,0 +1,197 @@
+"""
+Zep Cloud + DaoXE (OpenAI-compatible Chat Completions)
+
+Demonstrates AsyncZep memory with AsyncOpenAI pointed at DaoXE:
+
+    AsyncOpenAI(
+        api_key=os.environ["DAOXE_API_KEY"],
+        base_url="https://daoxe.com/v1",  # or DAOXE_BASE_URL
+    )
+
+DaoXE is a multi-model, multi-protocol API gateway (OpenAI Chat Completions,
+OpenAI Responses, Anthropic Messages / Claude protocol, and more). This sample
+uses only the OpenAI Python SDK + custom base URL path so it stays close to
+existing OpenAI-style Zep examples.
+
+Model IDs are account-scoped: set DAOXE_MODEL to an exact ID from your DaoXE
+catalog (dashboard or authenticated GET /v1/models). Do not hardcode a static
+public model list.
+
+Availability: DaoXE is not offered in mainland China. Use the regional guidance
+on the DaoXE site if your network cannot reach daoxe.com.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+from dotenv import load_dotenv
+from openai import AsyncOpenAI
+from zep_cloud.client import AsyncZep
+from zep_cloud.types import Message
+
+load_dotenv()
+
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY")
+DAOXE_API_KEY = os.environ.get("DAOXE_API_KEY")
+DAOXE_MODEL = os.environ.get("DAOXE_MODEL")
+DAOXE_BASE_URL = os.environ.get("DAOXE_BASE_URL", "https://daoxe.com/v1")
+
+FIRST_NAME = "Alex"
+LAST_NAME = "Rivera"
+USER_FULL_NAME = f"{FIRST_NAME} {LAST_NAME}"
+
+
+def require_env() -> None:
+    missing = [
+        name
+        for name, value in (
+            ("ZEP_API_KEY", ZEP_API_KEY),
+            ("DAOXE_API_KEY", DAOXE_API_KEY),
+            ("DAOXE_MODEL", DAOXE_MODEL),
+        )
+        if not value
+    ]
+    if missing:
+        raise SystemExit(
+            "Missing required environment variables: "
+            + ", ".join(missing)
+            + ". Copy .env.example to .env and set them."
+        )
+
+
+async def seed_prior_thread(zep: AsyncZep, user_id: str) -> None:
+    """Ingest a short prior conversation so memory context is non-empty."""
+    thread_id = f"daoxe-seed-{uuid.uuid4().hex[:8]}"
+    await zep.thread.create(thread_id=thread_id, user_id=user_id)
+
+    prior = [
+        Message(
+            name=USER_FULL_NAME,
+            role="user",
+            content="I'm planning a weekend trip to Lisbon and I prefer walking tours over buses.",
+        ),
+        Message(
+            name="AI Assistant",
+            role="assistant",
+            content="Great — I'll remember you prefer walking tours in Lisbon.",
+        ),
+        Message(
+            name=USER_FULL_NAME,
+            role="user",
+            content="Also keep replies under three short sentences when possible.",
+        ),
+        Message(
+            name="AI Assistant",
+            role="assistant",
+            content="Understood. I'll keep responses brief.",
+        ),
+    ]
+    await zep.thread.add_messages(thread_id=thread_id, messages=prior)
+    print(f"Seeded prior thread: {thread_id}")
+
+
+async def chat_once(
+    zep: AsyncZep,
+    openai_client: AsyncOpenAI,
+    *,
+    user_id: str,
+    thread_id: str,
+    user_message: str,
+) -> str:
+    await zep.thread.add_messages(
+        thread_id=thread_id,
+        messages=[
+            Message(name=USER_FULL_NAME, role="user", content=user_message),
+        ],
+    )
+
+    memory = await zep.thread.get_user_context(thread_id=thread_id, mode="basic")
+    context_block = memory.context or ""
+
+    system_prompt = (
+        "You are a helpful assistant with long-term memory from Zep. "
+        "Use the memory context when it is relevant. Keep replies concise.\n\n"
+        f"{context_block}"
+    )
+
+    stream = await openai_client.chat.completions.create(
+        model=DAOXE_MODEL,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ],
+        stream=True,
+        max_tokens=256,
+    )
+
+    parts: list[str] = []
+    async for chunk in stream:
+        delta = chunk.choices[0].delta.content if chunk.choices else None
+        if delta:
+            parts.append(delta)
+            print(delta, end="", flush=True)
+    print()
+
+    full_response = "".join(parts)
+    if full_response:
+        await zep.thread.add_messages(
+            thread_id=thread_id,
+            messages=[
+                Message(
+                    name="AI Assistant",
+                    role="assistant",
+                    content=full_response,
+                ),
+            ],
+        )
+    return full_response
+
+
+async def main() -> None:
+    require_env()
+
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+    openai_client = AsyncOpenAI(
+        api_key=DAOXE_API_KEY,
+        base_url=DAOXE_BASE_URL,
+    )
+
+    suffix = uuid.uuid4().hex[:8]
+    user_id = f"daoxe-demo-{suffix}"
+    thread_id = f"daoxe-live-{suffix}"
+
+    await zep.user.add(
+        user_id=user_id,
+        first_name=FIRST_NAME,
+        last_name=LAST_NAME,
+        email=f"{user_id}@example.com",
+    )
+    print(f"Created Zep user: {user_id}")
+
+    await seed_prior_thread(zep, user_id)
+
+    await zep.thread.create(thread_id=thread_id, user_id=user_id)
+    print(f"Live thread: {thread_id}")
+    print(f"DaoXE base_url: {DAOXE_BASE_URL}")
+    print(f"DaoXE model: {DAOXE_MODEL}")
+    print("---")
+
+    prompt = (
+        "Based on what you know about me, suggest one walking-friendly activity "
+        "for my Lisbon weekend."
+    )
+    print(f"User: {prompt}\nAssistant: ", end="", flush=True)
+    await chat_once(
+        zep,
+        openai_client,
+        user_id=user_id,
+        thread_id=thread_id,
+        user_message=prompt,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/daoxe-openai-compat/requirements.txt
+++ b/examples/python/daoxe-openai-compat/requirements.txt
@@ -1,0 +1,3 @@
+openai>=1.98.0
+python-dotenv>=1.0.0
+zep-cloud>=3.0.5


### PR DESCRIPTION
## Summary

Adds `examples/python/daoxe-openai-compat` showing **AsyncZep** agent memory with **AsyncOpenAI** pointed at [DaoXE](https://daoxe.com):

```python
from openai import AsyncOpenAI

client = AsyncOpenAI(
    api_key=os.environ["DAOXE_API_KEY"],
    base_url="https://daoxe.com/v1",
)
```

### Why this fits the examples tree

- Mirrors existing OpenAI-style Zep samples (`AsyncOpenAI` + thread memory / context injection).
- DaoXE is a **multi-model, multi-protocol** API gateway. This PR documents the **OpenAI Chat Completions** path only (same migration shape as other OpenAI-compatible backends). DaoXE also supports OpenAI Responses and Anthropic Messages / Claude protocol — those are out of scope for this folder.
- Model IDs are **account-scoped** via `DAOXE_MODEL` (no hardcoded public model list).
- **Availability:** DaoXE is **not offered in mainland China**; README notes regional guidance without hardcoding alternate hosts.

### Files

| Path | Purpose |
| --- | --- |
| `examples/python/daoxe-openai-compat/daoxe_zep_memory.py` | Seed prior thread → retrieve context → stream Chat Completions via DaoXE → write back to Zep |
| `README.md` | Setup, env vars, multi-protocol + region notes |
| `.env.example` | `ZEP_API_KEY`, `DAOXE_API_KEY`, `DAOXE_MODEL`, optional `DAOXE_BASE_URL` |
| `requirements.txt` | `openai`, `python-dotenv`, `zep-cloud` |

I maintain DaoXE. Related snippets: https://github.com/seven7763/DaoXE-AI

## Test plan

- [ ] `cd examples/python/daoxe-openai-compat && python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`
- [ ] `cp .env.example .env` and set `ZEP_API_KEY`, `DAOXE_API_KEY`, `DAOXE_MODEL` (exact account catalog ID)
- [ ] `python daoxe_zep_memory.py`
- [ ] Confirm streaming assistant reply references seeded Lisbon / walking-tour context when memory is available
- [ ] Confirm no secrets committed (env-only keys/models)