### PR TITLE
ci: fix Codex reviewer gating so reviews actually run

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,9 +7,10 @@ Integrations are organized framework-first, then language: `integrations/<framew
 
 ### `codex-code-review.yml` — automatic maintainer PR review
 
-Runs Codex when a non-draft pull request authored by a `getzep` organization
-member is opened, updated, reopened, or marked ready for review. Pull requests
-from outside contributors and external collaborators are skipped before the
+Runs Codex when a non-draft pull request is opened, updated, reopened, or
+marked ready for review. A secretless preflight job verifies the PR comes from
+a branch in this repository, its author is not a bot, and the author has write
+(or higher) repository permission; anything else is skipped before the
 secret-bearing job starts. Codex's output is posted as a GitHub pull request
 review. It does not submit a formal approval.
 

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -9,17 +9,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  review:
-    # Restrict paid, secret-bearing reviews to PRs from branches in this
-    # repository: only users with write access can push branches here, and
-    # fork PRs never receive secrets on pull_request events. Bots (e.g.
-    # dependabot) are excluded to avoid burning paid reviews. We don't gate
-    # on author_association because private org membership reports as
-    # CONTRIBUTOR in event payloads, which silently skips every review.
+  check-permission:
+    # Secretless preflight: restrict paid, secret-bearing reviews to PR
+    # authors with write access. A same-repo head check alone is not enough
+    # on a public repository -- anyone can open a PR from an existing
+    # upstream branch without push access -- so the author's repository
+    # permission is verified explicitly. We don't gate on author_association
+    # because private org membership reports as CONTRIBUTOR in event
+    # payloads, which silently skips every review.
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+
+    steps:
+      - name: Check author repository permission
+        id: check
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.pull_request.user.login,
+            });
+            const authorized = ["admin", "maintain", "write"].includes(data.permission);
+            core.info(`Author permission: ${data.permission} (authorized: ${authorized})`);
+            core.setOutput("authorized", authorized ? "true" : "false");
+
+  review:
+    needs: check-permission
+    if: needs.check-permission.outputs.authorized == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/codex-code-review.yml
+++ b/.github/workflows/codex-code-review.yml
@@ -10,13 +10,16 @@ concurrency:
 
 jobs:
   review:
-    # Restrict paid, secret-bearing reviews to PRs authored by members of the
-    # getzep organization. COLLABORATOR is intentionally excluded because it
-    # can include external repository collaborators.
+    # Restrict paid, secret-bearing reviews to PRs from branches in this
+    # repository: only users with write access can push branches here, and
+    # fork PRs never receive secrets on pull_request events. Bots (e.g.
+    # dependabot) are excluded to avoid burning paid reviews. We don't gate
+    # on author_association because private org membership reports as
+    # CONTRIBUTOR in event payloads, which silently skips every review.
     if: >-
       github.event.pull_request.draft == false &&
-      (github.event.pull_request.author_association == 'MEMBER' ||
-       github.event.pull_request.author_association == 'OWNER')
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository is **not** Zep's product or service. It contains **example code,
 integrations, and tools** for building agent memory with [Zep Cloud](https://www.getzep.com/),
 Zep's managed agent memory platform.
 
-To use Zep Cloud, sign up at [www.getzep.com](https://www.getzep.com/) and read the
+To use Zep Cloud, sign up at [www.getzep.com](https://www.getzep.com/) and explore the
 documentation at [help.getzep.com](https://help.getzep.com). Zep's official SDKs are:
 
 - **Python**: `pip install zep-cloud`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository is **not** Zep's product or service. It contains **example code,
 integrations, and tools** for building agent memory with [Zep Cloud](https://www.getzep.com/),
 Zep's managed agent memory platform.
 
-To use Zep Cloud, sign up at [www.getzep.com](https://www.getzep.com/) and explore the
+To use Zep Cloud, sign up at [www.getzep.com](https://www.getzep.com/) and read the
 documentation at [help.getzep.com](https://help.getzep.com). Zep's official SDKs are:
 
 - **Python**: `pip install zep-cloud`


### PR DESCRIPTION
## Summary
- The Codex review job never ran: it gated on `author_association == MEMBER/OWNER`, but private org membership reports as `CONTRIBUTOR` in Actions event payloads, so every run since #561 was skipped.
- Replace the gate with a secretless `check-permission` preflight job: non-draft + same-repo head + non-bot, then verify the PR author has write/maintain/admin repository permission via `getCollaboratorPermissionLevel` before the paid, secret-bearing review job runs.
- Update `.github/workflows/README.md` to document the new access control.

The permission preflight (rather than a same-repo check alone) closes the hole Codex itself flagged on this PR: on a public repo, anyone can open a PR from an existing upstream branch without push access.

## Test plan
- [x] Preflight, review, and post-review jobs all succeeded on this PR (previous runs were instantly skipped).
- [x] Codex posted a review, and its final pass reported "No actionable findings."