### PR TITLE
examples: add Zep + CKG two-layer context agent

### DIFF
--- a/examples/python/ckg-zep-example/README.md
+++ b/examples/python/ckg-zep-example/README.md
@@ -1,0 +1,63 @@
+# Zep + CKG: Two-Layer Context Agent
+
+An agent that combines Zep's episodic memory with [Compact Knowledge Graphs (CKG)](https://graphifymd.com) — giving it both user-specific history and authoritative domain knowledge.
+
+## Why two layers?
+
+| Layer | Source | Answers |
+|-------|--------|---------|
+| **Episodic** (Zep) | User's conversation history | Who is this user? What happened before? |
+| **Semantic** (CKG) | Pre-built domain graph, SHA-256 anchored | What is true about this domain? |
+
+Neither alone is complete. Zep knows the user; CKG knows the domain. Together, the agent personalizes accurate answers without hallucinating facts outside its knowledge.
+
+## Architecture
+
+```
+User message
+    ↓
+[Zep]  thread.get_user_context()  →  user summary + facts from past sessions
+    ↓
+[CKG]  CKGRetriever               →  concept subgraph (prerequisites + dependents)
+    ↓
+[LLM]  synthesize from both layers
+    ↓
+[Zep]  thread.add_messages()      →  store exchange for future sessions
+```
+
+## Setup
+
+```bash
+pip install zep-cloud langchain-ckg langchain-openai langgraph
+
+export ZEP_API_KEY=your-zep-api-key       # app.getzep.com
+export OPENAI_API_KEY=your-openai-key
+```
+
+## Run
+
+```bash
+python agent.py
+```
+
+## Available CKG domains
+
+97 domains available — NVIDIA AI, NemoClaw, Salesforce AgentForce, Nemotron, Perplexity, and more.
+
+```python
+from ckg_mcp.graph import list_domains
+print(list_domains())
+```
+
+Change `ckg_domain` in the example to query any domain.
+
+## What gets stored in Zep
+
+Every exchange is written back to the Zep thread via `thread.add_messages()`. On the next invocation, `thread.get_user_context()` returns a context block that includes facts extracted from prior exchanges — so the agent remembers what the user asked before and what it answered.
+
+## Links
+
+- [Zep documentation](https://help.getzep.com)
+- [CKG on PyPI](https://pypi.org/project/langchain-ckg/)
+- [CKG benchmark](https://huggingface.co/datasets/danyarm/ckg-benchmark)
+- [graphifymd.com](https://graphifymd.com)

--- a/examples/python/ckg-zep-example/agent.py
+++ b/examples/python/ckg-zep-example/agent.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
     try:
         zep.thread.get(THREAD_ID)
     except Exception:
-        zep.thread.add(thread_id=THREAD_ID, user_id=USER_ID)
+        zep.thread.create(thread_id=THREAD_ID, user_id=USER_ID)
 
     result = agent.invoke({
         "query": "What are the prerequisites for using NemoClaw kernel fusion?",

--- a/examples/python/ckg-zep-example/agent.py
+++ b/examples/python/ckg-zep-example/agent.py
@@ -1,0 +1,188 @@
+"""
+Zep + CKG: Two-layer context agent.
+
+Zep supplies the episodic layer — facts about this specific user
+across past sessions.
+
+CKG (Compact Knowledge Graph) supplies the semantic layer —
+authoritative domain knowledge structured as a typed dependency graph,
+SHA-256 anchored to source documents.
+
+Together they give an agent both personal memory and domain expertise
+without hallucination on either layer.
+
+Architecture:
+    User message
+        ↓
+    [Zep]   thread.get_user_context() → who this user is, what happened before
+        ↓
+    [CKG]   CKGRetriever → what is true about the domain they're asking about
+        ↓
+    [LLM]   synthesize from both context layers
+        ↓
+    [Zep]   thread.add_messages() → store exchange for future sessions
+
+Prerequisites:
+    pip install zep-cloud langchain-ckg langchain-openai langgraph
+
+    Set environment variables:
+        ZEP_API_KEY   — from app.getzep.com
+        OPENAI_API_KEY
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Annotated, TypedDict
+import operator
+
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, StateGraph
+from zep_cloud.client import Zep
+
+from langchain_ckg import CKGRetriever
+
+ZEP_API_KEY = os.environ["ZEP_API_KEY"]
+OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+
+zep = Zep(api_key=ZEP_API_KEY)
+llm = ChatOpenAI(model="gpt-4o-mini", api_key=OPENAI_API_KEY)
+
+
+# ── State ─────────────────────────────────────────────────────────────────────
+
+class AgentState(TypedDict):
+    query: str
+    user_id: str
+    thread_id: str
+    ckg_domain: str
+    episodic_context: str       # from Zep — who/history
+    semantic_context: str       # from CKG — domain knowledge
+    messages: Annotated[list, operator.add]
+    response: str
+
+
+# ── Node: Zep episodic retrieval ───────────────────────────────────────────────
+
+def retrieve_episodic(state: AgentState) -> dict:
+    """Pull user memory from Zep — facts, history, and user summary."""
+    try:
+        user_context = zep.thread.get_user_context(thread_id=state["thread_id"])
+        episodic = user_context.context or ""
+    except Exception as e:
+        # New thread/user has no prior context — treat as empty rather than failing.
+        # Re-raise auth errors so misconfigurations surface immediately.
+        if "auth" in str(e).lower() or "401" in str(e) or "403" in str(e):
+            raise
+        episodic = ""
+    return {"episodic_context": episodic}
+
+
+# ── Node: CKG semantic retrieval ───────────────────────────────────────────────
+
+def retrieve_semantic(state: AgentState) -> dict:
+    """Pull domain knowledge from a CKG — prerequisite + dependent concept graph."""
+    retriever = CKGRetriever(domain=state["ckg_domain"], depth=3)
+    docs = retriever.invoke(state["query"])
+    semantic = "\n\n".join(d.page_content for d in docs)
+    return {"semantic_context": semantic or "No matching domain concepts found."}
+
+
+# ── Node: synthesize ───────────────────────────────────────────────────────────
+
+_SYSTEM = """\
+You are a precise assistant with access to two context layers:
+
+EPISODIC MEMORY (Zep) — facts specific to this user from past sessions.
+Use this to personalize your answer and avoid repeating what the user already knows.
+
+SEMANTIC KNOWLEDGE (CKG) — authoritative domain knowledge, SHA-256 anchored.
+Use this as your ground truth for factual claims. Do not add facts not present here.
+
+Synthesize both layers into a single, accurate response.
+"""
+
+def synthesize(state: AgentState) -> dict:
+    prompt = f"""EPISODIC MEMORY (this user's history):
+{state["episodic_context"] or "No prior context available."}
+
+SEMANTIC KNOWLEDGE (domain graph):
+{state["semantic_context"]}
+
+Question: {state["query"]}"""
+
+    response = llm.invoke([
+        {"role": "system", "content": _SYSTEM},
+        {"role": "user", "content": prompt},
+    ])
+    return {
+        "response": response.content,
+        "messages": [{"role": "assistant", "content": response.content}],
+    }
+
+
+# ── Node: store in Zep ─────────────────────────────────────────────────────────
+
+def store_exchange(state: AgentState) -> dict:
+    """Persist the exchange in Zep so it's available in future sessions."""
+    from zep_cloud.types import Message
+    zep.thread.add_messages(
+        thread_id=state["thread_id"],
+        messages=[
+            Message(role="user", role_type="user", content=state["query"]),
+            Message(role="assistant", role_type="assistant", content=state["response"]),
+        ],
+    )
+    return {}
+
+
+# ── Graph ──────────────────────────────────────────────────────────────────────
+
+def build_graph() -> StateGraph:
+    g = StateGraph(AgentState)
+
+    g.add_node("retrieve_episodic", retrieve_episodic)
+    g.add_node("retrieve_semantic", retrieve_semantic)
+    g.add_node("synthesize", synthesize)
+    g.add_node("store_exchange", store_exchange)
+
+    g.set_entry_point("retrieve_episodic")
+    g.add_edge("retrieve_episodic", "retrieve_semantic")
+    g.add_edge("retrieve_semantic", "synthesize")
+    g.add_edge("synthesize", "store_exchange")
+    g.add_edge("store_exchange", END)
+
+    return g.compile()
+
+
+# ── Example run ────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    agent = build_graph()
+
+    # Ensure the user and thread exist in Zep before running.
+    USER_ID = "user-123"
+    THREAD_ID = "thread-456"
+
+    try:
+        zep.user.get(USER_ID)
+    except Exception:
+        zep.user.add(user_id=USER_ID)
+
+    try:
+        zep.thread.get(THREAD_ID)
+    except Exception:
+        zep.thread.add(thread_id=THREAD_ID, user_id=USER_ID)
+
+    result = agent.invoke({
+        "query": "What are the prerequisites for using NemoClaw kernel fusion?",
+        "user_id": USER_ID,
+        "thread_id": THREAD_ID,
+        "ckg_domain": "nvidia-nemoclaw",   # any of 97 available CKG domains
+        "episodic_context": "",
+        "semantic_context": "",
+        "messages": [],
+        "response": "",
+    })
+
+    print(result["response"])


### PR DESCRIPTION
Been building Compact Knowledge Graphs (CKG) — pre-built domain graphs served over MCP — and kept running into the same gap: Zep handles memory about *the user*, but there's no clean way to bring in authoritative *domain knowledge* alongside it.

This example wires them together in a LangGraph agent. Zep's `thread.get_user_context()` handles the episodic layer (who this user is, what happened before), and CKGRetriever handles the semantic layer (what's actually true about the domain they're asking about). The LLM synthesizes from both, then the exchange is written back to Zep for the next session.

The combination felt worth sharing because neither alone gives you the full picture — Zep knows the user but not the domain; CKG knows the domain but nothing about the user.

97 domains available in CKG (NVIDIA AI, Salesforce AgentForce, NemoClaw, etc.) — swap `ckg_domain` to change what domain knowledge the agent draws from.

`pip install zep-cloud langchain-ckg langchain-openai langgraph`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and sample code only; no production service or core library behavior changes.
> 
> **Overview**
> Adds **`examples/python/ckg-zep-example/`** with a README and runnable **`agent.py`** sample that wires **Zep episodic memory** and **CKG domain retrieval** into one **LangGraph** flow.
> 
> The graph loads user context via **`thread.get_user_context()`**, pulls a concept subgraph with **`CKGRetriever`**, synthesizes with **GPT-4o-mini**, then persists the turn through **`thread.add_messages()`**. The README documents setup, architecture, and swapping **`ckg_domain`** across available CKG domains.
> 
> Episodic retrieval treats missing thread context as empty but still surfaces auth misconfiguration (401/403).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b89e434b6884999704635da81ef8a549cc7101d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->