### PR TITLE
fix(ingestion): resolve Slack authors by real_name, not display_name

### DIFF
--- a/ingestion/CHANGELOG.md
+++ b/ingestion/CHANGELOG.md
@@ -46,6 +46,12 @@ structured data into Context Graphs correctly.
   size, metadata keys, UUIDs, RFC3339 timestamps, SCREAMING_SNAKE fact names, …)
   is checked before the first network call — a bad item is a clear Python error
   naming the field, not an HTTP 400 mid-run.
+- **Canonical Slack names:** speakers, `@mentions`, and DM labels resolve through
+  the export roster preferring `profile.real_name` over `profile.display_name`,
+  so a workspace handle ("morgan") does not split one person from the full name
+  used in other sources ("Morgan Lee"). Authors with no `real_name` are reported
+  in `warnings`, and `SlackMessage.user_id` exposes the raw Slack id so
+  `formatter=` can substitute names from your own directory.
 - **Runnable examples and sample data** for the Slack, document, email,
   JSON-record, thread-backfill, fact-triple, and user-graph paths, built around
   one coherent sample dataset.

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -111,6 +111,26 @@ Blake Carter") instead of the opaque id or slug Slack names their folder with �
 raw ids degrade entity extraction — and every episode carries its
 `conversation_type` in `metadata` for filtering at search time.
 
+**Slack names:** messages store author *ids*, so every speaker, `@mention`, and
+DM label is resolved through the export's `users.json` roster, preferring
+`profile.real_name` over `profile.display_name` (then the username, then the raw
+id). Slack's own precedence is the opposite, but it optimizes for how a name
+reads in a chat client: a display name is often a short handle ("morgan") that
+Zep cannot merge with the same person written in full ("Morgan Lee") in an email
+or document, which silently splits one person into two nodes. Authors whose
+roster entry has no `real_name` are counted in `result.warnings`. When your
+roster is thin, `formatter=` receives each `SlackMessage` — including its raw
+`user_id` — so you can substitute names from your own directory:
+
+```python
+ingest_slack_export(
+    client,
+    "export.zip",
+    graph_id="team_knowledge",
+    formatter=lambda m: f"{DIRECTORY.get(m.user_id, m.sender)}: {m.text}",
+)
+```
+
 **Batch vs sequential:** the Batch API (fast, 50k items/batch) is the default
 high-throughput submission path. `method="auto"` tries batch and transparently
 falls back to sequential `graph.add` calls with rate-limit-aware pacing in

--- a/ingestion/examples/data/slack_export/users.json
+++ b/ingestion/examples/data/slack_export/users.json
@@ -4,7 +4,7 @@
     "name": "avery-brown",
     "profile": {
       "real_name": "Avery Brown",
-      "display_name": ""
+      "display_name": "avery"
     }
   },
   {
@@ -12,7 +12,7 @@
     "name": "blake-carter",
     "profile": {
       "real_name": "Blake Carter",
-      "display_name": ""
+      "display_name": "blake"
     }
   },
   {

--- a/ingestion/src/zep_ingest/loaders/slack.py
+++ b/ingestion/src/zep_ingest/loaders/slack.py
@@ -306,6 +306,9 @@ class SlackExportLoader:
         # of those actually used by ingested content (id -> the name used)
         self._weak_name_ids: frozenset[str] = frozenset()
         self._weak_names: dict[str, str] = {}
+        # weak names seen while parsing one message, promoted to _weak_names only
+        # once that message survives validation (see _resolve)
+        self._pending_weak_names: dict[str, str] = {}
         self._duplicate_ts = 0
         self._invalid_ts = 0
 
@@ -315,6 +318,7 @@ class SlackExportLoader:
         # the previous pass's list would report every warning twice
         self._unresolved_users = set()
         self._weak_names = {}
+        self._pending_weak_names = {}
         self._duplicate_ts = 0
         self._invalid_ts = 0
         self.warnings = []
@@ -563,6 +567,8 @@ class SlackExportLoader:
                     continue
                 seen_ts.add(message.ts)
                 messages.append(message)
+                # accepted, so the names its text carries really do reach the graph
+                self._weak_names.update(self._pending_weak_names)
         messages.sort(key=lambda m: float(m.ts))
         if messages:
             # every episode below carries conversation.label, so the members it
@@ -586,6 +592,10 @@ class SlackExportLoader:
     def _parse(
         self, raw: dict[str, Any], conversation: _Conversation, users: dict[str, str]
     ) -> SlackMessage | None:
+        # @mentions are resolved while normalizing text below, which happens before
+        # this message is known to be usable; buffer what that records so a message
+        # dropped further down does not claim its mentions reached the graph
+        self._pending_weak_names = {}
         if raw.get("subtype") in self.skip_subtypes:
             return None
         # bot_message is the subtype Slack gives an app post; most carry a bot_id
@@ -636,13 +646,21 @@ class SlackExportLoader:
 
     def _resolve(self, user_id: str, users: dict[str, str]) -> str:
         """Map a Slack user ID to a name, recording IDs the roster misses and the
-        names that are not a person's full name."""
+        names that are not a person's full name.
+
+        The two are recorded at different times on purpose, because they claim
+        different things: an unresolved id was "referenced in messages", which
+        holds even for a message this run goes on to drop, while a weak name is
+        reported as "named in ingested content", which does not. Weak names
+        therefore go to a per-message buffer that _load_conversation promotes only
+        once the message is accepted.
+        """
         name = users.get(user_id)
         if name is None:
             self._unresolved_users.add(user_id)
             return user_id
         if user_id in self._weak_name_ids:
-            self._weak_names[user_id] = name
+            self._pending_weak_names[user_id] = name
         return name
 
     def _normalize_text(self, text: str, users: dict[str, str]) -> str:

--- a/ingestion/src/zep_ingest/loaders/slack.py
+++ b/ingestion/src/zep_ingest/loaders/slack.py
@@ -119,6 +119,11 @@ class _Conversation:
     folder: str
     label: str
     kind: ConversationType
+    # roster ids rendered into ``label`` (DMs and group DMs only). The label names
+    # them in every episode without going through _resolve, so they are carried
+    # here and recorded once the conversation is known to be both selected and
+    # non-empty — a skipped conversation must not warn about its members.
+    member_ids: tuple[str, ...] = ()
 
 
 class _DirReader:
@@ -355,7 +360,7 @@ class SlackExportLoader:
         if self._weak_names:
             examples = ", ".join(sorted(self._weak_names.values())[:3])
             self.warnings.append(
-                f"{len(self._weak_names)} Slack user(s) whose content was ingested have "
+                f"{len(self._weak_names)} Slack user(s) named in ingested content have "
                 f"no real_name in the roster, so they are labeled with a display-name "
                 f"handle, a username, or a raw ID instead (e.g. {examples}). Zep merges "
                 "entities by the names it sees, so these may not merge with the same "
@@ -442,9 +447,8 @@ class SlackExportLoader:
                 if folder in seen:
                     continue
                 seen.add(folder)
-                conversations.append(
-                    _Conversation(folder, self._label(entry, folder, kind, users), kind)
-                )
+                label, member_ids = self._label(entry, folder, kind, users)
+                conversations.append(_Conversation(folder, label, kind, member_ids))
         if conversations:
             return conversations
         return self._folder_inventory(reader)
@@ -490,15 +494,19 @@ class SlackExportLoader:
     @staticmethod
     def _label(
         entry: dict[str, Any], folder: str, kind: ConversationType, users: dict[str, str]
-    ) -> str:
+    ) -> tuple[str, tuple[str, ...]]:
         """Channels are labeled by name; DMs and group DMs by their members, since
-        their folders are an opaque id or slug and raw ids degrade extraction."""
+        their folders are an opaque id or slug and raw ids degrade extraction.
+
+        Returns the label and the roster ids it names, so the caller can report a
+        member whose name is only a handle even if they never posted.
+        """
         if kind not in ("dm", "group_dm"):
-            return folder
+            return folder, ()
         members = [m for m in entry.get("members") or [] if isinstance(m, str)]
         if not members:
-            return folder
-        return ", ".join(users.get(member, member) for member in members)
+            return folder, ()
+        return ", ".join(users.get(member, member) for member in members), tuple(members)
 
     def _select(self, inventory: list[_Conversation]) -> list[_Conversation]:
         """conversation_types picks the types; channels= filters by name within them."""
@@ -556,6 +564,10 @@ class SlackExportLoader:
                 seen_ts.add(message.ts)
                 messages.append(message)
         messages.sort(key=lambda m: float(m.ts))
+        if messages:
+            # every episode below carries conversation.label, so the members it
+            # names are now in the graph whether or not they authored anything
+            self._note_label_names(conversation, users)
         if self.grouping == "message":
             for message in messages:
                 yield self._episode([message], conversation)
@@ -613,6 +625,14 @@ class SlackExportLoader:
             conversation_type=conversation.kind,
             user_id=raw.get("user") or None,
         )
+
+    def _note_label_names(self, conversation: _Conversation, users: dict[str, str]) -> None:
+        """Record weak names a DM label puts into the graph. Called only for a
+        selected conversation that yielded episodes, so members of a conversation
+        the run skipped are never reported."""
+        for member in conversation.member_ids:
+            if member in self._weak_name_ids:
+                self._weak_names[member] = users[member]
 
     def _resolve(self, user_id: str, users: dict[str, str]) -> str:
         """Map a Slack user ID to a name, recording IDs the roster misses and the

--- a/ingestion/src/zep_ingest/loaders/slack.py
+++ b/ingestion/src/zep_ingest/loaders/slack.py
@@ -91,6 +91,13 @@ _LINK_LABELED = re.compile(r"<(https?://[^|>]+)\|([^>]+)>")
 _LINK_BARE = re.compile(r"<(https?://[^>]+)>")
 
 
+def _looks_like_handle(name: str) -> bool:
+    """True for a single-token name ("morgan"), which reads as a Slack handle
+    rather than a person. A bare first name fails to merge with the full name
+    just as a handle does, so both are reported."""
+    return not any(character.isspace() for character in name)
+
+
 @dataclass(slots=True)
 class SlackMessage:
     sender: str
@@ -99,6 +106,10 @@ class SlackMessage:
     channel: str  # the readable conversation label: a channel name, or DM members
     thread_ts: str | None = None
     conversation_type: ConversationType = "public_channel"
+    # The raw Slack ID behind ``sender``, so a formatter= can substitute names
+    # from its own directory when the export's roster is thin. None for a bot
+    # post, which Slack writes with a username instead of a user id.
+    user_id: str | None = None
 
 
 @dataclass(slots=True)
@@ -286,6 +297,10 @@ class SlackExportLoader:
         self.formatter = formatter or _default_formatter
         self.warnings: list[str] = []
         self._unresolved_users: set[str] = set()
+        # roster ids whose best name is not a person's full name, and the subset
+        # of those actually used by ingested content (id -> the name used)
+        self._weak_name_ids: frozenset[str] = frozenset()
+        self._weak_names: dict[str, str] = {}
         self._duplicate_ts = 0
         self._invalid_ts = 0
 
@@ -294,11 +309,12 @@ class SlackExportLoader:
         # both reset per pass: a second load() re-derives them, and appending to
         # the previous pass's list would report every warning twice
         self._unresolved_users = set()
+        self._weak_names = {}
         self._duplicate_ts = 0
         self._invalid_ts = 0
         self.warnings = []
         roster = self._read_roster(reader)
-        users = self._user_map(roster)
+        users, self._weak_name_ids = self._user_map(roster)
         inventory = self._inventory(reader, users)
         if roster is None and not inventory:
             raise ConfigurationError(
@@ -336,6 +352,16 @@ class SlackExportLoader:
                 "messages were absent from the roster (typically deactivated, bot, "
                 "or Slack Connect users) and were left as raw IDs."
             )
+        if self._weak_names:
+            examples = ", ".join(sorted(self._weak_names.values())[:3])
+            self.warnings.append(
+                f"{len(self._weak_names)} Slack user(s) whose content was ingested have "
+                f"no real_name in the roster, so they are labeled with a display-name "
+                f"handle, a username, or a raw ID instead (e.g. {examples}). Zep merges "
+                "entities by the names it sees, so these may not merge with the same "
+                "person written in full in another source. Populate real_name in the "
+                "export, or pass formatter= and map SlackMessage.user_id to your own names."
+            )
         if self._invalid_ts:
             self.warnings.append(
                 f"{self._invalid_ts} Slack message(s) had a timestamp that is not a "
@@ -361,17 +387,41 @@ class SlackExportLoader:
         return None
 
     @staticmethod
-    def _user_map(roster: Any) -> dict[str, str]:
+    def _user_map(roster: Any) -> tuple[dict[str, str], frozenset[str]]:
+        """Map each Slack user ID to the best name the roster offers.
+
+        ``real_name`` is preferred over ``display_name``. Zep merges entities by
+        the names it sees in text, and a Slack display name is frequently a short
+        handle ("morgan") that will not merge with the same person written in full
+        ("Morgan Lee") in an email or document, splitting one person into two
+        nodes. Slack's own precedence is the opposite, but it optimizes for how a
+        name reads in a chat client, not for entity resolution.
+
+        Returns the mapping plus the IDs whose name is *not* a person's full name,
+        so the run can warn about the ones it actually used.
+        """
         mapping: dict[str, str] = {}
+        weak: set[str] = set()
         for user in roster or []:
             profile = user.get("profile") or {}
-            mapping[user["id"]] = (
-                profile.get("display_name")
-                or profile.get("real_name")
-                or user.get("name")
-                or user["id"]
-            )
-        return mapping
+            real_name = (profile.get("real_name") or "").strip()
+            display_name = (profile.get("display_name") or "").strip()
+            username = (user.get("name") or "").strip()
+            if real_name:
+                name = real_name
+            elif display_name:
+                name = display_name
+                if _looks_like_handle(display_name):
+                    weak.add(user["id"])
+            elif username:
+                # a username slug ("morgan.lee") is a poor entity name
+                name = username
+                weak.add(user["id"])
+            else:
+                name = user["id"]
+                weak.add(user["id"])
+            mapping[user["id"]] = name
+        return mapping, frozenset(weak)
 
     def _inventory(
         self, reader: _DirReader | _ZipReader, users: dict[str, str]
@@ -561,14 +611,18 @@ class SlackExportLoader:
             channel=conversation.label,
             thread_ts=raw.get("thread_ts"),
             conversation_type=conversation.kind,
+            user_id=raw.get("user") or None,
         )
 
     def _resolve(self, user_id: str, users: dict[str, str]) -> str:
-        """Map a Slack user ID to a display name, recording IDs the roster misses."""
+        """Map a Slack user ID to a name, recording IDs the roster misses and the
+        names that are not a person's full name."""
         name = users.get(user_id)
         if name is None:
             self._unresolved_users.add(user_id)
             return user_id
+        if user_id in self._weak_name_ids:
+            self._weak_names[user_id] = name
         return name
 
     def _normalize_text(self, text: str, users: dict[str, str]) -> str:

--- a/ingestion/tests/fixtures/slack_export/users.json
+++ b/ingestion/tests/fixtures/slack_export/users.json
@@ -3,7 +3,7 @@
     "id": "U001",
     "name": "avery-brown",
     "profile": {
-      "display_name": "Avery Brown",
+      "display_name": "avery",
       "real_name": "Avery Brown"
     }
   },

--- a/ingestion/tests/test_slack_loader.py
+++ b/ingestion/tests/test_slack_loader.py
@@ -565,6 +565,91 @@ class TestWeakNameWarnings:
         assert any("riley" in w for w in loader.warnings if "no real_name" in w)
 
 
+class TestWeakNamesFromSkippedMessages:
+    """@mentions resolve while text is normalized, which happens before a message
+    is known to be usable. A message this run drops must not make the warning
+    claim its mentions were ingested."""
+
+    @staticmethod
+    def export_with(root: Path, messages: list[dict]) -> Path:
+        export = root / "export"
+        (export / "general").mkdir(parents=True)
+        (export / "users.json").write_text(
+            json.dumps(
+                [
+                    {"id": "U1", "name": "morgan", "profile": {"real_name": "Morgan Lee"}},
+                    {"id": "U2", "name": "riley", "profile": {"display_name": "riley"}},
+                ]
+            )
+        )
+        (export / "channels.json").write_text(json.dumps([{"name": "general"}]))
+        (export / "general" / "2024-06-14.json").write_text(json.dumps(messages))
+        return export
+
+    def test_mention_in_a_message_with_an_unusable_ts_is_not_reported(self, tmp_path):
+        export = self.export_with(
+            tmp_path,
+            [
+                {"user": "U1", "text": "ask <@U2>", "ts": "not-a-number"},
+                {"user": "U1", "text": "kept", "ts": "1718355600.000100"},
+            ],
+        )
+        loader = SlackExportLoader(export)
+        [episode] = list(loader.load())
+        assert "riley" not in episode.data
+        assert any("not a number" in w for w in loader.warnings)  # it really was dropped
+        assert not any("no real_name" in w for w in loader.warnings)
+
+    def test_mention_in_a_message_with_an_unusable_thread_ts_is_not_reported(self, tmp_path):
+        export = self.export_with(
+            tmp_path,
+            [
+                {"user": "U1", "text": "ask <@U2>", "ts": "1718355700.1", "thread_ts": "nope"},
+                {"user": "U1", "text": "kept", "ts": "1718355600.000100"},
+            ],
+        )
+        loader = SlackExportLoader(export)
+        list(loader.load())
+        assert not any("no real_name" in w for w in loader.warnings)
+
+    def test_mention_in_a_duplicate_message_is_not_reported(self, tmp_path):
+        """The duplicate drop happens in _load_conversation, after _parse returned."""
+        export = self.export_with(
+            tmp_path,
+            [
+                {"user": "U1", "text": "kept", "ts": "1718355600.000100"},
+                {"user": "U1", "text": "dupe mentioning <@U2>", "ts": "1718355600.000100"},
+            ],
+        )
+        loader = SlackExportLoader(export)
+        list(loader.load())
+        assert any("repeated a timestamp" in w for w in loader.warnings)
+        assert not any("no real_name" in w for w in loader.warnings)
+
+    def test_mention_in_a_kept_message_is_still_reported(self, tmp_path):
+        """The buffer must not swallow the real case."""
+        export = self.export_with(
+            tmp_path, [{"user": "U1", "text": "ask <@U2>", "ts": "1718355600.000100"}]
+        )
+        loader = SlackExportLoader(export)
+        [episode] = list(loader.load())
+        assert "@riley" in episode.data
+        assert any("riley" in w for w in loader.warnings if "no real_name" in w)
+
+    def test_a_dropped_mention_does_not_mask_a_later_kept_one(self, tmp_path):
+        """Buffering is per message, so an earlier drop must not clear a later hit."""
+        export = self.export_with(
+            tmp_path,
+            [
+                {"user": "U1", "text": "dropped <@U2>", "ts": "bad"},
+                {"user": "U1", "text": "kept <@U2>", "ts": "1718355600.000100"},
+            ],
+        )
+        loader = SlackExportLoader(export)
+        list(loader.load())
+        assert any("riley" in w for w in loader.warnings if "no real_name" in w)
+
+
 class TestWeakNamesInDmLabels:
     """A DM label names its members in every episode without going through
     _resolve, so a handle-only member reaches the graph even if they never post."""

--- a/ingestion/tests/test_slack_loader.py
+++ b/ingestion/tests/test_slack_loader.py
@@ -421,11 +421,51 @@ class TestFormatting:
         eps = general(load())
         assert eps[0].data == "Avery Brown (Slack #general, 2024-06-14 09:00 UTC): Hello world"
 
-    def test_display_name_fallbacks(self):
+    def test_real_name_wins_over_a_display_name_handle(self):
+        """U001's display_name is the handle "avery" and real_name is "Avery Brown".
+        Slack's own precedence would pick the handle, which then cannot merge with
+        the same person written in full in an email or document."""
+        eps = general(load())
+        assert "Avery Brown" in eps[0].data
+        assert "avery (" not in eps[0].data
+
+    def test_name_source_fallbacks(self):
         eps = general(load())
         # Blake Carter has empty display_name -> real_name; charlie has neither -> name
         assert "Blake Carter" in eps[1].data
         assert "charlie" in eps[1].data
+
+    def test_display_name_is_used_when_no_real_name_exists(self, tmp_path):
+        export = tmp_path / "export"
+        (export / "general").mkdir(parents=True)
+        (export / "users.json").write_text(
+            json.dumps([{"id": "U1", "name": "mo", "profile": {"display_name": "Morgan Lee"}}])
+        )
+        (export / "channels.json").write_text(json.dumps([{"name": "general"}]))
+        (export / "general" / "2024-06-14.json").write_text(
+            json.dumps([{"type": "message", "user": "U1", "text": "Hi", "ts": "1718355600.000100"}])
+        )
+        loader = SlackExportLoader(export)
+        [episode] = list(loader.load())
+        assert "Morgan Lee" in episode.data
+        # a full name, handle-shaped or not, is not worth warning about
+        assert not any("no real_name" in w for w in loader.warnings)
+
+    def test_user_id_is_exposed_to_a_custom_formatter(self):
+        """The escape hatch for a thin roster: remap the raw Slack id yourself."""
+        directory = {"U001": "Avery Q. Brown", "U002": "Blake Carter", "U003": "Charlie Diaz"}
+        eps = general(load(formatter=lambda m: f"{directory[m.user_id]}: {m.text}"))
+        assert eps[0].data == "Avery Q. Brown: Hello world"
+
+    def test_bot_message_has_no_user_id(self):
+        captured: list[str | None] = []
+
+        def formatter(message):
+            captured.append(message.user_id)
+            return message.text
+
+        load(include_bots=True, formatter=formatter)
+        assert None in captured  # the fixture's bot post carries a username, not an id
 
     def test_markup_normalization(self):
         markup = general(load())[2].data
@@ -438,6 +478,91 @@ class TestFormatting:
     def test_custom_formatter(self):
         eps = general(load(formatter=lambda m: f"{m.sender}: {m.text}"))
         assert eps[0].data == "Avery Brown: Hello world"
+
+
+class TestWeakNameWarnings:
+    def test_warns_when_an_ingested_author_has_no_real_name(self):
+        """charlie (U003) has neither real_name nor display_name, so the label falls
+        back to the username slug — reported because it may not merge."""
+        loader = SlackExportLoader(FIXTURE)
+        list(loader.load())
+        warning = next(w for w in loader.warnings if "no real_name" in w)
+        assert "charlie" in warning
+        assert "SlackMessage.user_id" in warning
+
+    def test_no_warning_when_every_ingested_author_has_a_real_name(self, tmp_path):
+        export = tmp_path / "export"
+        (export / "general").mkdir(parents=True)
+        (export / "users.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "U1",
+                        "name": "mo",
+                        "profile": {"display_name": "mo", "real_name": "Morgan Lee"},
+                    }
+                ]
+            )
+        )
+        (export / "channels.json").write_text(json.dumps([{"name": "general"}]))
+        (export / "general" / "2024-06-14.json").write_text(
+            json.dumps([{"type": "message", "user": "U1", "text": "Hi", "ts": "1718355600.000100"}])
+        )
+        loader = SlackExportLoader(export)
+        list(loader.load())
+        assert not any("no real_name" in w for w in loader.warnings)
+
+    def test_a_weak_name_never_ingested_is_not_reported(self, tmp_path):
+        """The roster lists a handle-only user who posts nowhere we read; warning
+        about them would be noise."""
+        export = tmp_path / "export"
+        (export / "general").mkdir(parents=True)
+        (export / "users.json").write_text(
+            json.dumps(
+                [
+                    {"id": "U1", "profile": {"real_name": "Morgan Lee"}},
+                    {"id": "U2", "name": "ghost", "profile": {}},
+                ]
+            )
+        )
+        (export / "channels.json").write_text(json.dumps([{"name": "general"}]))
+        (export / "general" / "2024-06-14.json").write_text(
+            json.dumps([{"type": "message", "user": "U1", "text": "Hi", "ts": "1718355600.000100"}])
+        )
+        loader = SlackExportLoader(export)
+        list(loader.load())
+        assert not any("no real_name" in w for w in loader.warnings)
+
+    def test_a_handle_in_a_mention_is_reported(self, tmp_path):
+        """@mentions resolve through the same roster, so a handle reaches the graph
+        even when that user never posted."""
+        export = tmp_path / "export"
+        (export / "general").mkdir(parents=True)
+        (export / "users.json").write_text(
+            json.dumps(
+                [
+                    {"id": "U1", "profile": {"real_name": "Morgan Lee"}},
+                    {"id": "U2", "name": "riley", "profile": {"display_name": "riley"}},
+                ]
+            )
+        )
+        (export / "channels.json").write_text(json.dumps([{"name": "general"}]))
+        (export / "general" / "2024-06-14.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "type": "message",
+                        "user": "U1",
+                        "text": "ask <@U2> about it",
+                        "ts": "1718355600.000100",
+                    }
+                ]
+            )
+        )
+        loader = SlackExportLoader(export)
+        [episode] = list(loader.load())
+        assert "@riley" in episode.data
+        assert any("riley" in w for w in loader.warnings if "no real_name" in w)
 
 
 class TestExtractedWrapper:

--- a/ingestion/tests/test_slack_loader.py
+++ b/ingestion/tests/test_slack_loader.py
@@ -565,6 +565,64 @@ class TestWeakNameWarnings:
         assert any("riley" in w for w in loader.warnings if "no real_name" in w)
 
 
+class TestWeakNamesInDmLabels:
+    """A DM label names its members in every episode without going through
+    _resolve, so a handle-only member reaches the graph even if they never post."""
+
+    @staticmethod
+    def dm_export(root: Path) -> Path:
+        export = root / "export"
+        (export / "general").mkdir(parents=True)
+        (export / "D01ABC234").mkdir()
+        (export / "users.json").write_text(
+            json.dumps(
+                [
+                    {"id": "U1", "name": "morgan", "profile": {"real_name": "Morgan Lee"}},
+                    # handle-only, and never authors or is mentioned anywhere
+                    {"id": "U2", "name": "riley", "profile": {"display_name": "riley"}},
+                ]
+            )
+        )
+        (export / "channels.json").write_text(json.dumps([{"name": "general"}]))
+        (export / "dms.json").write_text(json.dumps([{"id": "D01ABC234", "members": ["U1", "U2"]}]))
+        (export / "general" / "2024-06-14.json").write_text(
+            json.dumps(
+                [{"type": "message", "user": "U1", "text": "public", "ts": "1718355600.000100"}]
+            )
+        )
+        (export / "D01ABC234" / "2024-06-14.json").write_text(
+            json.dumps(
+                [{"type": "message", "user": "U1", "text": "dm text", "ts": "1718355700.000100"}]
+            )
+        )
+        return export
+
+    def test_handle_only_dm_member_is_reported(self, tmp_path):
+        loader = SlackExportLoader(self.dm_export(tmp_path), conversation_types=["dm"])
+        [episode] = list(loader.load())
+        # the handle is in the episode text and metadata, so it reaches extraction
+        assert "riley" in episode.data
+        assert "riley" in episode.metadata["channel"]
+        warning = next(w for w in loader.warnings if "no real_name" in w)
+        assert "riley" in warning
+
+    def test_a_skipped_dm_does_not_report_its_members(self, tmp_path):
+        """Default conversation_types excludes DMs; warning about a conversation the
+        run never read would be noise."""
+        loader = SlackExportLoader(self.dm_export(tmp_path))
+        episodes = list(loader.load())
+        assert all("riley" not in e.data for e in episodes)
+        assert not any("no real_name" in w for w in loader.warnings)
+
+    def test_an_empty_selected_dm_does_not_report_its_members(self, tmp_path):
+        """Selected but produced no episodes, so its label reached nothing."""
+        export = self.dm_export(tmp_path)
+        (export / "D01ABC234" / "2024-06-14.json").write_text(json.dumps([]))
+        loader = SlackExportLoader(export, conversation_types=["dm"])
+        assert list(loader.load()) == []
+        assert not any("no real_name" in w for w in loader.warnings)
+
+
 class TestExtractedWrapper:
     """A zip whose export sits in a single wrapper folder is unwrapped; the same
     export extracted to disk has to be too, or a valid export ingests nothing."""


### PR DESCRIPTION
Slack messages store author ids, so speakers, `@mentions`, and DM labels are resolved through the export's `users.json` roster — but that lookup preferred `profile.display_name`, which in a real export is frequently a short handle like "morgan". Zep merges entities by the names it sees in text, so a handle never merges with the same person written in full elsewhere: verified against a live graph, ingesting a handle-based export alongside full-name documents produced both `'morgan'` and `'Morgan Lee'` as `Person` nodes, where it now produces one. This change prefers `real_name` (then `display_name`, then the username, then the raw id), reports ingested authors whose roster entry has no `real_name`, and exposes `SlackMessage.user_id` so `formatter=` can substitute names from a directory of your own when the roster is thin. Both fixtures previously wrote `display_name` so it could never behave like a display name — the example roster left it empty and the test roster put a full name in it — which is why this went unnoticed; they now carry realistic handles, making them a regression guard, so reverting only the loader change fails nine tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all Slack speaker/mention/DM strings are labeled (behavior change for existing exports), but scope is limited to the ingestion loader with broad test coverage and no auth or API surface changes.
> 
> **Overview**
> **Slack export ingestion** now resolves speakers, `@mentions`, and DM member labels from `users.json` with **`profile.real_name` before `display_name`** (then username, then raw id), so short handles like `morgan` do not land in the graph when a full name exists elsewhere.
> 
> The loader adds **`SlackMessage.user_id`** for custom `formatter=` callbacks, and **`result.warnings`** when ingested text actually uses a weak label (no `real_name`, handle-shaped display name, or username)—including DM labels and mentions, but only for messages/conversations that are kept (skipped/duplicate/invalid messages do not inflate warnings). Docs, changelog, example/fixture rosters, and regression tests were updated for realistic handles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1f483c770fa9a1194d922d773222d79fd83cf1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->