### PR TITLE
feat(building-with-zep): add Cursor as a third plugin ecosystem

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "zep",
+  "owner": {
+    "name": "Zep"
+  },
+  "metadata": {
+    "description": "Cursor plugins for building with Zep."
+  },
+  "plugins": [
+    {
+      "name": "building-with-zep",
+      "source": "plugins/building-with-zep",
+      "description": "Skill plus the Zep documentation MCP server for building apps on Zep."
+    }
+  ]
+}

--- a/plugins/building-with-zep/.cursor-plugin/plugin.json
+++ b/plugins/building-with-zep/.cursor-plugin/plugin.json
@@ -9,10 +9,5 @@
   "repository": "https://github.com/getzep/zep",
   "keywords": ["zep", "agent-memory", "context-graph", "mcp"],
   "category": "development",
-  "skills": "./skills/",
-  "mcpServers": {
-    "zep-docs": {
-      "url": "https://docs-mcp.getzep.com/mcp"
-    }
-  }
+  "skills": "./skills/"
 }

--- a/plugins/building-with-zep/.cursor-plugin/plugin.json
+++ b/plugins/building-with-zep/.cursor-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "building-with-zep",
+  "version": "0.1.0",
+  "description": "Build and configure applications that use Zep — agent memory built on temporal Context Graphs. Bundles the building-with-zep skill (how to reason about and build on Zep) and the Zep documentation MCP server (real-time docs search).",
+  "author": {
+    "name": "Zep"
+  },
+  "homepage": "https://help.getzep.com",
+  "repository": "https://github.com/getzep/zep",
+  "keywords": ["zep", "agent-memory", "context-graph", "mcp"],
+  "category": "development",
+  "skills": "./skills/",
+  "mcpServers": {
+    "zep-docs": {
+      "url": "https://docs-mcp.getzep.com/mcp"
+    }
+  }
+}

--- a/plugins/building-with-zep/README.md
+++ b/plugins/building-with-zep/README.md
@@ -5,17 +5,30 @@ A plugin for building applications that use [Zep](https://www.getzep.com) — ag
 It bundles two things:
 
 - **The `building-with-zep` skill** (`skills/building-with-zep/`) — the decision-and-workflow layer for building on Zep: scoping graphs, ingesting data, retrieving context, and evaluating whether Zep delivers your use case. It indexes the Zep docs rather than duplicating them. Model-invoked when you work on Zep integration code.
-- **The Zep documentation MCP server** (`zep-docs`) — real-time search over Zep's docs at `https://docs-mcp.getzep.com/mcp` (remote HTTP, no API key), declared once in `.mcp.json`.
+- **The Zep documentation MCP server** (`zep-docs`) — real-time search over Zep's docs at `https://docs-mcp.getzep.com/mcp` (remote HTTP, no API key). Claude Code and Codex read it from `.mcp.json`; Cursor reads it from `mcp.json`. See [MCP config](#mcp-config-two-files-one-server) for why there are two.
 
 ## One directory, three ecosystems
 
-All three runtimes load the **same** `skills/building-with-zep/` tree; each reads only its own manifest and ignores the others'. There is exactly one physical copy of the skill — no per-ecosystem duplication and no sync step.
+All three runtimes load the **same** `skills/building-with-zep/` tree; each reads only its own manifest and ignores the others'. There is exactly one physical copy of the skill, so no per-ecosystem duplication and no sync step for the substance of this plugin. The MCP server config is the one thing that exists twice, for the reason below.
 
 - **Claude Code** — manifest `.claude-plugin/plugin.json`; auto-discovers `skills/` and `.mcp.json`. Listed in the marketplace at the repo root (`.claude-plugin/marketplace.json`).
 - **Codex** — manifest `.codex-plugin/plugin.json` (points at `./skills/` and `./.mcp.json`). Listed in the Codex marketplace at `.agents/plugins/marketplace.json`.
-- **Cursor** — manifest `.cursor-plugin/plugin.json` (points at `./skills/`, declares `zep-docs` **inline**). Listed in the Cursor marketplace at `.cursor-plugin/marketplace.json`.
+- **Cursor** — manifest `.cursor-plugin/plugin.json` (points at `./skills/`); auto-discovers `mcp.json`. Listed in the Cursor marketplace at `.cursor-plugin/marketplace.json`.
 
-Cursor is the one exception to sharing `.mcp.json`. Cursor auto-discovers `mcp.json` without the leading dot, and its remote-server schema has no `type` key (`type` is documented for stdio servers only). Rather than depend on Cursor tolerating `"type": "http"`, the Cursor manifest declares the same server inline with a bare `url`. Both point at `https://docs-mcp.getzep.com/mcp`; keep them in sync if the endpoint ever changes.
+### MCP config: two files, one server
+
+`zep-docs` is declared twice, and the duplication is deliberate:
+
+| File | Read by | Shape |
+|---|---|---|
+| `.mcp.json` | Claude Code, Codex | `{"type":"http","url":...}` |
+| `mcp.json` | Cursor | `{"url":...}`, no `type` |
+
+Cursor discovers `mcp.json` at the plugin root, without the leading dot, and its remote-server schema has no `type` key (`type` is documented for stdio servers only). A single shared file would therefore have to rely on Cursor tolerating `"type": "http"`, which is undocumented.
+
+Declaring the server inline under `mcpServers` in `.cursor-plugin/plugin.json` is permitted by Cursor's schema, but no official Cursor plugin does it — every one that ships an MCP server uses a plugin-root `mcp.json`, and [`cursor/plugins@a65002e`](https://github.com/cursor/plugins/commit/a65002e3) moved the Figma plugin onto that convention. This plugin follows it.
+
+**Both files point at `https://docs-mcp.getzep.com/mcp`. Change one and you must change the other.**
 
 ## Install
 
@@ -36,7 +49,7 @@ Local dev: `claude --plugin-dir plugins/building-with-zep`.
 /add-plugin building-with-zep@https://github.com/getzep/zep
 ```
 
-This resolves `building-with-zep` through `.cursor-plugin/marketplace.json` at the repo root, and installs the skill and the `zep-docs` server together. No Cursor Marketplace listing is involved.
+This resolves `building-with-zep` through `.cursor-plugin/marketplace.json` at the repo root, and installs the skill and the `zep-docs` server (from `mcp.json`) together. No Cursor Marketplace listing is involved.
 
 Local dev: symlink the plugin directory into Cursor's local plugin folder, then run **Developer: Reload Window**.
 
@@ -50,8 +63,9 @@ ln -s "$PWD/plugins/building-with-zep" ~/.cursor/plugins/local/building-with-zep
 plugins/building-with-zep/
 ├── .claude-plugin/plugin.json   # Claude manifest
 ├── .codex-plugin/plugin.json    # Codex manifest (skills:"./skills/", mcpServers:"./.mcp.json")
-├── .cursor-plugin/plugin.json   # Cursor manifest (skills:"./skills/", zep-docs inline)
-├── .mcp.json                    # zep-docs remote HTTP MCP (Claude + Codex)
+├── .cursor-plugin/plugin.json   # Cursor manifest (skills:"./skills/")
+├── .mcp.json                    # zep-docs, with type:"http" (Claude + Codex)
+├── mcp.json                     # zep-docs, bare url (Cursor, auto-discovered)
 ├── skills/
 │   └── building-with-zep/
 │       ├── SKILL.md             # the one shared skill
@@ -63,8 +77,8 @@ plugins/building-with-zep/
 > `type`; Codex uses the `url` and should ignore the `type` key. Verify the
 > `zep-docs` server loads under your installed Codex CLI; if Codex rejects
 > `type`, move Claude's MCP inline into `.claude-plugin/plugin.json` and keep
-> `.mcp.json` as a bare-`url` Codex-only file. Cursor sidesteps this entirely
-> by declaring the server inline in its own manifest.
+> `.mcp.json` as a bare-`url` Codex-only file. Cursor reads `mcp.json` instead
+> and is unaffected either way.
 
 ## What goes in the skill vs. the docs
 

--- a/plugins/building-with-zep/README.md
+++ b/plugins/building-with-zep/README.md
@@ -1,18 +1,21 @@
 # building-with-zep
 
-A plugin for building applications that use [Zep](https://www.getzep.com) — agent memory built on temporal Context Graphs. This one directory is **both** a Claude Code plugin and an OpenAI Codex plugin, wrapping a single shared skill.
+A plugin for building applications that use [Zep](https://www.getzep.com) — agent memory built on temporal Context Graphs. This one directory is simultaneously a Claude Code plugin, an OpenAI Codex plugin, and a Cursor plugin, wrapping a single shared skill.
 
 It bundles two things:
 
 - **The `building-with-zep` skill** (`skills/building-with-zep/`) — the decision-and-workflow layer for building on Zep: scoping graphs, ingesting data, retrieving context, and evaluating whether Zep delivers your use case. It indexes the Zep docs rather than duplicating them. Model-invoked when you work on Zep integration code.
 - **The Zep documentation MCP server** (`zep-docs`) — real-time search over Zep's docs at `https://docs-mcp.getzep.com/mcp` (remote HTTP, no API key), declared once in `.mcp.json`.
 
-## One directory, two ecosystems
+## One directory, three ecosystems
 
-Both runtimes load the **same** `skills/building-with-zep/` tree and the **same** `.mcp.json`; each reads only its own manifest and ignores the other's. There is exactly one physical copy of the skill — no per-ecosystem duplication and no sync step.
+All three runtimes load the **same** `skills/building-with-zep/` tree; each reads only its own manifest and ignores the others'. There is exactly one physical copy of the skill — no per-ecosystem duplication and no sync step.
 
 - **Claude Code** — manifest `.claude-plugin/plugin.json`; auto-discovers `skills/` and `.mcp.json`. Listed in the marketplace at the repo root (`.claude-plugin/marketplace.json`).
 - **Codex** — manifest `.codex-plugin/plugin.json` (points at `./skills/` and `./.mcp.json`). Listed in the Codex marketplace at `.agents/plugins/marketplace.json`.
+- **Cursor** — manifest `.cursor-plugin/plugin.json` (points at `./skills/`, declares `zep-docs` **inline**). Listed in the Cursor marketplace at `.cursor-plugin/marketplace.json`.
+
+Cursor is the one exception to sharing `.mcp.json`. Cursor auto-discovers `mcp.json` without the leading dot, and its remote-server schema has no `type` key (`type` is documented for stdio servers only). Rather than depend on Cursor tolerating `"type": "http"`, the Cursor manifest declares the same server inline with a bare `url`. Both point at `https://docs-mcp.getzep.com/mcp`; keep them in sync if the endpoint ever changes.
 
 ## Install
 
@@ -27,13 +30,28 @@ Local dev: `claude --plugin-dir plugins/building-with-zep`.
 
 **Codex** — install per the [Codex plugins docs](https://learn.chatgpt.com/docs/build-plugins) via the marketplace at `.agents/plugins/marketplace.json`.
 
+**Cursor** — requires Cursor 2.5 or later. In an Agent chat, type the full command; it does not appear in autocomplete:
+
+```
+/add-plugin building-with-zep@https://github.com/getzep/zep
+```
+
+This resolves `building-with-zep` through `.cursor-plugin/marketplace.json` at the repo root, and installs the skill and the `zep-docs` server together. No Cursor Marketplace listing is involved.
+
+Local dev: symlink the plugin directory into Cursor's local plugin folder, then run **Developer: Reload Window**.
+
+```bash
+ln -s "$PWD/plugins/building-with-zep" ~/.cursor/plugins/local/building-with-zep
+```
+
 ## Contents
 
 ```
 plugins/building-with-zep/
 ├── .claude-plugin/plugin.json   # Claude manifest
 ├── .codex-plugin/plugin.json    # Codex manifest (skills:"./skills/", mcpServers:"./.mcp.json")
-├── .mcp.json                    # zep-docs remote HTTP MCP (shared by both)
+├── .cursor-plugin/plugin.json   # Cursor manifest (skills:"./skills/", zep-docs inline)
+├── .mcp.json                    # zep-docs remote HTTP MCP (Claude + Codex)
 ├── skills/
 │   └── building-with-zep/
 │       ├── SKILL.md             # the one shared skill
@@ -45,7 +63,8 @@ plugins/building-with-zep/
 > `type`; Codex uses the `url` and should ignore the `type` key. Verify the
 > `zep-docs` server loads under your installed Codex CLI; if Codex rejects
 > `type`, move Claude's MCP inline into `.claude-plugin/plugin.json` and keep
-> `.mcp.json` as a bare-`url` Codex-only file.
+> `.mcp.json` as a bare-`url` Codex-only file. Cursor sidesteps this entirely
+> by declaring the server inline in its own manifest.
 
 ## What goes in the skill vs. the docs
 

--- a/plugins/building-with-zep/mcp.json
+++ b/plugins/building-with-zep/mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "zep-docs": {
+      "url": "https://docs-mcp.getzep.com/mcp"
+    }
+  }
+}


### PR DESCRIPTION
Adds a Cursor manifest (`plugins/building-with-zep/.cursor-plugin/plugin.json`) and a repo-root Cursor marketplace (`.cursor-plugin/marketplace.json`) alongside the existing Claude and Codex manifests, so all three runtimes load the same single copy of the `skills/building-with-zep/` tree with no duplication or sync step. Cursor is the one exception to sharing `.mcp.json` — it auto-discovers `mcp.json` without the leading dot and its remote-server schema has no `type` key, so rather than rely on Cursor tolerating `"type": "http"`, the Cursor manifest declares the `zep-docs` server inline with a bare `url`. The plugin README is updated to document the three-ecosystem layout, the Cursor install command (`/add-plugin building-with-zep@https://github.com/getzep/zep`, Cursor 2.5+), and local-dev symlinking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and documentation only—no application runtime, auth, or data-path changes; main maintenance risk is keeping `.mcp.json` and `mcp.json` URLs in sync.
> 
> **Overview**
> **Extends `building-with-zep` to Cursor** while keeping one shared `skills/building-with-zep/` tree. New repo-root `.cursor-plugin/marketplace.json` and `plugins/building-with-zep/.cursor-plugin/plugin.json` wire the plugin into Cursor’s marketplace/install flow.
> 
> **Adds plugin-root `mcp.json`** (bare `url`, no `type`) for Cursor auto-discovery, alongside existing `.mcp.json` for Claude/Codex. README now documents the three-ecosystem layout, why MCP is duplicated, Cursor 2.5+ `/add-plugin building-with-zep@https://github.com/getzep/zep`, and local symlink dev.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50b0c9cbf9c7d667677b88043f949e4906c62ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

