### PR TITLE
Deprecate Zep MCP server README

### DIFF
--- a/mcp/zep-mcp-server/README.md
+++ b/mcp/zep-mcp-server/README.md
@@ -1,4 +1,6 @@
-# Zep MCP Server
+# Zep MCP Server (Deprecated)
+
+> **Deprecated:** This MCP server is no longer maintained. Use the [official Zep Memory MCP server](https://help.getzep.com/memory-mcp-server) instead.
 
 A Model Context Protocol (MCP) server for [Zep Cloud](https://www.getzep.com/), providing read-only access to Zep's temporal knowledge graph and memory features.
 


### PR DESCRIPTION
## Summary

Mark the legacy Zep MCP server README as deprecated and direct users to the official Zep Memory MCP server.

## Validation

- `git diff origin/main... --check`