### PR TITLE
ci(ingestion): add manual package release workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -52,14 +52,13 @@ proxy. For example, ADK version `0.1.0` is consumed with
 
 ### `release-ingestion.yml` — ingestion package releases
 
-Triggered only by a published GitHub Release whose tag matches
-`zep-ingest-v<version>`. The workflow resolves and archives the release event's
-exact commit once, then tests that source on Python 3.11–3.13, builds it, checks
-that `ingestion/pyproject.toml` matches the tag version, and publishes
-`zep-ingest` to PyPI through trusted publishing.
-
-There is no manual arbitrary-ref publishing path. To release version `0.1.0`,
-publish the GitHub Release for tag `zep-ingest-v0.1.0`.
+Triggered only by manual dispatch from `main`. Enter the version from
+`ingestion/pyproject.toml` without the `v` prefix (for example, `0.1.0`). The
+workflow resolves and archives the exact commit once, tests that source on
+Python 3.11–3.13, builds it, and checks that the declared package version
+matches the input. After the `release` environment is approved, it creates the
+`zep-ingest-v<version>` tag and GitHub Release, then publishes `zep-ingest` to
+PyPI through trusted publishing.
 
 ## Setup requirements
 

--- a/.github/workflows/release-ingestion.yml
+++ b/.github/workflows/release-ingestion.yml
@@ -5,8 +5,12 @@
 name: Release Ingestion Package
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version without the v prefix (e.g. 0.1.0)'
+        required: true
+        type: string
 
 concurrency:
   group: release-zep-ingest
@@ -17,12 +21,10 @@ permissions:
 
 jobs:
   resolve-release:
-    # Releases with other tag schemes (integrations, Go modules) also fire the
-    # `release: published` event; skip them cleanly instead of failing.
-    if: startsWith(github.event.release.tag_name, 'zep-ingest-v')
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.release.outputs.sha }}
+      tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -31,21 +33,42 @@ jobs:
           fetch-depth: 1
       - id: release
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Ingestion releases must be dispatched from main (got '$GITHUB_REF')." >&2
+            exit 1
+          fi
+          VERSION="$INPUT_VERSION"
+          RELEASE_TAG="zep-ingest-v$VERSION"
+
           if [[ ! "$RELEASE_TAG" =~ ^zep-ingest-v[0-9]+(\.[0-9]+)*([-.][0-9A-Za-z.-]+)?$ ]]; then
             echo "release tag must match zep-ingest-v<version>" >&2
             exit 1
           fi
-          git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+
           HEAD_SHA="$(git rev-parse HEAD)"
-          TAG_SHA="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
-          if [[ "$TAG_SHA" != "$HEAD_SHA" ]]; then
-            echo "release tag resolves to $TAG_SHA, but the release event resolved to $HEAD_SHA" >&2
+          PACKAGE_VERSION="$(python -c 'import tomllib; print(tomllib.load(open("ingestion/pyproject.toml", "rb"))["project"]["version"])')"
+          if [[ "$PACKAGE_VERSION" != "$VERSION" ]]; then
+            echo "ingestion/pyproject.toml declares '$PACKAGE_VERSION', not '$VERSION'." >&2
             exit 1
           fi
-          echo "sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-          echo "version=${RELEASE_TAG#zep-ingest-v}" >> "$GITHUB_OUTPUT"
+
+          TAG_REF="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG")"
+          if [[ -n "$TAG_REF" ]]; then
+            git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+            TAG_SHA="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
+            if [[ "$TAG_SHA" != "$HEAD_SHA" ]]; then
+              echo "release tag resolves to $TAG_SHA, but the release source is $HEAD_SHA" >&2
+              exit 1
+            fi
+          fi
+
+          {
+            echo "sha=$HEAD_SHA"
+            echo "tag=$RELEASE_TAG"
+            echo "version=$VERSION"
+          } >> "$GITHUB_OUTPUT"
       - name: Archive resolved source
         run: git archive --format=tar "${{ steps.release.outputs.sha }}" > release-source.tar
       - name: Upload resolved source
@@ -128,14 +151,53 @@ jobs:
           path: ingestion/dist/
 
   publish-pypi:
-    needs: [test, build]
+    needs: [resolve-release, test, build]
     runs-on: ubuntu-latest
     permissions:
+      contents: write # required to create the tag and GitHub Release on manual runs
       id-token: write # required for PyPI trusted publishing (OIDC)
     environment:
       name: release
       url: https://pypi.org/p/zep-ingest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.resolve-release.outputs.sha }}
+          fetch-depth: 0
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.resolve-release.outputs.sha }}
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.tag }}
+          VERSION: ${{ needs.resolve-release.outputs.version }}
+        run: |
+          TAG_EXISTS=false
+          TAG_REF="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG")"
+          if [[ -n "$TAG_REF" ]]; then
+            TAG_EXISTS=true
+            git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+            TAG_SHA="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
+            if [[ "$TAG_SHA" != "$RELEASE_SHA" ]]; then
+              echo "Tag '$RELEASE_TAG' already points to $TAG_SHA, not $RELEASE_SHA." >&2
+              exit 1
+            fi
+          fi
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release '$RELEASE_TAG' already exists at the validated commit; continuing."
+          else
+            RELEASE_ARGS=(
+              "$RELEASE_TAG"
+              --title "zep-ingest v$VERSION"
+              --generate-notes
+            )
+            if [[ "$TAG_EXISTS" == "true" ]]; then
+              RELEASE_ARGS+=(--verify-tag)
+            else
+              RELEASE_ARGS+=(--target "$RELEASE_SHA")
+            fi
+            gh release create "${RELEASE_ARGS[@]}"
+          fi
       - name: Download build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:


### PR DESCRIPTION
## Summary

- make `zep-ingest` releases manual-only through `workflow_dispatch`
- require releases to run from `main` and match the version declared in `ingestion/pyproject.toml`
- test and build the exact resolved commit before creating the matching tag and GitHub Release
- publish the validated distribution to PyPI through trusted publishing and document the manual release process

## Why

The ingestion package release workflow previously required a GitHub Release to be published before its validation and publishing jobs could run. A manual workflow provides the same operator-driven release path as the repository's other release automation while preserving exact-source, version, and tag validation.

## Validation

- ran actionlint with ShellCheck and Pyflakes enabled
- exercised valid manual dispatch, wrong-branch rejection, and version-mismatch rejection
- exercised new-tag release creation, existing-release retry, and conflicting-tag rejection paths
- ran `git diff --check`
