### PR TITLE
fix(integrations): bump typed Python package versions

### DIFF
--- a/integrations/adk/python/CHANGELOG.md
+++ b/integrations/adk/python/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.3.1 (2026-07-29)
+
 ### Added
 
 - Added the `py.typed` marker so installed `zep-adk` packages expose their inline type annotations to PEP 561-compatible type checkers.

--- a/integrations/adk/python/pyproject.toml
+++ b/integrations/adk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-adk"
-version = "0.3.0"
+version = "0.3.1"
 description = "Google ADK integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/adk/python/src/zep_adk/__init__.py
+++ b/integrations/adk/python/src/zep_adk/__init__.py
@@ -56,7 +56,7 @@ Usage:
     )
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "Zep AI"
 __description__ = "Google ADK integration for Zep"
 

--- a/integrations/ag2/python/CHANGELOG.md
+++ b/integrations/ag2/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-29
+
 ### Added
 
 - Added the `py.typed` marker so installed `zep-ag2` packages expose their inline type annotations to PEP 561-compatible type checkers.

--- a/integrations/ag2/python/pyproject.toml
+++ b/integrations/ag2/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-ag2"
-version = "0.2.0"
+version = "0.2.1"
 description = "Zep memory integration for AG2 (AutoGen community fork)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/ag2/python/src/zep_ag2/__init__.py
+++ b/integrations/ag2/python/src/zep_ag2/__init__.py
@@ -57,4 +57,4 @@ __all__ = [
     "DEFAULT_CONTEXT_TEMPLATE",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/integrations/ag2/python/tests/test_basic.py
+++ b/integrations/ag2/python/tests/test_basic.py
@@ -121,7 +121,7 @@ class TestImports:
         import zep_ag2
 
         assert hasattr(zep_ag2, "__version__")
-        assert zep_ag2.__version__ == "0.2.0"
+        assert zep_ag2.__version__ == "0.2.1"
 
     def test_all_public_symbols(self) -> None:
         assert ZepMemoryManager is not None

--- a/integrations/autogen/python/CHANGELOG.md
+++ b/integrations/autogen/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-29
+
 ### Added
 
 - Added the `py.typed` marker so installed `zep-autogen` packages expose their inline type annotations to PEP 561-compatible type checkers.

--- a/integrations/autogen/python/pyproject.toml
+++ b/integrations/autogen/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-autogen"
-version = "1.2.0"
+version = "1.2.1"
 description = "Autogen integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/crewai/python/CHANGELOG.md
+++ b/integrations/crewai/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-29
+
 ### Added
 
 - Added the `py.typed` marker so installed `zep-crewai` packages expose their inline type annotations to PEP 561-compatible type checkers.

--- a/integrations/crewai/python/pyproject.toml
+++ b/integrations/crewai/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-crewai"
-version = "1.2.0"
+version = "1.2.1"
 description = "CrewAI integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/crewai/python/src/zep_crewai/__init__.py
+++ b/integrations/crewai/python/src/zep_crewai/__init__.py
@@ -42,7 +42,7 @@ Note:
     Zep into a CrewAI agent's tool list, the supported extension point in 1.x.
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __author__ = "Zep AI"
 __description__ = "Zep integration for CrewAI"
 

--- a/integrations/langgraph/python/CHANGELOG.md
+++ b/integrations/langgraph/python/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.1 (2026-07-29)
+
 ### Added
 
 - Added the `py.typed` marker so installed `zep-langgraph` packages expose their inline type annotations to PEP 561-compatible type checkers.

--- a/integrations/langgraph/python/pyproject.toml
+++ b/integrations/langgraph/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-langgraph"
-version = "0.2.0"
+version = "0.2.1"
 description = "LangGraph integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/langgraph/python/src/zep_langgraph/__init__.py
+++ b/integrations/langgraph/python/src/zep_langgraph/__init__.py
@@ -55,7 +55,7 @@ Quick start (primary path)::
         return {"messages": [response]}
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "Zep AI"
 __description__ = "LangGraph integration for Zep"
 

--- a/integrations/langgraph/python/tests/test_basic.py
+++ b/integrations/langgraph/python/tests/test_basic.py
@@ -38,7 +38,7 @@ class TestPackageStructure:
         import zep_langgraph
 
         assert hasattr(zep_langgraph, "__version__")
-        assert zep_langgraph.__version__ == "0.2.0"
+        assert zep_langgraph.__version__ == "0.2.1"
 
     def test_author_exists(self) -> None:
         import zep_langgraph

--- a/integrations/livekit/python/CHANGELOG.md
+++ b/integrations/livekit/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-07-29
+
 ### Added
 
 - Added the `py.typed` marker so installed `zep-livekit` packages expose their inline type annotations to PEP 561-compatible type checkers.

--- a/integrations/livekit/python/pyproject.toml
+++ b/integrations/livekit/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-livekit"
-version = "0.2.0"
+version = "0.2.1"
 description = "LiveKit integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/livekit/python/src/zep_livekit/__init__.py
+++ b/integrations/livekit/python/src/zep_livekit/__init__.py
@@ -17,7 +17,7 @@ from .exceptions import AgentConfigurationError, ZepLiveKitError
 from .provisioning import UserSetupHook, ensure_thread, ensure_user
 from .tools import create_graph_search_tool
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = [
     "ZepUserAgent",
     "ZepGraphAgent",

--- a/integrations/ms-agent-framework/python/CHANGELOG.md
+++ b/integrations/ms-agent-framework/python/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.1 (2026-07-29)
+
 ### Added
 
 - Added the `py.typed` marker so installed `zep-ms-agent-framework` packages expose their inline type annotations to PEP 561-compatible type checkers.

--- a/integrations/ms-agent-framework/python/pyproject.toml
+++ b/integrations/ms-agent-framework/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-ms-agent-framework"
-version = "0.2.0"
+version = "0.2.1"
 description = "Microsoft Agent Framework integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/ms-agent-framework/python/src/zep_ms_agent_framework/__init__.py
+++ b/integrations/ms-agent-framework/python/src/zep_ms_agent_framework/__init__.py
@@ -42,7 +42,7 @@ Usage::
     print(result.text)
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "Zep AI"
 __description__ = "Microsoft Agent Framework integration for Zep"
 

--- a/integrations/ms-agent-framework/python/tests/test_basic.py
+++ b/integrations/ms-agent-framework/python/tests/test_basic.py
@@ -119,7 +119,7 @@ class TestPackageStructure:
         import zep_ms_agent_framework
 
         assert hasattr(zep_ms_agent_framework, "__version__")
-        assert zep_ms_agent_framework.__version__ == "0.2.0"
+        assert zep_ms_agent_framework.__version__ == "0.2.1"
 
     def test_author_exists(self) -> None:
         import zep_ms_agent_framework

--- a/integrations/pydantic-ai/python/CHANGELOG.md
+++ b/integrations/pydantic-ai/python/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.2.1 (2026-07-29)
+
 ### Added
 
 - Added the `py.typed` marker so installed `zep-pydantic-ai` packages expose their inline type annotations to PEP 561-compatible type checkers.

--- a/integrations/pydantic-ai/python/pyproject.toml
+++ b/integrations/pydantic-ai/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-pydantic-ai"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pydantic AI integration for Zep"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/integrations/pydantic-ai/python/src/zep_pydantic_ai/__init__.py
+++ b/integrations/pydantic-ai/python/src/zep_pydantic_ai/__init__.py
@@ -60,7 +60,7 @@ Usage::
 
 from .exceptions import ZepDependencyError
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "Zep AI"
 __description__ = "Pydantic AI integration for Zep"
 

--- a/integrations/pydantic-ai/python/tests/test_basic.py
+++ b/integrations/pydantic-ai/python/tests/test_basic.py
@@ -32,7 +32,7 @@ class TestPackageMetadata:
         import zep_pydantic_ai
 
         assert hasattr(zep_pydantic_ai, "__version__")
-        assert zep_pydantic_ai.__version__ == "0.2.0"
+        assert zep_pydantic_ai.__version__ == "0.2.1"
 
     def test_author_and_description(self) -> None:
         import zep_pydantic_ai


### PR DESCRIPTION
## Summary

- bump all eight typed Python integration packages to new patch versions
- synchronize exported `__version__` constants and version assertions for the seven packages that expose them
- move each `py.typed` changelog entry into a dated release section

## Why

Eight Python release runs were dispatched with new patch-version inputs, but each package still declared its previously published version in `pyproject.toml`. The builds therefore produced existing filenames and PyPI rejected every upload.

This change makes the intended patch versions the actual package versions so the integrations can be published with their PEP 561 markers, with matching runtime and distribution metadata.

## Validation

- built wheels and sdists for all eight Python packages at their new versions
- ran `twine check` on all sixteen distributions
- verified every wheel and sdist contains a blank `py.typed` marker
- ran all seven basic test suites for packages exporting `__version__` (279 tests passed)
- verified every exported runtime version matches its installed distribution metadata
- confirmed PyPI still reports the previous versions for all eight packages
- ran Ruff checks, Ruff formatting checks, and `git diff --check`
