### PR TITLE
Release building-with-zep plugin v0.2.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -11,8 +11,7 @@
         "source": "local",
         "path": "./plugins/building-with-zep"
       },
-      "description": "Skill plus the Zep documentation MCP server for building apps on Zep.",
-      "version": "0.1.0"
+      "description": "Skill plus the Zep documentation MCP server for building apps on Zep."
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,15 +5,13 @@
     "url": "https://www.getzep.com"
   },
   "metadata": {
-    "description": "Claude Code plugins for building with Zep.",
-    "version": "0.1.0"
+    "description": "Claude Code plugins for building with Zep."
   },
   "plugins": [
     {
       "name": "building-with-zep",
       "source": "./plugins/building-with-zep",
       "description": "Skill plus the Zep documentation MCP server for building apps on Zep.",
-      "version": "0.1.0",
       "category": "development",
       "keywords": ["zep", "agent-memory", "context-graph"]
     }

--- a/.claude/rules/building-with-zep.md
+++ b/.claude/rules/building-with-zep.md
@@ -1,0 +1,126 @@
+---
+paths:
+  - "plugins/building-with-zep/**/*"
+---
+
+# Build with Zep plugin maintainer instructions
+
+These instructions apply to every file under `plugins/building-with-zep/`.
+
+The plugin helps Claude Code, Codex, and Cursor build applications with Zep. For
+installation, usage, supported agents, and an overview, use the canonical
+[Implement Zep with agents](https://help.getzep.com/implement-zep-with-agents)
+documentation.
+
+The maintainer guidance is deliberately repeated in
+`plugins/building-with-zep/AGENTS.md`, `plugins/building-with-zep/README.md`, and
+`.claude/rules/building-with-zep.md` so agents receive it automatically. When
+changing guidance that appears in these files, update all of them and keep them
+consistent.
+
+## Package architecture
+
+This one directory is simultaneously a Claude Code plugin, a Codex plugin, and a
+Cursor plugin. All three runtimes load the same
+`skills/building-with-zep/` tree.
+
+- Do not create ecosystem-specific copies of the skill.
+- Keep the plugin name `building-with-zep` in all three manifests.
+- Keep the three manifest versions identical:
+  - `.claude-plugin/plugin.json`
+  - `.codex-plugin/plugin.json`
+  - `.cursor-plugin/plugin.json`
+- Keep the root marketplace entries free of `version`. Each ecosystem resolves
+  the version from its own plugin manifest.
+- Preserve `.codex-plugin/plugin.json`; it is required for the Codex package.
+- Do not add `CLAUDE.md` at this plugin root. Claude's strict plugin validator
+  rejects it because installed plugins load context from skills, not that file.
+  Keep Claude's maintainer guidance in the repository's path-scoped rule.
+
+The ecosystem-specific files are:
+
+- Claude Code: `.claude-plugin/plugin.json`, `.mcp.json`, and the root
+  `.claude-plugin/marketplace.json`.
+- Codex: `.codex-plugin/plugin.json`, `.mcp.json`, and the root
+  `.agents/plugins/marketplace.json`.
+- Cursor: `.cursor-plugin/plugin.json`, `mcp.json`, and the root
+  `.cursor-plugin/marketplace.json`.
+
+## MCP configuration
+
+The `zep-docs` server is intentionally declared twice:
+
+- `.mcp.json` is read by Claude Code and Codex. Its server entry contains
+  `{"type":"http","url":...}`.
+- `mcp.json` is read by Cursor. Its server entry contains `{"url":...}` without
+  a `type` field.
+
+Both files must point to `https://docs-mcp.getzep.com/mcp`. Whenever one endpoint
+changes, update the other in the same change. Do not consolidate the files unless
+all three ecosystems document a shared compatible schema.
+
+## Releasing
+
+Merging the plugin change to `main` is the release; there is no separate publish
+or tag step.
+
+For loaded plugin content changes:
+
+1. From the repository root, bump all three manifests together:
+
+   ```bash
+   python3 scripts/plugin_manifests.py set <version>
+   ```
+
+2. Add an entry to `CHANGELOG.md`.
+3. Validate the Claude package:
+
+   ```bash
+   claude plugin validate plugins/building-with-zep --strict
+   ```
+
+4. Run the repository plugin-manifest check and confirm the `test-plugins.yml`
+   workflow passes in the pull request.
+
+Changes limited to the maintainer-only `README.md`, `CHANGELOG.md`, or
+`plugins/building-with-zep/AGENTS.md` do not require a version bump. All other
+files under this plugin are treated as loaded plugin content by the CI check. If
+multiple plugin changes are being prepared in the same unreleased branch, one
+semantic version increase covering that release is sufficient.
+
+Do not add a plugin git tag. Nothing consumes one. The repository's package tags
+trigger package-publishing workflows, but this plugin has no tag-based publish
+workflow.
+
+## What goes in the skill versus the docs
+
+The skill is the decision-and-workflow layer, not a second copy of the product
+documentation.
+
+- Put stable, cross-cutting philosophy, decision rules, mental models, and
+  critical invariants in `skills/building-with-zep/SKILL.md`.
+- Leave volatile or exhaustive details to the Zep documentation accessed through
+  `zep-docs`. This includes method names, parameters, limits, pricing, plan
+  availability, exact reranker names, template syntax, and full per-feature
+  checklists.
+- Add a file under `skills/building-with-zep/references/` only when it provides
+  agent-specific value the docs do not serve well, or when a self-contained,
+  versioned fallback is deliberately required and has a maintenance plan.
+- Stable guidance may be duplicated when it must always be in context. Do not
+  duplicate volatile API details without a deliberate reason and maintenance
+  plan.
+
+## Local development
+
+Load the plugin directly in Claude Code:
+
+```bash
+claude --plugin-dir plugins/building-with-zep
+```
+
+For Cursor, symlink the plugin directory into Cursor's local plugin folder, then
+run **Developer: Reload Window**:
+
+```bash
+ln -s "$PWD/plugins/building-with-zep" ~/.cursor/plugins/local/building-with-zep
+```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,7 @@
-# Integration Package Workflows
+# Repository Workflows
 
-GitHub Actions workflows for testing and releasing Zep integration packages.
+GitHub Actions workflows for testing and releasing Zep integration packages, the
+`zep-ingest` package, and the agent plugins under `plugins/`.
 Integrations are organized framework-first, then language: `integrations/<framework>/<language>/`.
 
 ## Workflows
@@ -60,6 +61,44 @@ that `ingestion/pyproject.toml` matches the tag version, and publishes
 
 There is no manual arbitrary-ref publishing path. To release version `0.1.0`,
 publish the GitHub Release for tag `zep-ingest-v0.1.0`.
+
+### `test-plugins.yml` — plugin manifest consistency
+
+Runs on pull requests that touch `plugins/**`, the path-scoped Claude rule, or
+any of the three marketplace manifests — and only there; there is no post-merge
+run.
+`scripts/plugin_manifests.py --check` asserts the two values `building-with-zep` is
+forced to duplicate, because it ships as one directory published into three
+ecosystems (Claude Code, Codex, Cursor):
+
+- **The release version**, in the three ecosystem plugin manifests. Claude Code
+  uses it for update detection, while all three ecosystems expose the same version
+  as the plugin's release and support identity.
+- **The `zep-docs` MCP endpoint**, in `.mcp.json` (Claude, Codex) and `mcp.json`
+  (Cursor).
+
+The check also fails if a `version` appears in any marketplace entry. Each
+ecosystem reads its version from its own `plugin.json`; a marketplace copy is
+redundant and can drift.
+
+A second step verifies that the nested `AGENTS.md` and Claude's path-scoped rule
+contain exactly the same instructions. A third step fails when **the plugin's
+loaded content changes without a semantic version increase** (`README.md`,
+`CHANGELOG.md`, and the maintainer-only `AGENTS.md` are exempt). Without the bump
+check, a PR can change the skill and pass every check while Claude Code keeps
+serving the cached release, which is what happened to #566 and #567 — both
+shipped under `0.1.0`. It diffs against the base branch, so the job checks out
+with `fetch-depth: 0`.
+
+All three steps are **advisory**. Like the other path-filtered test workflows here, this
+is not a required status check: a failure shows as a red check on the pull request
+and does not disable the merge button. It warns the author before merge; it is not a
+gate.
+
+Plugins have no publish step — the marketplace is this git repository, so merging
+to `main` is the release. There is no `release-plugins.yml`. See
+[`plugins/building-with-zep/README.md#releasing`](../../plugins/building-with-zep/README.md#releasing)
+for the release procedure.
 
 ## Setup requirements
 

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -1,0 +1,81 @@
+name: Test Plugins
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/**'
+      - '.claude-plugin/marketplace.json'
+      - '.cursor-plugin/marketplace.json'
+      - '.agents/plugins/marketplace.json'
+      - '.claude/rules/building-with-zep.md'
+      - 'scripts/plugin_manifests.py'
+      - '.github/workflows/test-plugins.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # the bump check diffs against the base branch
+
+      # Parses every plugin and marketplace manifest, then asserts the values that
+      # are necessarily duplicated across the three ecosystems still agree: the
+      # shared release version and the zep-docs MCP endpoint. It also rejects
+      # redundant marketplace versions. Stdlib only — no setup step needed.
+      - name: Check plugin manifests agree
+        run: python3 scripts/plugin_manifests.py --check
+
+      # Codex reads the nested AGENTS.md, while Claude loads the path-scoped rule.
+      # Keep their actual instructions byte-for-byte identical; the first five
+      # lines of the Claude rule are its path-scoping frontmatter.
+      - name: Check agent instructions agree
+        run: tail -n +6 .claude/rules/building-with-zep.md | diff -u plugins/building-with-zep/AGENTS.md -
+
+      # Claude Code uses the explicit version for update detection. Two changes
+      # already shipped under 0.1.0 (#566, #567), so require a semantic version
+      # increase whenever the plugin's loaded content changes. Maintainer-only
+      # Markdown files are exempt because installed plugins do not load them.
+      - name: Require a newer version when plugin content changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          base="origin/${BASE_REF}"
+          manifest=plugins/building-with-zep/.claude-plugin/plugin.json
+
+          changed=$(git diff --name-only "$base"...HEAD -- plugins/building-with-zep/ \
+            ':!plugins/building-with-zep/README.md' \
+            ':!plugins/building-with-zep/CHANGELOG.md' \
+            ':!plugins/building-with-zep/AGENTS.md')
+          if [ -z "$changed" ]; then
+            echo "No change to the plugin's loaded content; no bump required."
+            exit 0
+          fi
+
+          new=$(python3 scripts/plugin_manifests.py version)
+          old=$(git show "$base:$manifest" 2>/dev/null \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version",""))' \
+            || echo "")
+
+          if [ -z "$old" ]; then
+            echo "No version on $base (new plugin?); nothing to compare."
+            exit 0
+          fi
+          if ! python3 scripts/plugin_manifests.py require-newer "$new" "$old"; then
+            echo "::error::Plugin content changed but its semantic version did not increase ($old -> $new)."
+            echo "::error::Claude Code would not deliver this as a newer explicit release."
+            echo "::error::Run: python3 scripts/plugin_manifests.py set <version>"
+            echo "Changed files:"
+            while IFS= read -r file; do
+              echo "  $file"
+            done <<< "$changed"
+            exit 1
+          fi
+          echo "Version increased for:"
+          while IFS= read -r file; do
+            echo "  $file"
+          done <<< "$changed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository instructions
+
+## Build with Zep plugin
+
+Before modifying any file under `plugins/building-with-zep/`, read
+`plugins/building-with-zep/AGENTS.md` in full and follow it. It contains the
+plugin-specific architecture, release, validation, and content-placement rules.

--- a/plugins/building-with-zep/.claude-plugin/plugin.json
+++ b/plugins/building-with-zep/.claude-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "building-with-zep",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Build and configure applications that use Zep — agent memory built on temporal Context Graphs. Bundles the building-with-zep skill (how to reason about and build on Zep) and the Zep documentation MCP server (real-time docs search).",
   "author": {
     "name": "Zep",
     "url": "https://www.getzep.com"
   },
-  "homepage": "https://help.getzep.com",
+  "homepage": "https://help.getzep.com/implement-zep-with-agents",
   "keywords": ["zep", "agent-memory", "context-graph", "mcp"]
 }

--- a/plugins/building-with-zep/.codex-plugin/plugin.json
+++ b/plugins/building-with-zep/.codex-plugin/plugin.json
@@ -1,13 +1,27 @@
 {
   "name": "building-with-zep",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Build and configure applications that use Zep — agent memory built on temporal Context Graphs. Bundles the building-with-zep skill (how to reason about and build on Zep) and the Zep documentation MCP server (real-time docs search).",
   "author": {
     "name": "Zep",
     "url": "https://www.getzep.com"
   },
-  "homepage": "https://help.getzep.com",
+  "homepage": "https://help.getzep.com/implement-zep-with-agents",
   "keywords": ["zep", "agent-memory", "context-graph", "mcp"],
   "skills": "./skills/",
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Build with Zep",
+    "shortDescription": "Build Zep integrations with current docs and best practices.",
+    "longDescription": "Design, build, debug, and evaluate Zep integrations with guided workflows and live documentation access.",
+    "developerName": "Zep",
+    "category": "Productivity",
+    "capabilities": ["Interactive"],
+    "websiteURL": "https://help.getzep.com/implement-zep-with-agents",
+    "defaultPrompt": [
+      "Help me design a Zep integration for my agent.",
+      "Review my Zep integration against current best practices.",
+      "Debug how my agent retrieves context from Zep."
+    ]
+  }
 }

--- a/plugins/building-with-zep/.cursor-plugin/plugin.json
+++ b/plugins/building-with-zep/.cursor-plugin/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "building-with-zep",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Build and configure applications that use Zep — agent memory built on temporal Context Graphs. Bundles the building-with-zep skill (how to reason about and build on Zep) and the Zep documentation MCP server (real-time docs search).",
   "author": {
     "name": "Zep"
   },
-  "homepage": "https://help.getzep.com",
+  "homepage": "https://help.getzep.com/implement-zep-with-agents",
   "repository": "https://github.com/getzep/zep",
   "keywords": ["zep", "agent-memory", "context-graph", "mcp"],
   "category": "development",

--- a/plugins/building-with-zep/AGENTS.md
+++ b/plugins/building-with-zep/AGENTS.md
@@ -1,0 +1,121 @@
+# Build with Zep plugin maintainer instructions
+
+These instructions apply to every file under `plugins/building-with-zep/`.
+
+The plugin helps Claude Code, Codex, and Cursor build applications with Zep. For
+installation, usage, supported agents, and an overview, use the canonical
+[Implement Zep with agents](https://help.getzep.com/implement-zep-with-agents)
+documentation.
+
+The maintainer guidance is deliberately repeated in
+`plugins/building-with-zep/AGENTS.md`, `plugins/building-with-zep/README.md`, and
+`.claude/rules/building-with-zep.md` so agents receive it automatically. When
+changing guidance that appears in these files, update all of them and keep them
+consistent.
+
+## Package architecture
+
+This one directory is simultaneously a Claude Code plugin, a Codex plugin, and a
+Cursor plugin. All three runtimes load the same
+`skills/building-with-zep/` tree.
+
+- Do not create ecosystem-specific copies of the skill.
+- Keep the plugin name `building-with-zep` in all three manifests.
+- Keep the three manifest versions identical:
+  - `.claude-plugin/plugin.json`
+  - `.codex-plugin/plugin.json`
+  - `.cursor-plugin/plugin.json`
+- Keep the root marketplace entries free of `version`. Each ecosystem resolves
+  the version from its own plugin manifest.
+- Preserve `.codex-plugin/plugin.json`; it is required for the Codex package.
+- Do not add `CLAUDE.md` at this plugin root. Claude's strict plugin validator
+  rejects it because installed plugins load context from skills, not that file.
+  Keep Claude's maintainer guidance in the repository's path-scoped rule.
+
+The ecosystem-specific files are:
+
+- Claude Code: `.claude-plugin/plugin.json`, `.mcp.json`, and the root
+  `.claude-plugin/marketplace.json`.
+- Codex: `.codex-plugin/plugin.json`, `.mcp.json`, and the root
+  `.agents/plugins/marketplace.json`.
+- Cursor: `.cursor-plugin/plugin.json`, `mcp.json`, and the root
+  `.cursor-plugin/marketplace.json`.
+
+## MCP configuration
+
+The `zep-docs` server is intentionally declared twice:
+
+- `.mcp.json` is read by Claude Code and Codex. Its server entry contains
+  `{"type":"http","url":...}`.
+- `mcp.json` is read by Cursor. Its server entry contains `{"url":...}` without
+  a `type` field.
+
+Both files must point to `https://docs-mcp.getzep.com/mcp`. Whenever one endpoint
+changes, update the other in the same change. Do not consolidate the files unless
+all three ecosystems document a shared compatible schema.
+
+## Releasing
+
+Merging the plugin change to `main` is the release; there is no separate publish
+or tag step.
+
+For loaded plugin content changes:
+
+1. From the repository root, bump all three manifests together:
+
+   ```bash
+   python3 scripts/plugin_manifests.py set <version>
+   ```
+
+2. Add an entry to `CHANGELOG.md`.
+3. Validate the Claude package:
+
+   ```bash
+   claude plugin validate plugins/building-with-zep --strict
+   ```
+
+4. Run the repository plugin-manifest check and confirm the `test-plugins.yml`
+   workflow passes in the pull request.
+
+Changes limited to the maintainer-only `README.md`, `CHANGELOG.md`, or
+`plugins/building-with-zep/AGENTS.md` do not require a version bump. All other
+files under this plugin are treated as loaded plugin content by the CI check. If
+multiple plugin changes are being prepared in the same unreleased branch, one
+semantic version increase covering that release is sufficient.
+
+Do not add a plugin git tag. Nothing consumes one. The repository's package tags
+trigger package-publishing workflows, but this plugin has no tag-based publish
+workflow.
+
+## What goes in the skill versus the docs
+
+The skill is the decision-and-workflow layer, not a second copy of the product
+documentation.
+
+- Put stable, cross-cutting philosophy, decision rules, mental models, and
+  critical invariants in `skills/building-with-zep/SKILL.md`.
+- Leave volatile or exhaustive details to the Zep documentation accessed through
+  `zep-docs`. This includes method names, parameters, limits, pricing, plan
+  availability, exact reranker names, template syntax, and full per-feature
+  checklists.
+- Add a file under `skills/building-with-zep/references/` only when it provides
+  agent-specific value the docs do not serve well, or when a self-contained,
+  versioned fallback is deliberately required and has a maintenance plan.
+- Stable guidance may be duplicated when it must always be in context. Do not
+  duplicate volatile API details without a deliberate reason and maintenance
+  plan.
+
+## Local development
+
+Load the plugin directly in Claude Code:
+
+```bash
+claude --plugin-dir plugins/building-with-zep
+```
+
+For Cursor, symlink the plugin directory into Cursor's local plugin folder, then
+run **Developer: Reload Window**:
+
+```bash
+ln -s "$PWD/plugins/building-with-zep" ~/.cursor/plugins/local/building-with-zep
+```

--- a/plugins/building-with-zep/CHANGELOG.md
+++ b/plugins/building-with-zep/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable changes to the `building-with-zep` plugin. This file is the only
+release feed the plugin system offers — Claude Code, Codex, and Cursor have no
+changelog plumbing, so users who want to know what a version changed read this.
+
+The version here is the release identity shared by all three ecosystem manifests;
+Claude Code also uses it for update detection. Bump it with
+`python3 scripts/plugin_manifests.py set <version>` from the repo root; see
+[Releasing](README.md#releasing).
+
+## 0.2.0 — 2026-07-30
+
+### Added
+
+- **Cursor as a third ecosystem** ([#581]). The plugin directory now carries a
+  `.cursor-plugin/plugin.json` manifest and a Cursor-shaped `mcp.json`, and the
+  repo root carries a `.cursor-plugin/marketplace.json`. Install with
+  `/add-plugin building-with-zep@https://github.com/getzep/zep` in a Cursor 2.5+
+  Agent chat. All three runtimes load the same `skills/building-with-zep/` tree.
+
+### Changed
+
+- The version now lives in exactly one place per ecosystem, and CI fails on
+  drift. `version` was removed from the `building-with-zep` entries in both
+  `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`: each
+  ecosystem resolves the release from its own `plugin.json`, so marketplace
+  copies are dead weight that can mask a bump. The Claude marketplace manifest's
+  own `metadata.version` was removed for the same reason — nothing consumes it,
+  and it reads as the plugin's version.
+- CI now requires a strictly newer semantic version whenever loaded plugin
+  content changes. The release helper updates all three manifests together and
+  refuses invalid versions or downgrades.
+- All three manifests now link to the canonical plugin documentation, and the
+  Codex manifest includes the interface metadata required by current plugin
+  ingestion.
+
+## 0.1.0 — 2026-06-15
+
+Initial release ([#520]): the `building-with-zep` skill plus the `zep-docs` MCP
+server (`https://docs-mcp.getzep.com/mcp`, remote HTTP, no API key).
+
+Two later changes shipped **under this same `0.1.0` string**, so anyone who
+installed before them never received them and had to reinstall:
+
+- Codex as a second ecosystem, sharing one skill and MCP config ([#566]).
+- Restored skill guidance and the "what goes in the skill vs. the docs"
+  placement rule ([#567]).
+
+That is the failure mode 0.2.0's tooling exists to prevent: Claude Code uses the
+explicit version for update detection, so pushing plugin content without
+increasing it leaves existing Claude Code installs on the old cached release.
+
+[#520]: https://github.com/getzep/zep/pull/520
+[#566]: https://github.com/getzep/zep/pull/566
+[#567]: https://github.com/getzep/zep/pull/567
+[#581]: https://github.com/getzep/zep/pull/581

--- a/plugins/building-with-zep/README.md
+++ b/plugins/building-with-zep/README.md
@@ -1,6 +1,21 @@
-# building-with-zep
+# Build with Zep
 
-A plugin for building applications that use [Zep](https://www.getzep.com) — agent memory built on temporal Context Graphs. This one directory is simultaneously a Claude Code plugin, an OpenAI Codex plugin, and a Cursor plugin, wrapping a single shared skill.
+The Build with Zep plugin helps Claude Code, Codex, and Cursor build applications
+with [Zep](https://www.getzep.com).
+
+## User documentation
+
+For installation, usage, supported agents, and an overview of what the plugin
+does, see [Implement Zep with agents](https://help.getzep.com/implement-zep-with-agents).
+That page is the canonical user-facing documentation for this plugin.
+
+This README contains contributor and maintainer information that belongs beside
+the plugin source.
+
+## What this directory contains
+
+This one directory is simultaneously a Claude Code plugin, an OpenAI Codex
+plugin, and a Cursor plugin, wrapping a single shared skill.
 
 It bundles two things:
 
@@ -30,33 +45,6 @@ Declaring the server inline under `mcpServers` in `.cursor-plugin/plugin.json` i
 
 **Both files point at `https://docs-mcp.getzep.com/mcp`. Change one and you must change the other.**
 
-## Install
-
-**Claude Code** — this repo's root is a marketplace named `zep`:
-
-```bash
-/plugin marketplace add getzep/zep
-/plugin install building-with-zep@zep
-```
-
-Local dev: `claude --plugin-dir plugins/building-with-zep`.
-
-**Codex** — install per the [Codex plugins docs](https://learn.chatgpt.com/docs/build-plugins) via the marketplace at `.agents/plugins/marketplace.json`.
-
-**Cursor** — requires Cursor 2.5 or later. In an Agent chat, type the full command; it does not appear in autocomplete:
-
-```
-/add-plugin building-with-zep@https://github.com/getzep/zep
-```
-
-This resolves `building-with-zep` through `.cursor-plugin/marketplace.json` at the repo root, and installs the skill and the `zep-docs` server (from `mcp.json`) together. No Cursor Marketplace listing is involved.
-
-Local dev: symlink the plugin directory into Cursor's local plugin folder, then run **Developer: Reload Window**.
-
-```bash
-ln -s "$PWD/plugins/building-with-zep" ~/.cursor/plugins/local/building-with-zep
-```
-
 ## Contents
 
 ```
@@ -70,8 +58,22 @@ plugins/building-with-zep/
 │   └── building-with-zep/
 │       ├── SKILL.md             # the one shared skill
 │       └── references/          # empty initially
+├── AGENTS.md                    # scoped maintainer instructions for coding agents
+├── CHANGELOG.md
 └── README.md
 ```
+
+Maintainer tooling lives at `scripts/plugin_manifests.py` in the repo root, not here:
+this directory is copied wholesale into every user's plugin cache.
+
+`AGENTS.md` deliberately repeats the maintainer guidance in this README so coding
+agents receive it without another file read. The repository-root `AGENTS.md`
+directs Codex agents launched from the workspace root to load these scoped
+instructions before changing the plugin. Claude Code receives the same guidance
+from the path-scoped `.claude/rules/building-with-zep.md` file at the repository
+root. It lives outside the plugin because Claude's strict plugin validator rejects
+a plugin-root `CLAUDE.md`: installed plugins load agent context from skills, not
+from that file.
 
 > MCP note: `.mcp.json` uses `{"type":"http","url":...}`. Claude requires the
 > `type`; Codex uses the `url` and should ignore the `type` key. Verify the
@@ -79,6 +81,94 @@ plugins/building-with-zep/
 > `type`, move Claude's MCP inline into `.claude-plugin/plugin.json` and keep
 > `.mcp.json` as a bare-`url` Codex-only file. Cursor reads `mcp.json` instead
 > and is unaffected either way.
+
+## Local development
+
+Load the plugin directly in Claude Code:
+
+```bash
+claude --plugin-dir plugins/building-with-zep
+```
+
+For Cursor, symlink the plugin directory into Cursor's local plugin folder, then
+run **Developer: Reload Window**:
+
+```bash
+ln -s "$PWD/plugins/building-with-zep" ~/.cursor/plugins/local/building-with-zep
+```
+
+## Releasing
+
+The marketplace *is* this git repository, so there is no publish step — merging to
+`main` is the release. For Claude Code, the explicit `version` decides whether
+users actually **receive** a new cached copy. Pushing plugin changes without
+increasing it leaves Claude Code users on the old release, including users with
+auto-update enabled. Two changes already shipped under the same `0.1.0` string
+this way ([CHANGELOG.md](CHANGELOG.md)).
+
+`version` lives in the three ecosystem plugin manifests, and one command bumps
+all of them:
+
+```bash
+python3 scripts/plugin_manifests.py set 0.3.0
+```
+
+| File | Read by |
+|---|---|
+| `.claude-plugin/plugin.json` | Claude Code |
+| `.codex-plugin/plugin.json` | Codex |
+| `.cursor-plugin/plugin.json` | Cursor |
+
+The root marketplace entries deliberately declare **no** `version`: each ecosystem
+resolves it from its own `plugin.json`, so a second copy is dead weight that can
+mask a real bump. [`test-plugins.yml`](../../.github/workflows/test-plugins.yml)
+fails if one reappears, if the three managed versions drift apart, or if the two MCP
+configs stop agreeing on the `zep-docs` endpoint. It also fails when a PR changes
+loaded plugin content without a **semantic version increase**, except `README.md`,
+`CHANGELOG.md`, and the maintainer-only `AGENTS.md`. The workflow also verifies
+that `AGENTS.md` and Claude's path-scoped copy contain identical instructions.
+
+That check is **advisory, not required** — a failure shows as a red check on the pull
+request but leaves the merge button enabled. Forgetting step 1 warns you before you
+merge; it does not stop you.
+
+Full procedure:
+
+1. `python3 scripts/plugin_manifests.py set <version>`, from the repo root
+2. Add a [CHANGELOG.md](CHANGELOG.md) entry — no ecosystem has changelog plumbing,
+   so this file is the only release note users get
+3. `claude plugin validate plugins/building-with-zep --strict`
+4. Open the PR; `test-plugins.yml` re-checks agreement and flags a missing increase
+
+Merging step 4 is the release. There is no step 5.
+
+Plugins are deliberately **not tagged**, unlike everything else released from this
+repo. The `zep-ingest-v<version>` and `zep-<framework>-<language>-v<version>` schemes
+are functional: publishing a GitHub Release for one of those tags is what fires the
+PyPI upload, and CI checks the tag against the package metadata before publishing.
+Plugins have no publish workflow for a tag to trigger, so one would be a marker
+nothing reads. `claude plugin tag` would create `building-with-zep--v<version>`, and
+nothing would consume it. If a plugin ever declares a semver-range dependency on this
+one, tag the historical release commits at that point — `git tag` works retroactively
+on any commit.
+
+### Why explicit semver rather than commit SHAs
+
+Omitting `version` everywhere makes Claude Code fall back to the git commit SHA, so
+every merge reaches users with no bump to remember. Tempting, and wrong here:
+
+- **The source is a relative path inside a monorepo.** The SHA that resolves is this
+  repository's, not the plugin directory's, so commits to `ingestion/`,
+  `integrations/`, or the eval harness would each register as a new plugin version —
+  re-downloading the plugin and prompting `/reload-plugins` for changes that touched
+  nothing the user has.
+- **Only Claude Code documents the fallback.** Cursor lists `version` as optional but
+  documents no SHA behavior, and Codex documents neither, so dropping it would leave a
+  split release model across the three ecosystems.
+- **Semver is a support handle.** "Which version are you on?" stays answerable.
+
+The cost is a bump that must not be forgotten — which is what the script and the CI
+check exist to enforce.
 
 ## What goes in the skill vs. the docs
 

--- a/scripts/plugin_manifests.py
+++ b/scripts/plugin_manifests.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Keep the building-with-zep plugin's duplicated manifest values in agreement.
+
+One plugin directory is published into three ecosystems, which forces two values
+to exist in more than one file:
+
+- **The version**, in three files — one plugin manifest per ecosystem. Claude
+  Code uses it for update detection; all three ecosystems expose the same release
+  identity to users and maintainers.
+- **The zep-docs MCP URL**, in two — `.mcp.json` (Claude, Codex) and `mcp.json`
+  (Cursor) declare the same server in two different shapes, so moving the
+  endpoint means editing both.
+
+No ecosystem's validator catches drift in either value, hence this script.
+
+    python3 scripts/plugin_manifests.py --check     # assert agreement (CI)
+    python3 scripts/plugin_manifests.py set 0.3.0   # bump the version everywhere
+    python3 scripts/plugin_manifests.py version     # print the current version
+    python3 scripts/plugin_manifests.py require-newer 0.3.0 0.2.0
+
+It lives outside plugins/ on purpose: a plugin directory is copied wholesale
+into every user's plugin cache, and maintainer tooling has no business there.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_NAME = "building-with-zep"
+
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?"
+    r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+# Every managed file holds exactly one "version" key, which lets the rewrite be a
+# scoped text substitution that preserves the file's existing formatting.
+VERSION_KEY_RE = re.compile(r'("version"\s*:\s*")([^"]*)(")')
+
+# (path, kind, label). kind "manifest" reads the top-level version; kind "entry"
+# reads the version of the PLUGIN_NAME entry in a marketplace's plugins array.
+VERSION_SITES: list[tuple[str, str, str]] = [
+    ("plugins/building-with-zep/.claude-plugin/plugin.json", "manifest", "Claude plugin manifest"),
+    ("plugins/building-with-zep/.codex-plugin/plugin.json", "manifest", "Codex plugin manifest"),
+    ("plugins/building-with-zep/.cursor-plugin/plugin.json", "manifest", "Cursor plugin manifest"),
+]
+
+# Places a version must never appear. Each ecosystem resolves the release version
+# from its plugin.json; a second marketplace value is redundant and can drift.
+FORBIDDEN_SITES: list[tuple[str, str, str]] = [
+    (
+        ".claude-plugin/marketplace.json",
+        "entry",
+        "Claude Code always prefers plugin.json's version, so a value here is dead weight "
+        "that can mask a real bump",
+    ),
+    (
+        ".claude-plugin/marketplace.json",
+        "metadata",
+        "the marketplace manifest's own version is a legacy field nothing consumes, and it "
+        "reads as the plugin's version",
+    ),
+    (
+        ".agents/plugins/marketplace.json",
+        "entry",
+        "Codex resolves the version from .codex-plugin/plugin.json, so a second value "
+        "can only drift",
+    ),
+    (
+        ".cursor-plugin/marketplace.json",
+        "entry",
+        "Cursor resolves the version from .cursor-plugin/plugin.json, so a second value "
+        "can only drift",
+    ),
+]
+
+# The zep-docs endpoint, declared once per MCP config shape. See the README's
+# "MCP config: two files, one server" for why the shapes differ.
+MCP_SITES: list[tuple[str, str]] = [
+    ("plugins/building-with-zep/.mcp.json", "Claude + Codex (.mcp.json)"),
+    ("plugins/building-with-zep/mcp.json", "Cursor (mcp.json)"),
+]
+MCP_SERVER_NAME = "zep-docs"
+
+
+class SiteError(Exception):
+    """A manifest is missing, unparseable, or not shaped the way this script expects."""
+
+
+def parse_semver(version: str) -> tuple[tuple[int, int, int], tuple[str, ...] | None]:
+    """Parse a strict SemVer string into the parts that determine precedence."""
+    match = SEMVER_RE.fullmatch(version)
+    if match is None:
+        raise ValueError(f"'{version}' is not a semantic version (MAJOR.MINOR.PATCH)")
+    core = tuple(int(match.group(index)) for index in (1, 2, 3))
+    prerelease = match.group(4)
+    return core, tuple(prerelease.split(".")) if prerelease is not None else None
+
+
+def compare_semver(left: str, right: str) -> int:
+    """Return -1, 0, or 1 according to SemVer precedence (build metadata ignored)."""
+    left_core, left_pre = parse_semver(left)
+    right_core, right_pre = parse_semver(right)
+    if left_core != right_core:
+        return 1 if left_core > right_core else -1
+    if left_pre is None or right_pre is None:
+        if left_pre is right_pre:
+            return 0
+        return 1 if left_pre is None else -1
+
+    for left_part, right_part in zip(left_pre, right_pre):
+        if left_part == right_part:
+            continue
+        left_numeric = left_part.isdigit()
+        right_numeric = right_part.isdigit()
+        if left_numeric and right_numeric:
+            return 1 if int(left_part) > int(right_part) else -1
+        if left_numeric != right_numeric:
+            return -1 if left_numeric else 1
+        return 1 if left_part > right_part else -1
+    if len(left_pre) == len(right_pre):
+        return 0
+    return 1 if len(left_pre) > len(right_pre) else -1
+
+
+def _load(rel_path: str) -> tuple[Path, str, object]:
+    path = REPO_ROOT / rel_path
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        raise SiteError(f"{rel_path}: cannot read ({exc})") from exc
+    try:
+        return path, text, json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise SiteError(f"{rel_path}: invalid JSON ({exc})") from exc
+
+
+def _entry(rel_path: str, data: object) -> dict:
+    plugins = data.get("plugins") if isinstance(data, dict) else None
+    if not isinstance(plugins, list):
+        raise SiteError(f"{rel_path}: expected a top-level 'plugins' array")
+    for entry in plugins:
+        if isinstance(entry, dict) and entry.get("name") == PLUGIN_NAME:
+            return entry
+    raise SiteError(f"{rel_path}: no plugins entry named '{PLUGIN_NAME}'")
+
+
+def read_version(rel_path: str, kind: str) -> str:
+    """Return the version declared at a site, or raise if it declares none."""
+    _, _, data = _load(rel_path)
+    holder = data if kind == "manifest" else _entry(rel_path, data)
+    version = holder.get("version") if isinstance(holder, dict) else None
+    if not isinstance(version, str) or not version:
+        raise SiteError(f"{rel_path}: no version declared ({kind})")
+    return version
+
+
+def find_version(rel_path: str, kind: str) -> str | None:
+    """Return the version declared at a site, or None. Used for forbidden sites."""
+    _, _, data = _load(rel_path)
+    if kind == "metadata":
+        holder = data.get("metadata") if isinstance(data, dict) else None
+    elif kind == "manifest":
+        holder = data
+    else:
+        try:
+            holder = _entry(rel_path, data)
+        except SiteError:
+            return None
+    if not isinstance(holder, dict):
+        return None
+    version = holder.get("version")
+    return version if isinstance(version, str) else None
+
+
+def read_mcp_url(rel_path: str) -> str:
+    """Return the MCP_SERVER_NAME url declared in an MCP config file."""
+    _, _, data = _load(rel_path)
+    servers = data.get("mcpServers") if isinstance(data, dict) else None
+    if not isinstance(servers, dict):
+        raise SiteError(f"{rel_path}: expected a top-level 'mcpServers' object")
+    server = servers.get(MCP_SERVER_NAME)
+    if not isinstance(server, dict):
+        raise SiteError(f"{rel_path}: no '{MCP_SERVER_NAME}' server declared")
+    url = server.get("url")
+    if not isinstance(url, str) or not url:
+        raise SiteError(f"{rel_path}: '{MCP_SERVER_NAME}' declares no url")
+    return url
+
+
+def check() -> int:
+    """Report the managed values; fail on drift, a missing site, or a stray version."""
+    problems: list[str] = []
+    versions: dict[str, str] = {}
+    urls: dict[str, str] = {}
+
+    for rel_path, kind, label in VERSION_SITES:
+        try:
+            versions[label] = read_version(rel_path, kind)
+        except SiteError as exc:
+            problems.append(str(exc))
+    for rel_path, label in MCP_SITES:
+        try:
+            urls[label] = read_mcp_url(rel_path)
+        except SiteError as exc:
+            problems.append(str(exc))
+
+    print("version")
+    for label, version in versions.items():
+        print(f"  {version:<12} {label}")
+    print(f"{MCP_SERVER_NAME} url")
+    for label, url in urls.items():
+        print(f"  {url}  {label}")
+
+    distinct = set(versions.values())
+    if len(distinct) > 1:
+        problems.append(
+            "version drift across manifests: "
+            + ", ".join(f"{label}={v}" for label, v in sorted(versions.items()))
+            + " — choose the intended release and run: "
+            "python3 scripts/plugin_manifests.py set <version>"
+        )
+    for version in distinct:
+        try:
+            parse_semver(version)
+        except ValueError as exc:
+            problems.append(str(exc))
+
+    if len(set(urls.values())) > 1:
+        problems.append(
+            f"'{MCP_SERVER_NAME}' points at different endpoints: "
+            + ", ".join(f"{label}={u}" for label, u in sorted(urls.items()))
+            + " — both MCP configs must name the same server"
+        )
+
+    for rel_path, kind, why in FORBIDDEN_SITES:
+        try:
+            stray = find_version(rel_path, kind)
+        except SiteError as exc:
+            problems.append(str(exc))
+            continue
+        if stray is not None:
+            problems.append(f"{rel_path}: remove the {kind} 'version' ({stray}) — {why}")
+
+    if problems:
+        sys.stdout.flush()
+        print("\nFAIL", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    print(
+        f"\nOK — {len(versions)} manifests agree on {distinct.pop()}, "
+        f"{len(urls)} MCP configs agree on one endpoint"
+    )
+    return 0
+
+
+def set_version(new_version: str) -> int:
+    """Rewrite every managed site to new_version, preserving each file's formatting."""
+    try:
+        parse_semver(new_version)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    pending: list[tuple[Path, str, str, str]] = []
+    problems: list[str] = []
+
+    # Resolve every edit before writing anything, so a bad manifest can't leave
+    # the tree half-bumped.
+    for rel_path, kind, label in VERSION_SITES:
+        try:
+            path, text, data = _load(rel_path)
+            holder = data if kind == "manifest" else _entry(rel_path, data)
+            old = holder.get("version") if isinstance(holder, dict) else None
+            if not isinstance(old, str) or not old:
+                raise SiteError(f"{rel_path}: no version declared ({kind})")
+            try:
+                direction = compare_semver(new_version, old)
+            except ValueError as exc:
+                raise SiteError(f"{rel_path}: {exc}") from exc
+            if direction < 0:
+                raise SiteError(
+                    f"{rel_path}: refusing to decrease the version from {old} to {new_version}"
+                )
+
+            matches = VERSION_KEY_RE.findall(text)
+            if len(matches) != 1:
+                raise SiteError(
+                    f"{rel_path}: found {len(matches)} 'version' keys, expected exactly 1 — "
+                    "this script rewrites the only one in the file; generalize it before "
+                    "adding another"
+                )
+
+            new_text = VERSION_KEY_RE.sub(
+                lambda m: f"{m.group(1)}{new_version}{m.group(3)}", text, count=1
+            )
+            written = json.loads(new_text)
+            landed = (
+                written if kind == "manifest" else _entry(rel_path, written)
+            ).get("version")
+            if landed != new_version:
+                raise SiteError(f"{rel_path}: rewrite landed on {landed!r}, not {new_version!r}")
+
+            pending.append((path, label, old, new_text))
+        except SiteError as exc:
+            problems.append(str(exc))
+
+    if problems:
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        print("\nnothing written", file=sys.stderr)
+        return 1
+
+    for path, label, old, new_text in pending:
+        if old == new_version:
+            print(f"  unchanged  {new_version:<12} {label}")
+            continue
+        path.write_text(new_text)
+        print(f"  {old} -> {new_version:<8} {label}")
+
+    print(f"\nBumped {PLUGIN_NAME} to {new_version}. Next:")
+    print("  1. add a CHANGELOG.md entry describing what users get")
+    print("  2. claude plugin validate plugins/building-with-zep --strict")
+    print("  3. open the PR — merging it is the release; plugins are not tagged")
+    return 0
+
+
+def require_newer(new_version: str, old_version: str) -> int:
+    """Fail unless new_version has strictly greater SemVer precedence."""
+    try:
+        direction = compare_semver(new_version, old_version)
+    except ValueError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    if direction <= 0:
+        print(
+            f"{new_version} is not newer than {old_version}; "
+            "plugin releases must increase the semantic version",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"{old_version} -> {new_version}")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv[1:] == ["--check"]:
+        return check()
+    if len(argv) == 3 and argv[1] == "set":
+        return set_version(argv[2])
+    if argv[1:] == ["version"]:
+        # Bare version on stdout, for scripting. VERSION_SITES[0] is canonical;
+        # --check is what proves the others match it.
+        rel_path, kind, _ = VERSION_SITES[0]
+        try:
+            print(read_version(rel_path, kind))
+        except SiteError as exc:
+            print(exc, file=sys.stderr)
+            return 1
+        return 0
+    if len(argv) == 4 and argv[1] == "require-newer":
+        return require_newer(argv[2], argv[3])
+    print(__doc__, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary
- Release `building-with-zep` v0.2.0 across Claude Code, Codex, and Cursor, remove redundant marketplace versions, add required Codex interface metadata, and point all manifests to the canonical documentation.
- Add a changelog and refocus the README on maintainer architecture, local development, content placement, and the release process.
- Add scoped Claude and Codex maintainer instructions with CI enforcement that keeps their duplicated guidance synchronized.
- Add manifest tooling and an advisory PR workflow that enforce matching versions and MCP endpoints and require a semantic-version increase for loaded plugin changes.

## Validation
- `claude plugin validate plugins/building-with-zep --strict`
- Codex plugin validator
- `python3 scripts/plugin_manifests.py --check`
- Semantic-version, instruction-sync, workflow-YAML, and `origin/main` bump checks
