### PR TITLE
feat(eval-harness): default retrieval to auto search

### DIFF
--- a/zep-eval-harness/.claude/commands/zep-eval-harness/SKILL.md
+++ b/zep-eval-harness/.claude/commands/zep-eval-harness/SKILL.md
@@ -40,7 +40,7 @@ Metrics are calculated in aggregate, per-category (based on test case `category`
 
 ### Context Block: Auto Search
 
-The evaluation script retrieves context via `build_context_block()` in `config/evaluation_config/retrieval_strategy.py`. The default strategy uses `scope="auto"` with `MAX_CHARACTERS = 10000`, and prepends the user-node summary (fetched separately — auto search does not include it).
+The evaluation script retrieves context via `build_context_block()` in `config/evaluation_config/retrieval_strategy.py`. The default strategy uses `scope="auto"` with `MAX_CHARACTERS = 10000`, and prepends the user-node summary (fetched once per user via `fetch_user_summary` — auto search does not include it).
 
 Auto search packs relevant edges (facts), nodes (entities), episodes, observations, and thread summaries into a pre-assembled context string. ``limit`` and ``reranker`` do not apply under auto — volume is controlled by the character budget.
 

--- a/zep-eval-harness/.claude/commands/zep-eval-harness/SKILL.md
+++ b/zep-eval-harness/.claude/commands/zep-eval-harness/SKILL.md
@@ -15,7 +15,7 @@ The pipeline has four steps:
 
 ### Scope: Single-Shot Retrieval
 
-**The harness evaluates single-shot retrieval only.** Every test case issues one fixed batch of scoped searches from the raw test question (nodes + edges, optionally episodes, across the user graph and any document graph), then hands the resulting context block to the response model in a single turn — no second retrieval round, no query reformulation. This mirrors deterministic/programmatic retrieval, not the tool-based pattern where an agent is handed Zep search tools (e.g. `search_graph` from the Zep MCP server) and decides when and what to search.
+**The harness evaluates single-shot retrieval only.** Every test case issues one retrieval from the raw test question via auto search (`config/evaluation_config/retrieval_strategy.py`), then hands the resulting context block to the response model in a single turn — no second retrieval round, no query reformulation. This mirrors deterministic/programmatic retrieval, not the tool-based pattern where an agent is handed Zep search tools (e.g. `search_graph` from the Zep MCP server) and decides when and what to search.
 
 That makes the harness a clean instrument for the ingestion and search configuration, but it says nothing about agent tool-use behavior. A tool-based agent may do better (several targeted searches, reformulating after a weak result) or worse (never searching, poorly phrased queries, running out of turns). When reporting results, scope conclusions to the config under test and never present them as a prediction of production agent performance.
 
@@ -28,7 +28,7 @@ That makes the harness a clean instrument for the ingestion and search configura
 
 This is the metric that matters most. It directly measures Zep's retrieval quality — whether the knowledge graph and search surface the right facts, entities, and relationships.
 
-When completeness is low, the key diagnostic question is: **does the graph contain the right information but search failed to retrieve it, or is the information missing from the graph entirely?** Use `zep_graph_inspect.py` to examine what's actually in the graph. If the information is there but not retrieved, the issue is search configuration (limits, reranker, query phrasing). If the information is absent from the graph, the issue is upstream — ingestion, ontology, or custom instructions need adjustment.
+When completeness is low, the key diagnostic question is: **does the graph contain the right information but search failed to retrieve it, or is the information missing from the graph entirely?** Use `zep_graph_inspect.py` to examine what's actually in the graph. If the information is there but not retrieved, the issue is retrieval strategy (auto-search character budget, query phrasing). If the information is absent from the graph, the issue is upstream — ingestion, ontology, or custom instructions need adjustment.
 
 **Answer Accuracy (SECONDARY)** — Did the LLM produce a correct answer from the retrieved context?
 - **CORRECT**: Answer conveys the same key information as the golden answer
@@ -38,15 +38,13 @@ This measures whether the response model uses the context well. It depends on th
 
 Metrics are calculated in aggregate, per-category (based on test case `category` field), and per-user.
 
-### Context Block: Edges vs Nodes vs Episodes
+### Context Block: Auto Search
 
-The evaluation script constructs a context block from graph search results. Understanding what each component contributes:
+The evaluation script retrieves context via `build_context_block()` in `config/evaluation_config/retrieval_strategy.py`. The default strategy uses `scope="auto"` with `MAX_CHARACTERS = 10000`, and prepends the user-node summary (fetched separately — auto search does not include it).
 
-- **Edges (facts)**: Relationships extracted by Zep between entities — e.g., "Sarah WORKS_FOR TechCorp", "Biscuit IS_OWNED_BY Sarah". These are the primary source of structured knowledge. Controlled by `USER_FACTS_LIMIT` / `DOC_FACTS_LIMIT`.
-- **Nodes (entities)**: Entity summaries — e.g., a Person node with name, relationship type, and a description synthesized from all conversations mentioning them. Controlled by `USER_ENTITIES_LIMIT` / `DOC_ENTITIES_LIMIT`.
-- **Episodes (raw data)**: The original messages, document chunks, or JSON data that was ingested. These provide verbatim source text but are bulkier. Disabled by default (`*_EPISODES_LIMIT = 0`). Enable by setting limits > 0 in `config/evaluation_config/constants.py`.
+Auto search packs relevant edges (facts), nodes (entities), episodes, observations, and thread summaries into a pre-assembled context string. ``limit`` and ``reranker`` do not apply under auto — volume is controlled by the character budget.
 
-Most evaluations work best with edges + nodes (structured, concise). Enable episodes when verbatim source text is needed for answering questions that require exact quotes or details not captured in the graph extraction.
+To change retrieval (e.g. manual multi-scope searches with per-type limits and a reranker), edit `build_context_block` in that module. That function is the source of truth for the strategy.
 
 All commands run from `zep-eval-harness/` using `uv run`. Depending on the user's request, either run the scripts directly or provide the terminal commands for the user.
 
@@ -76,7 +74,8 @@ config/
 ├── document_chunking_config/
 │   └── constants.py                    # CHUNK_SIZE, CHUNK_OVERLAP, LLM_CONTEXTUALIZATION_MODEL
 └── evaluation_config/
-    ├── constants.py                    # Search limits, LLM_RESPONSE_MODEL, LLM_JUDGE_MODEL
+    ├── constants.py                    # LLM_RESPONSE_MODEL, LLM_JUDGE_MODEL
+    ├── retrieval_strategy.py           # build_context_block() — retrieval + context assembly
     └── response_prompt.py              # get_response_system_prompt() — AI persona for eval
 ```
 

--- a/zep-eval-harness/README.md
+++ b/zep-eval-harness/README.md
@@ -174,20 +174,20 @@ Rate limits are handled automatically — if you hit limits, the retry backoff w
 
 ### Pipeline Steps (automated in zep_evaluate.py)
 
-1. **Search**: Query Zep's knowledge graph (nodes, edges) using cross-encoder reranker
+1. **Search**: Query Zep's knowledge graph with ``scope="auto"`` (character-budgeted context block)
 2. **Evaluate Context**: Assess whether retrieved context contains sufficient information (PRIMARY METRIC)
 3. **Generate Response**: Use LLM with retrieved context to answer questions
 4. **Grade Answer**: Evaluate answers against golden answers using LLM judge (SECONDARY METRIC)
 
 ### Scope: Single-Shot Retrieval
 
-**This harness evaluates single-shot retrieval only.** Each test case issues one fixed batch of searches — the raw test question against nodes and edges (plus episodes if enabled), across the user graph and any document graph, all in parallel — assembles the results into a context block, and hands it to the response model in a single turn. There is no second retrieval round and no query reformulation. That mirrors *deterministic/programmatic* retrieval, where your application searches on every turn and injects the context itself.
+**This harness evaluates single-shot retrieval only.** Each test case issues one retrieval — the raw test question via auto search on the user graph (and any document graph), using the strategy in `config/evaluation_config/retrieval_strategy.py` — and hands the resulting context block to the response model in a single turn. There is no second retrieval round and no query reformulation. That mirrors *deterministic/programmatic* retrieval, where your application searches on every turn and injects the context itself.
 
 Production agents are frequently built the other way: Zep is exposed to the model as **tools** — for example `search_graph` from the [Zep MCP server](../mcp/zep-mcp-server/), or your own tool definitions — and the LLM decides when to search, how to phrase each query, and whether to search again after seeing results.
 
 Read the scores accordingly:
 
-- **What they measure**: whether your ingestion and search configuration (ontology, custom instructions, chunking, search limits, reranker) puts the right facts within reach of one well-formed query. Pinning retrieval to a single deterministic search is what keeps runs comparable — the config stays the only variable.
+- **What they measure**: whether your ingestion and retrieval strategy (ontology, custom instructions, chunking, auto-search character budget) puts the right facts within reach of one well-formed query. Pinning retrieval to a single deterministic search is what keeps runs comparable — the config stays the only variable.
 - **What they do not measure**: agent behavior. A tool-based agent can beat these numbers by issuing several targeted searches and reformulating after a weak result, or fall short of them by not searching at all, phrasing a query poorly, or running out of turns. Tool choice, query formulation, and multi-turn dynamics are untested here.
 
 If your production path exposes Zep through tools, treat a strong result here as a prerequisite rather than a verdict, and evaluate the agent end-to-end as well. See [Evaluate Zep for your use case](https://help.getzep.com/evaluate-zep-for-your-use-case).
@@ -210,11 +210,12 @@ config/
 ├── document_chunking_config/
 │   └── constants.py                          # CHUNK_SIZE, CHUNK_OVERLAP, LLM_CONTEXTUALIZATION_MODEL
 └── evaluation_config/
-    ├── constants.py                          # Search limits, LLM_RESPONSE_MODEL, LLM_JUDGE_MODEL
+    ├── constants.py                          # LLM_RESPONSE_MODEL, LLM_JUDGE_MODEL
+    ├── retrieval_strategy.py                 # build_context_block() — retrieval + context assembly
     └── response_prompt.py                    # get_response_system_prompt() — the system prompt for AI responses
 ```
 
-Each script imports only from its relevant config subfolder. The response prompt used during evaluation is defined in `config/evaluation_config/response_prompt.py` and can be customized independently from the evaluation logic.
+Each script imports only from its relevant config subfolder. The response prompt used during evaluation is defined in `config/evaluation_config/response_prompt.py` and can be customized independently from the evaluation logic. Retrieval behavior lives entirely in `retrieval_strategy.py`.
 
 ## Run Tracking
 
@@ -390,15 +391,16 @@ To add more users:
 
 ## Advanced Evaluation
 
-### Tune Zep Search Parameters
+### Tune Zep Retrieval Strategy
 
-The evaluation script uses `cross_encoder` reranker by default for best accuracy. Search parameters and LLM models are configured in `config/evaluation_config/constants.py`:
-- `USER_FACTS_LIMIT = 20`: Number of facts (edges) from user graph
-- `USER_ENTITIES_LIMIT = 10`: Number of entities (nodes) from user graph
-- `USER_EPISODES_LIMIT = 0`: User episodes disabled by default (set >0 to enable)
-- `DOC_FACTS_LIMIT = 10`: Number of facts from document graph
-- `DOC_ENTITIES_LIMIT = 5`: Number of entities from document graph
-- `DOC_EPISODES_LIMIT = 0`: Document episodes disabled by default
+Retrieval is defined by a single module: `config/evaluation_config/retrieval_strategy.py`. Its `build_context_block()` function is the source of truth — edit that function (and the constants it uses) to change how context is retrieved and assembled.
+
+Default strategy:
+- `SCOPE = "auto"`: Zep packs edges, nodes, episodes, observations, and thread summaries into a pre-assembled context string
+- `MAX_CHARACTERS = 10000`: character budget for auto search (``limit`` and ``reranker`` do not apply under auto)
+- User-node summary is fetched via `user.get_node()` and prepended (auto search does not include it)
+
+LLM models remain in `config/evaluation_config/constants.py`:
 - `LLM_RESPONSE_MODEL`: Model for generating responses
 - `LLM_JUDGE_MODEL`: Model for grading answers
 
@@ -407,20 +409,15 @@ Chunking-specific constants are in `config/document_chunking_config/constants.py
 - `CHUNK_OVERLAP`: Characters of overlap between consecutive chunks (default: 100)
 - `LLM_CONTEXTUALIZATION_MODEL`: Model for document chunk contextualization
 
-You can experiment with different rerankers by modifying the `reranker` parameter in `perform_graph_search()`:
-- `cross_encoder`: Best accuracy, slower (default)
-- `rrf`: Reciprocal Rank Fusion, balanced
-- `mmr`: Maximal Marginal Relevance, diversity-focused
-
-For guidance, check out the [Searching the Graph documentation](https://help.getzep.com/searching-the-graph).
+For guidance, check out the [Searching the Graph documentation](https://help.getzep.com/searching-the-graph) (including Auto Search).
 
 ### Customize Response Prompt
 
 The system prompt used when generating AI responses during evaluation is defined in `config/evaluation_config/response_prompt.py`. Edit the `get_response_system_prompt()` function to customize the AI's persona, response style, or instructions for your use case. This is snapshotted into each evaluation run for reproducibility.
 
-### Customize Context Block
+### Customize Context Block / Retrieval
 
-The harness constructs a custom context block from graph search results. You can modify the `construct_context_block()` function in `zep_evaluate.py` to format results differently. See the [Customize Your Context Block documentation](https://help.getzep.com/cookbook/customize-your-context-block) for best practices.
+Change retrieval by editing `build_context_block()` in `config/evaluation_config/retrieval_strategy.py`. For example, you can switch to manual multi-scope searches with per-type limits and a chosen reranker, or adjust the auto-search character budget. See the [Customize Your Context Block documentation](https://help.getzep.com/cookbook/customize-your-context-block) and [Searching the Graph](https://help.getzep.com/searching-the-graph) for best practices.
 
 ### Add JSON/Text Data
 
@@ -485,12 +482,9 @@ Results are saved to `runs/evaluations/{run_number}_{timestamp}/results.json` wi
     "document_run": { "run_number": 1, "run_dir": "runs/documents/1_20260331T222500", "graph_id": "zep_eval_shared_documents_1d4d9a28" }
   },
   "search_configuration": {
-    "user_facts_limit": 20,
-    "user_entities_limit": 10,
-    "user_episodes_limit": 0,
-    "doc_facts_limit": 10,
-    "doc_entities_limit": 5,
-    "doc_episodes_limit": 0
+    "strategy": "auto_search",
+    "scope": "auto",
+    "max_characters": 10000
   },
   "model_configuration": {
     "response_model": "gemini-2.5-flash-lite",

--- a/zep-eval-harness/README.md
+++ b/zep-eval-harness/README.md
@@ -398,7 +398,7 @@ Retrieval is defined by a single module: `config/evaluation_config/retrieval_str
 Default strategy:
 - `SCOPE = "auto"`: Zep packs edges, nodes, episodes, observations, and thread summaries into a pre-assembled context string
 - `MAX_CHARACTERS = 10000`: character budget for auto search (``limit`` and ``reranker`` do not apply under auto)
-- User-node summary is fetched via `user.get_node()` and prepended (auto search does not include it)
+- User-node summary is fetched once per user via `fetch_user_summary()` and prepended (auto search does not include it)
 
 LLM models remain in `config/evaluation_config/constants.py`:
 - `LLM_RESPONSE_MODEL`: Model for generating responses

--- a/zep-eval-harness/config/evaluation_config/constants.py
+++ b/zep-eval-harness/config/evaluation_config/constants.py
@@ -1,13 +1,3 @@
-# Search configuration — user graphs
-USER_FACTS_LIMIT = 20  # Number of facts (edges) to return
-USER_ENTITIES_LIMIT = 10  # Number of entities (nodes) to return
-USER_EPISODES_LIMIT = 0  # Number of episodes to return (when enabled)
-
-# Search configuration — standalone document graph
-DOC_FACTS_LIMIT = 10  # Number of facts (edges) to return
-DOC_ENTITIES_LIMIT = 5  # Number of entities (nodes) to return
-DOC_EPISODES_LIMIT = 0  # Number of episodes to return (when enabled)
-
 # LLM models for evaluation
 LLM_RESPONSE_MODEL = "gemini-3-flash-preview"  # Model used for generating responses
 LLM_JUDGE_MODEL = "gemini-3-flash-preview"  # Model used for grading responses

--- a/zep-eval-harness/config/evaluation_config/retrieval_strategy.py
+++ b/zep-eval-harness/config/evaluation_config/retrieval_strategy.py
@@ -1,0 +1,123 @@
+"""
+Retrieval strategy for evaluation context blocks.
+
+This module is the source of truth for how the harness retrieves and assembles
+context. Edit ``build_context_block`` (and the constants it closes over) to
+change search behavior — there is no separate per-scope limit/reranker config.
+
+Default: ``scope="auto"`` with a 10k character budget. Auto search packs edges,
+nodes, episodes, observations, and thread summaries into a pre-assembled
+``result.context`` string. ``limit`` and ``reranker`` do not apply under auto.
+The user-node summary is fetched separately and prepended (auto search does
+not include it).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from retry import retry_with_backoff
+
+if TYPE_CHECKING:
+    from zep_cloud.client import AsyncZep
+
+STRATEGY_NAME = "auto_search"
+SCOPE = "auto"
+MAX_CHARACTERS = 10_000
+
+
+def get_search_configuration() -> dict:
+    """Snapshot of the active retrieval strategy for evaluation result files."""
+    return {
+        "strategy": STRATEGY_NAME,
+        "scope": SCOPE,
+        "max_characters": MAX_CHARACTERS,
+    }
+
+
+async def _fetch_user_summary(zep_client: AsyncZep, user_id: str) -> str | None:
+    """Fetch the user-node summary, or None if unavailable."""
+    try:
+        user_node_response = await retry_with_backoff(
+            zep_client.user.get_node,
+            user_id=user_id,
+            description=f"get user node [{user_id}]",
+        )
+        node = getattr(user_node_response, "node", None)
+        summary = getattr(node, "summary", None) if node else None
+        if summary and str(summary).strip():
+            return str(summary).strip()
+    except Exception as e:
+        print(f"  Could not retrieve user summary for [{user_id}]: {e}")
+    return None
+
+
+async def build_context_block(
+    zep_client: AsyncZep,
+    *,
+    user_id: str,
+    query: str,
+    doc_graph_id: str | None = None,
+) -> str:
+    """
+    Retrieve a context block for ``query`` using the configured strategy.
+
+    Fetches the user-node summary, runs auto search on the user graph, and
+    optionally auto-searches a standalone document graph in parallel. Assembles
+    summary + Zep's materialized ``context`` string(s).
+    """
+    print(f"Searching [{user_id}]: '{query}' (scope={SCOPE}, max_characters={MAX_CHARACTERS})")
+
+    summary_task = _fetch_user_summary(zep_client, user_id)
+    user_task = retry_with_backoff(
+        zep_client.graph.search,
+        user_id=user_id,
+        query=query,
+        scope=SCOPE,
+        max_characters=MAX_CHARACTERS,
+        description=f"auto search user [{user_id}]",
+    )
+
+    if doc_graph_id:
+        doc_task = retry_with_backoff(
+            zep_client.graph.search,
+            graph_id=doc_graph_id,
+            query=query,
+            scope=SCOPE,
+            max_characters=MAX_CHARACTERS,
+            description=f"auto search doc [{doc_graph_id}]",
+        )
+        user_summary, user_result, doc_result = await asyncio.gather(
+            summary_task, user_task, doc_task
+        )
+    else:
+        user_summary, user_result = await asyncio.gather(summary_task, user_task)
+        doc_result = None
+
+    parts: list[str] = []
+
+    if user_summary:
+        parts.append(
+            "# High-level summary of the user\n"
+            "<USER_SUMMARY>\n"
+            f"{user_summary}\n"
+            "</USER_SUMMARY>"
+        )
+
+    user_context = getattr(user_result, "context", None) or ""
+    if user_context.strip():
+        parts.append(user_context.strip())
+
+    if doc_result is not None:
+        doc_context = getattr(doc_result, "context", None) or ""
+        if doc_context.strip():
+            parts.append(
+                "The following context is from shared reference documents.\n\n"
+                + doc_context.strip()
+            )
+
+    if not parts:
+        return "No relevant context found."
+
+    return "\n\n".join(parts)

--- a/zep-eval-harness/config/evaluation_config/retrieval_strategy.py
+++ b/zep-eval-harness/config/evaluation_config/retrieval_strategy.py
@@ -8,8 +8,8 @@ change search behavior — there is no separate per-scope limit/reranker config.
 Default: ``scope="auto"`` with a 10k character budget. Auto search packs edges,
 nodes, episodes, observations, and thread summaries into a pre-assembled
 ``result.context`` string. ``limit`` and ``reranker`` do not apply under auto.
-The user-node summary is fetched separately and prepended (auto search does
-not include it).
+The user-node summary is fetched separately (once per user by the eval loop)
+and prepended — auto search does not include it.
 """
 
 from __future__ import annotations
@@ -36,8 +36,12 @@ def get_search_configuration() -> dict:
     }
 
 
-async def _fetch_user_summary(zep_client: AsyncZep, user_id: str) -> str | None:
-    """Fetch the user-node summary, or None if unavailable."""
+async def fetch_user_summary(zep_client: AsyncZep, user_id: str) -> str | None:
+    """Fetch the user-node summary, or None if unavailable.
+
+    Call once per user and pass the result into ``build_context_block`` so
+    concurrent queries do not repeat ``user.get_node``.
+    """
     try:
         user_node_response = await retry_with_backoff(
             zep_client.user.get_node,
@@ -59,17 +63,17 @@ async def build_context_block(
     user_id: str,
     query: str,
     doc_graph_id: str | None = None,
+    user_summary: str | None = None,
 ) -> str:
     """
     Retrieve a context block for ``query`` using the configured strategy.
 
-    Fetches the user-node summary, runs auto search on the user graph, and
-    optionally auto-searches a standalone document graph in parallel. Assembles
-    summary + Zep's materialized ``context`` string(s).
+    Runs auto search on the user graph, and optionally on a standalone document
+    graph in parallel. Prepends ``user_summary`` when provided (fetch it once
+    per user via ``fetch_user_summary``).
     """
     print(f"Searching [{user_id}]: '{query}' (scope={SCOPE}, max_characters={MAX_CHARACTERS})")
 
-    summary_task = _fetch_user_summary(zep_client, user_id)
     user_task = retry_with_backoff(
         zep_client.graph.search,
         user_id=user_id,
@@ -88,11 +92,9 @@ async def build_context_block(
             max_characters=MAX_CHARACTERS,
             description=f"auto search doc [{doc_graph_id}]",
         )
-        user_summary, user_result, doc_result = await asyncio.gather(
-            summary_task, user_task, doc_task
-        )
+        user_result, doc_result = await asyncio.gather(user_task, doc_task)
     else:
-        user_summary, user_result = await asyncio.gather(summary_task, user_task)
+        user_result = await user_task
         doc_result = None
 
     parts: list[str] = []

--- a/zep-eval-harness/zep_evaluate.py
+++ b/zep-eval-harness/zep_evaluate.py
@@ -23,16 +23,14 @@ from zep_cloud.client import AsyncZep
 
 from config.constants import GEMINI_BASE_URL
 from config.evaluation_config.constants import (
-    DOC_ENTITIES_LIMIT,
-    DOC_EPISODES_LIMIT,
-    DOC_FACTS_LIMIT,
     LLM_JUDGE_MODEL,
     LLM_RESPONSE_MODEL,
-    USER_ENTITIES_LIMIT,
-    USER_EPISODES_LIMIT,
-    USER_FACTS_LIMIT,
 )
 from config.evaluation_config.response_prompt import get_response_system_prompt
+from config.evaluation_config.retrieval_strategy import (
+    build_context_block,
+    get_search_configuration,
+)
 from retry import retry_with_backoff
 
 
@@ -173,279 +171,9 @@ async def load_all_test_cases() -> Dict[str, List[Dict[str, Any]]]:
 
 
 # ============================================================================
-# Step 2: Graph Search
+# Step 2: Graph Search / Context Retrieval
 # ============================================================================
-
-
-async def perform_graph_search(
-    zep_client: AsyncZep,
-    user_id: str,
-    query: str,
-    include_episodes: bool = False,
-    doc_graph_id: str | None = None,
-) -> Dict[str, Any]:
-    """
-    Perform parallel graph search across the user graph and optionally a
-    standalone document graph. All searches run concurrently.
-
-    Args:
-        zep_client: AsyncZep client instance
-        user_id: User ID for user graph search
-        query: Search query string
-        include_episodes: Whether to search episodes (default: False)
-        doc_graph_id: If provided, also search this standalone graph
-
-    Returns:
-        Dictionary containing search results for all scopes
-    """
-    print(f"Searching [{user_id}]: '{query}'")
-
-    # Build all search tasks for maximum parallelism
-    tasks: dict[str, Any] = {}
-
-    # User graph searches
-    tasks["user_nodes"] = retry_with_backoff(
-        zep_client.graph.search,
-        user_id=user_id,
-        query=query,
-        scope="nodes",
-        limit=USER_ENTITIES_LIMIT,
-        reranker="cross_encoder",
-        description=f"search user nodes [{user_id}]",
-    )
-    tasks["user_edges"] = retry_with_backoff(
-        zep_client.graph.search,
-        user_id=user_id,
-        query=query,
-        scope="edges",
-        limit=USER_FACTS_LIMIT,
-        reranker="cross_encoder",
-        description=f"search user edges [{user_id}]",
-    )
-    if include_episodes:
-        tasks["user_episodes"] = retry_with_backoff(
-            zep_client.graph.search,
-            user_id=user_id,
-            query=query,
-            scope="episodes",
-            limit=USER_EPISODES_LIMIT,
-            reranker="cross_encoder",
-            description=f"search user episodes [{user_id}]",
-        )
-
-    # Standalone document graph searches (if enabled)
-    if doc_graph_id:
-        tasks["doc_nodes"] = retry_with_backoff(
-            zep_client.graph.search,
-            graph_id=doc_graph_id,
-            query=query,
-            scope="nodes",
-            limit=DOC_ENTITIES_LIMIT,
-            reranker="cross_encoder",
-            description=f"search doc nodes [{doc_graph_id}]",
-        )
-        tasks["doc_edges"] = retry_with_backoff(
-            zep_client.graph.search,
-            graph_id=doc_graph_id,
-            query=query,
-            scope="edges",
-            limit=DOC_FACTS_LIMIT,
-            reranker="cross_encoder",
-            description=f"search doc edges [{doc_graph_id}]",
-        )
-        if include_episodes:
-            tasks["doc_episodes"] = retry_with_backoff(
-                zep_client.graph.search,
-                graph_id=doc_graph_id,
-                query=query,
-                scope="episodes",
-                limit=DOC_EPISODES_LIMIT,
-                reranker="cross_encoder",
-                description=f"search doc episodes [{doc_graph_id}]",
-            )
-
-    # Execute all searches in parallel
-    keys = list(tasks.keys())
-    results_list = await asyncio.gather(*tasks.values())
-    results = dict(zip(keys, results_list))
-
-    return {
-        # User graph results
-        "nodes": results["user_nodes"],
-        "edges": results["user_edges"],
-        "episodes": results.get("user_episodes"),
-        # Document graph results (None if not searched)
-        "doc_nodes": results.get("doc_nodes"),
-        "doc_edges": results.get("doc_edges"),
-        "doc_episodes": results.get("doc_episodes"),
-    }
-
-
-def _format_edges(edges) -> list[str]:
-    """Format a list of edge results into context lines."""
-    parts = []
-    if edges:
-        for edge in edges:
-            fact = getattr(edge, "fact", "No fact available")
-            valid_at = getattr(edge, "valid_at", None)
-            invalid_at = getattr(edge, "invalid_at", None)
-            labels = getattr(edge, "labels", None)
-            attributes = getattr(edge, "attributes", None)
-
-            valid_at_str = valid_at if valid_at else "unknown"
-            invalid_at_str = invalid_at if invalid_at else "present"
-
-            parts.append(
-                f"{fact} (Date range: {valid_at_str} - {invalid_at_str})"
-            )
-
-            if labels and len(labels) > 0:
-                parts.append(f"  Labels: {', '.join(labels)}")
-
-            if attributes and isinstance(attributes, dict) and len(attributes) > 0:
-                parts.append(f"  Attributes:")
-                for attr_name, attr_value in attributes.items():
-                    parts.append(f"    {attr_name}: {attr_value}")
-
-            parts.append("")
-    else:
-        parts.append("No relevant facts found")
-    return parts
-
-
-def _format_nodes(nodes) -> list[str]:
-    """Format a list of node results into context lines."""
-    parts = []
-    if nodes:
-        for node in nodes:
-            name = getattr(node, "name", "Unknown")
-            labels = getattr(node, "labels", None)
-            attributes = getattr(node, "attributes", None)
-            summary = getattr(node, "summary", "No summary available")
-
-            parts.append(f"Name: {name}")
-
-            if labels and len(labels) > 0:
-                filtered_labels = (
-                    [l for l in labels if l != "Entity"] if len(labels) > 1 else labels
-                )
-                if filtered_labels:
-                    parts.append(f"Labels: {', '.join(filtered_labels)}")
-
-            if attributes and isinstance(attributes, dict) and len(attributes) > 0:
-                parts.append(f"Attributes:")
-                for attr_name, attr_value in attributes.items():
-                    parts.append(f"  {attr_name}: {attr_value}")
-
-            parts.append(f"Summary: {summary}")
-            parts.append("")
-    else:
-        parts.append("No relevant entities found")
-    return parts
-
-
-def _format_episodes(episodes) -> list[str]:
-    """Format a list of episode results into context lines."""
-    parts = []
-    if episodes:
-        for episode in episodes:
-            content = getattr(episode, "content", "No content available")
-            created_at = getattr(episode, "created_at", "Unknown date")
-            parts.append(f"({created_at}) {content}")
-    else:
-        parts.append("No relevant episodes found")
-    return parts
-
-
-def construct_context_block(
-    search_results: Dict[str, Any],
-    user_summary: str | None = None,
-) -> str:
-    """
-    Construct a context block from graph search results.
-    Includes user summary, user graph results, and optionally document graph results.
-
-    Args:
-        search_results: Dictionary containing user and document graph results
-        user_summary: Optional user summary from the user node
-
-    Returns:
-        Formatted context block string for LLM consumption
-    """
-    context_parts = []
-
-    has_episodes = search_results.get("episodes") is not None
-    has_doc_results = search_results.get("doc_edges") is not None
-
-    # User summary
-    if user_summary:
-        context_parts.append("# High-level summary of the user")
-        context_parts.append("<USER_SUMMARY>")
-        context_parts.append(user_summary)
-        context_parts.append("</USER_SUMMARY>\n")
-
-    # --- User graph results ---
-    context_parts.append(
-        "FACTS, ENTITIES,"
-        + (" and EPISODES " if has_episodes else " ")
-        + "represent relevant context from the user's knowledge graph.\n"
-    )
-
-    # Facts
-    context_parts.append("# These are the most relevant facts about the user")
-    context_parts.append('# Facts ending in "present" are currently valid')
-    context_parts.append("# Facts with a past end date are NO LONGER VALID.")
-    context_parts.append("<FACTS>")
-    edges = getattr(search_results["edges"], "edges", [])
-    context_parts.extend(_format_edges(edges))
-    context_parts.append("</FACTS>\n")
-
-    # Entities
-    context_parts.append(
-        "# These are the most relevant entities (people, locations, organizations, items, and more)."
-    )
-    context_parts.append("<ENTITIES>")
-    nodes = getattr(search_results["nodes"], "nodes", [])
-    context_parts.extend(_format_nodes(nodes))
-    context_parts.append("</ENTITIES>")
-
-    # Episodes (optional)
-    if has_episodes:
-        context_parts.append("\n# These are the most relevant episodes")
-        context_parts.append("<EPISODES>")
-        episodes = getattr(search_results["episodes"], "episodes", [])
-        context_parts.extend(_format_episodes(episodes))
-        context_parts.append("</EPISODES>")
-
-    # --- Document graph results (optional) ---
-    if has_doc_results:
-        has_doc_episodes = search_results.get("doc_episodes") is not None
-
-        context_parts.append("\n")
-        context_parts.append(
-            "The following FACTS and ENTITIES are from shared reference documents.\n"
-        )
-
-        context_parts.append("# Reference document facts")
-        context_parts.append("<DOCUMENT_FACTS>")
-        doc_edges = getattr(search_results["doc_edges"], "edges", [])
-        context_parts.extend(_format_edges(doc_edges))
-        context_parts.append("</DOCUMENT_FACTS>\n")
-
-        context_parts.append("# Reference document entities")
-        context_parts.append("<DOCUMENT_ENTITIES>")
-        doc_nodes = getattr(search_results["doc_nodes"], "nodes", [])
-        context_parts.extend(_format_nodes(doc_nodes))
-        context_parts.append("</DOCUMENT_ENTITIES>")
-
-        if has_doc_episodes:
-            context_parts.append("\n# Reference document episodes")
-            context_parts.append("<DOCUMENT_EPISODES>")
-            doc_episodes = getattr(search_results["doc_episodes"], "episodes", [])
-            context_parts.extend(_format_episodes(doc_episodes))
-            context_parts.append("</DOCUMENT_EPISODES>")
-
-    return "\n".join(context_parts)
+# Implemented by config.evaluation_config.retrieval_strategy.build_context_block
 
 
 # ============================================================================
@@ -694,7 +422,6 @@ async def process_single_query(
     query: str,
     golden_answer: str,
     doc_graph_id: str | None = None,
-    user_summary: str | None = None,
 ) -> Dict[str, Any]:
     """
     Process a single query through the complete pipeline:
@@ -707,19 +434,19 @@ async def process_single_query(
         query: Question to answer
         golden_answer: Expected answer for evaluation
         doc_graph_id: Optional standalone document graph to also search
-        user_summary: Optional user summary from the user node
 
     Returns:
         Dictionary containing all results for this query
     """
     start_time = time()
 
-    # Step 1: Search (user graph + optionally document graph, all in parallel)
-    include_episodes = USER_EPISODES_LIMIT > 0 or DOC_EPISODES_LIMIT > 0
-    search_results = await perform_graph_search(
-        zep_client, user_id, query, include_episodes=include_episodes, doc_graph_id=doc_graph_id
+    # Step 1: Retrieve context (strategy defined in retrieval_strategy.py)
+    context = await build_context_block(
+        zep_client,
+        user_id=user_id,
+        query=query,
+        doc_graph_id=doc_graph_id,
     )
-    context = construct_context_block(search_results, user_summary=user_summary)
     search_duration_ms = (time() - start_time) * 1000
 
     # Steps 2 & 3: Run completeness evaluation and response generation in parallel
@@ -854,21 +581,7 @@ async def evaluate_all_questions(
         # Warm the user's graph cache for low-latency search
         print(f"Warming graph cache for user {zep_user_id}...")
         await zep_client.user.warm(user_id=zep_user_id)
-        print(f"✓ Graph cache warmed for {zep_user_id}")
-
-        # Fetch user summary from the user node
-        user_summary = None
-        try:
-            user_node_response = await zep_client.user.get_node(user_id=zep_user_id)
-            if user_node_response.node:
-                user_summary = getattr(user_node_response.node, "summary", None)
-            if user_summary:
-                print(f"✓ User summary retrieved")
-            else:
-                print(f"  No user summary available")
-        except Exception as e:
-            print(f"  Could not retrieve user summary: {e}")
-        print()
+        print(f"✓ Graph cache warmed for {zep_user_id}\n")
 
         # Process all test cases concurrently, bounded by semaphore
         completed = 0
@@ -886,7 +599,6 @@ async def evaluate_all_questions(
                     query,
                     test_case["golden_answer"],
                     doc_graph_id=doc_graph_id,
-                    user_summary=user_summary,
                 )
             result["test_id"] = test_case.get("id")
             result["category"] = test_case.get("category")
@@ -1190,14 +902,7 @@ def save_results(
         "evaluation_timestamp": timestamp,
         "run_number": run_number,
         "parent_runs": parent_runs,
-        "search_configuration": {
-            "user_facts_limit": USER_FACTS_LIMIT,
-            "user_entities_limit": USER_ENTITIES_LIMIT,
-            "user_episodes_limit": USER_EPISODES_LIMIT,
-            "doc_facts_limit": DOC_FACTS_LIMIT,
-            "doc_entities_limit": DOC_ENTITIES_LIMIT,
-            "doc_episodes_limit": DOC_EPISODES_LIMIT,
-        },
+        "search_configuration": get_search_configuration(),
         "model_configuration": {
             "response_model": LLM_RESPONSE_MODEL,
             "judge_model": LLM_JUDGE_MODEL,

--- a/zep-eval-harness/zep_evaluate.py
+++ b/zep-eval-harness/zep_evaluate.py
@@ -29,6 +29,7 @@ from config.evaluation_config.constants import (
 from config.evaluation_config.response_prompt import get_response_system_prompt
 from config.evaluation_config.retrieval_strategy import (
     build_context_block,
+    fetch_user_summary,
     get_search_configuration,
 )
 from retry import retry_with_backoff
@@ -422,6 +423,7 @@ async def process_single_query(
     query: str,
     golden_answer: str,
     doc_graph_id: str | None = None,
+    user_summary: str | None = None,
 ) -> Dict[str, Any]:
     """
     Process a single query through the complete pipeline:
@@ -434,6 +436,7 @@ async def process_single_query(
         query: Question to answer
         golden_answer: Expected answer for evaluation
         doc_graph_id: Optional standalone document graph to also search
+        user_summary: Optional user-node summary (fetched once per user)
 
     Returns:
         Dictionary containing all results for this query
@@ -446,6 +449,7 @@ async def process_single_query(
         user_id=user_id,
         query=query,
         doc_graph_id=doc_graph_id,
+        user_summary=user_summary,
     )
     search_duration_ms = (time() - start_time) * 1000
 
@@ -581,7 +585,15 @@ async def evaluate_all_questions(
         # Warm the user's graph cache for low-latency search
         print(f"Warming graph cache for user {zep_user_id}...")
         await zep_client.user.warm(user_id=zep_user_id)
-        print(f"✓ Graph cache warmed for {zep_user_id}\n")
+        print(f"✓ Graph cache warmed for {zep_user_id}")
+
+        # Fetch user summary once per user (reused across concurrent queries)
+        user_summary = await fetch_user_summary(zep_client, zep_user_id)
+        if user_summary:
+            print(f"✓ User summary retrieved")
+        else:
+            print(f"  No user summary available")
+        print()
 
         # Process all test cases concurrently, bounded by semaphore
         completed = 0
@@ -599,6 +611,7 @@ async def evaluate_all_questions(
                     query,
                     test_case["golden_answer"],
                     doc_graph_id=doc_graph_id,
+                    user_summary=user_summary,
                 )
             result["test_id"] = test_case.get("id")
             result["category"] = test_case.get("category")


### PR DESCRIPTION
## Summary
- Moves eval context retrieval into `retrieval_strategy.build_context_block`, defaulting to `scope="auto"` with a 10k character budget.
- Prepends the user-node summary (fetched via `user.get_node`) and optionally concatenates document-graph auto search when `--doc-run` is set.
- Removes per-type facts/entities/episodes limit constants and updates harness docs to describe the strategy-module approach.

## Test plan
- [ ] Run a user-only eval (`uv run zep_evaluate.py`) and confirm context includes `<USER_SUMMARY>` plus auto-packed graph context
- [ ] Run with `--doc-run N` and confirm document context is appended
- [ ] Check results JSON `search_configuration` shows `strategy`/`scope`/`max_characters`


Made with [Cursor](https://cursor.com)