### PR TITLE
feat(integrations): add Zep MemoryStore for Strands Agents

### DIFF
--- a/.github/workflows/test-integrations.yml
+++ b/.github/workflows/test-integrations.yml
@@ -42,6 +42,8 @@ jobs:
               - 'integrations/langgraph/python/**'
             pydantic-ai:
               - 'integrations/pydantic-ai/python/**'
+            strands:
+              - 'integrations/strands/python/**'
 
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: typescript

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Framework integration packages live under [`integrations/`](integrations/), orga
 framework-first then language: `integrations/<framework>/<language>/`. Each package is built,
 tested, and released independently.
 
-- **Python**: Google ADK, Microsoft Agent Framework, Microsoft AutoGen, AG2, CrewAI, LangGraph, LiveKit, Pydantic AI
+- **Python**: Google ADK, Microsoft Agent Framework, Microsoft AutoGen, AG2, CrewAI, LangGraph, LiveKit, Pydantic AI, Strands Agents
 - **TypeScript**: Google ADK, Mastra, Vercel AI SDK
 - **Go**: Google ADK
 

--- a/integrations/CLAUDE.md
+++ b/integrations/CLAUDE.md
@@ -30,6 +30,7 @@ Current packages:
 | `mastra/typescript` | `@getzep/zep-mastra` (npm) | `@getzep/zep-mastra` |
 | `ms-agent-framework/python` | `zep-ms-agent-framework` (PyPI) | `zep_ms_agent_framework` |
 | `pydantic-ai/python` | `zep-pydantic-ai` (PyPI) | `zep_pydantic_ai` |
+| `strands/python` | `zep-strands` (PyPI) | `zep_strands` |
 | `vercel-ai/typescript` | `@getzep/zep-vercel-ai` (npm) | `@getzep/zep-vercel-ai` |
 
 **Naming convention (keep CI derivation simple):** the framework directory is the package

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -23,6 +23,7 @@ New to Zep? Sign up at [getzep.com](https://www.getzep.com) and create an API ke
 | Microsoft Agent Framework | Python | `zep-ms-agent-framework` | [`ms-agent-framework/python/`](ms-agent-framework/python/) |
 | Microsoft AutoGen | Python | [`zep-autogen`](https://pypi.org/p/zep-autogen) | [`autogen/python/`](autogen/python/) |
 | Pydantic AI | Python | `zep-pydantic-ai` | [`pydantic-ai/python/`](pydantic-ai/python/) |
+| Strands Agents | Python | `zep-strands` | [`strands/python/`](strands/python/) |
 | Vercel AI SDK | TypeScript | `@getzep/zep-vercel-ai` | [`vercel-ai/typescript/`](vercel-ai/typescript/) |
 
 Looking for bulk data ingestion (Slack exports, documents, email, CSV/JSON records,

--- a/integrations/strands/python/CHANGELOG.md
+++ b/integrations/strands/python/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Fixed
 
 - `ZepMemoryStore` now rejects `extraction=True` (or an `ExtractionConfig`) at construction unless the store is writable user-graph mode with both `user_id` and `thread_id`, so `MemoryManager` never schedules extraction that would raise on every cycle.
+- `add()` no longer truncates oversized `json` payloads. Slicing JSON strips its closing syntax, so the size guard produced a document Zep would reject; oversized `json` now raises a `ValueError` pointing at chunking. `text`/`message` payloads are still truncated with a warning.
 
 ### Changed
 
 - Documented that Strands' default extraction cadence is every **5 turns**, so conversation batches only reach Zep when the trigger fires (or on `flush()`), delaying graph building relative to turn-by-turn persistence — in addition to Zep's asynchronous ingestion after messages arrive.
+- Documented the failure-handling contract: Zep SDK errors propagate out of `search`/`add`/`add_messages` by design, because `MemoryManager` and `ExtractionCoordinator` own failure isolation (skip-and-log, `AggregateMemoryError`, and high-water-mark rollback for retry). Added tests pinning that behavior.
 
 ## 0.1.0 (2026-08-01)
 

--- a/integrations/strands/python/CHANGELOG.md
+++ b/integrations/strands/python/CHANGELOG.md
@@ -24,6 +24,10 @@
 - `add()` no longer truncates oversized `json` payloads. Slicing JSON strips its closing syntax, so the size guard produced a document Zep would reject; oversized `json` now raises a `ValueError` pointing at chunking. `text`/`message` payloads are still truncated with a warning.
 - Corrected the `provisioning` module docstring (it incorrectly referred to
   `ZepContextProvider`).
+- `zep_search` no longer returns raw exception text to the model. SDK errors
+  can include URLs, identifiers, or response bodies; the tool now returns a
+  fixed `"Graph search failed."` string and logs only the exception type
+  (and `status_code` when present), with the full traceback at DEBUG.
 - The example and live agent test now pass an explicit `OpenAIModel`. Both
   require `OPENAI_API_KEY` and document `strands-agents[openai]`, but neither
   passed `model=` to `Agent`, so Strands silently fell back to its

--- a/integrations/strands/python/CHANGELOG.md
+++ b/integrations/strands/python/CHANGELOG.md
@@ -21,8 +21,8 @@
 
 - Documented that Strands' default extraction cadence is every **5 turns**, so conversation batches only reach Zep when the trigger fires (or on `flush()`), delaying graph building relative to turn-by-turn persistence — in addition to Zep's asynchronous ingestion after messages arrive.
 - Documented the failure-handling contract: Zep SDK errors propagate out of `search`/`add`/`add_messages` by design, because `MemoryManager` and `ExtractionCoordinator` own failure isolation (skip-and-log, `AggregateMemoryError`, and high-water-mark rollback for retry). Added tests pinning that behavior.
-- Example and live tests use every-turn extraction (`InvocationTrigger`) plus
-  `flush()` after `invoke_async` so demos are not flaky on the default cadence.
+- Example and live tests flush at the session boundary after `invoke_async`,
+  which `MemoryManager` requires to persist buffered turns on that path.
 
 ## 0.1.0 (2026-08-01)
 

--- a/integrations/strands/python/CHANGELOG.md
+++ b/integrations/strands/python/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- `ZepMemoryStore` now rejects `extraction=True` (or an `ExtractionConfig`) at construction unless the store is writable user-graph mode with both `user_id` and `thread_id`, so `MemoryManager` never schedules extraction that would raise on every cycle.
+
+### Changed
+
+- Documented that Strands' default extraction cadence is every **5 turns**, so conversation batches only reach Zep when the trigger fires (or on `flush()`), delaying graph building relative to turn-by-turn persistence — in addition to Zep's asynchronous ingestion after messages arrive.
+
 ## 0.1.0 (2026-08-01)
 
 ### Added

--- a/integrations/strands/python/CHANGELOG.md
+++ b/integrations/strands/python/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## Unreleased
+
+## 0.1.0 (2026-08-01)
+
+### Added
+
+- `ZepMemoryStore` — a Strands Agents `MemoryStore` backed by Zep's temporal Context Graph.
+- `search` via `graph.search` (default `scope="auto"` returns Zep's assembled Context Block).
+- `add_messages` via `thread.add_messages` for server-side extraction in user-graph mode.
+- `add` via `graph.add` for text/JSON/message facts (`metadata["type"]` selects the data type).
+- `initialize` provisions the Zep user and thread (no-op for standalone graphs).
+- Standalone-graph mode via `graph_id` (search + add only).
+- `ensure_user` / `ensure_thread` idempotent provisioning helpers with optional `on_created` hook.
+- `create_zep_search_tool` with pin-or-expose control over `graph.search` parameters.
+- `expose_search_tool` on `ZepMemoryStore` to register the search tool through `get_tools()`.
+- Message and graph payload truncation helpers with length-only warnings.
+- Mock-based unit tests, a gated live integration test, and a runnable example.

--- a/integrations/strands/python/CHANGELOG.md
+++ b/integrations/strands/python/CHANGELOG.md
@@ -2,15 +2,27 @@
 
 ## Unreleased
 
+### Added
+
+- Live agent integration test (`test_integration_full_lifecycle`) exercising
+  `Agent` + `MemoryManager` + `ZepMemoryStore` against Zep Cloud and OpenAI,
+  including cross-thread recall and `on_user_created` (gated on
+  `ZEP_API_KEY` + `OPENAI_API_KEY`). Store-only round-trip remains available
+  with just `ZEP_API_KEY`.
+
 ### Fixed
 
 - `ZepMemoryStore` now rejects `extraction=True` (or an `ExtractionConfig`) at construction unless the store is writable user-graph mode with both `user_id` and `thread_id`, so `MemoryManager` never schedules extraction that would raise on every cycle.
 - `add()` no longer truncates oversized `json` payloads. Slicing JSON strips its closing syntax, so the size guard produced a document Zep would reject; oversized `json` now raises a `ValueError` pointing at chunking. `text`/`message` payloads are still truncated with a warning.
+- Corrected the `provisioning` module docstring (it incorrectly referred to
+  `ZepContextProvider`).
 
 ### Changed
 
 - Documented that Strands' default extraction cadence is every **5 turns**, so conversation batches only reach Zep when the trigger fires (or on `flush()`), delaying graph building relative to turn-by-turn persistence — in addition to Zep's asynchronous ingestion after messages arrive.
 - Documented the failure-handling contract: Zep SDK errors propagate out of `search`/`add`/`add_messages` by design, because `MemoryManager` and `ExtractionCoordinator` own failure isolation (skip-and-log, `AggregateMemoryError`, and high-water-mark rollback for retry). Added tests pinning that behavior.
+- Example and live tests use every-turn extraction (`InvocationTrigger`) plus
+  `flush()` after `invoke_async` so demos are not flaky on the default cadence.
 
 ## 0.1.0 (2026-08-01)
 

--- a/integrations/strands/python/CHANGELOG.md
+++ b/integrations/strands/python/CHANGELOG.md
@@ -12,10 +12,23 @@
 
 ### Fixed
 
+- `ZepMemoryStore.initialize()` no longer calls Zep. `Agent.__init__` is
+  synchronous, so Strands runs that hook on a throwaway event loop in a worker
+  thread; provisioning there drove the caller's `AsyncZep` client from a second
+  event loop and raised `RuntimeError: ... is bound to a different event loop`
+  whenever the caller had already awaited that client (the pattern the README
+  and example recommend: `ensure_user`, then hand the client to the store).
+  Provisioning now happens on the store's first search or write, which always
+  runs on the agent's own loop.
 - `ZepMemoryStore` now rejects `extraction=True` (or an `ExtractionConfig`) at construction unless the store is writable user-graph mode with both `user_id` and `thread_id`, so `MemoryManager` never schedules extraction that would raise on every cycle.
 - `add()` no longer truncates oversized `json` payloads. Slicing JSON strips its closing syntax, so the size guard produced a document Zep would reject; oversized `json` now raises a `ValueError` pointing at chunking. `text`/`message` payloads are still truncated with a warning.
 - Corrected the `provisioning` module docstring (it incorrectly referred to
   `ZepContextProvider`).
+- The example and live agent test now pass an explicit `OpenAIModel`. Both
+  require `OPENAI_API_KEY` and document `strands-agents[openai]`, but neither
+  passed `model=` to `Agent`, so Strands silently fell back to its
+  `BedrockModel()` default and the run failed on missing AWS credentials. The
+  model ID is overridable via `OPENAI_MODEL` (default `gpt-5-mini`).
 
 ### Changed
 

--- a/integrations/strands/python/Makefile
+++ b/integrations/strands/python/Makefile
@@ -1,0 +1,72 @@
+# Makefile for zep-strands development
+
+.PHONY: help install format lint lint-fix type-check test test-cov clean build all pre-commit ci
+
+# Default target
+help:
+	@echo "Available commands:"
+	@echo "  install     - Install package and dependencies in development mode"
+	@echo "  format      - Format code with ruff"
+	@echo "  lint        - Run linting checks"
+	@echo "  type-check  - Run type checking with mypy"
+	@echo "  test        - Run tests"
+	@echo "  test-cov    - Run tests with coverage report"
+	@echo "  all         - Run format, lint, type-check, and test"
+	@echo "  build       - Build the package"
+	@echo "  clean       - Clean build artifacts"
+
+# Install package in development mode
+install:
+	uv sync --extra dev
+
+# Format code
+format:
+	uv run ruff format .
+
+# Run linting checks
+lint:
+	uv run ruff check .
+
+# Fix linting issues automatically
+lint-fix:
+	uv run ruff check --fix .
+
+# Run type checking
+type-check:
+	uv run mypy src/
+
+# Run tests (mock-based; integration tests skip without API keys)
+test:
+	uv run pytest tests/ -v
+
+# Run tests with coverage
+test-cov:
+	uv run pytest tests/ -v --cov=zep_strands --cov-report=term-missing --cov-report=xml
+
+# Run all checks (format first, then lint, then type-check, then test)
+all: format lint type-check test
+
+# Build the package
+build:
+	uv build
+
+# Clean build artifacts
+clean:
+	rm -rf dist/
+	rm -rf build/
+	rm -rf *.egg-info/
+	rm -rf .pytest_cache/
+	rm -rf .mypy_cache/
+	rm -rf .ruff_cache/
+	find . -type d -name __pycache__ -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+	rm -f coverage.xml
+	rm -f .coverage
+
+# Development workflow - run this before committing
+pre-commit: lint-fix format lint type-check test
+	@echo "All checks passed! Ready to commit."
+
+# CI workflow - strict checks without auto-fixing
+ci: lint type-check test
+	@echo "CI checks passed!"

--- a/integrations/strands/python/README.md
+++ b/integrations/strands/python/README.md
@@ -56,7 +56,7 @@ With no further configuration, the manager injects relevant Zep context before e
 | `MemoryStore.search` | `graph.search` | Recall for injection and the `search_memory` tool |
 | `MemoryStore.add_messages` | `thread.add_messages` | Server-side extraction from conversation turns |
 | `MemoryStore.add` | `graph.add` | Single-fact writes (`add_memory` tool / programmatic) |
-| `MemoryStore.initialize` | `user.add` + `thread.create` | Provision resources before the agent runs |
+| First `search` / write | `user.add` + `thread.create` | Provision resources on first use (see below) |
 | `MemoryStore.get_tools` | `create_zep_search_tool` | Optional on-demand graph search (when enabled) |
 
 Context comes from the **whole user graph**; the thread only scopes relevance and records the conversation. A new thread for the same user still recalls earlier facts.
@@ -109,7 +109,9 @@ Provide exactly one of `user_id` or `graph_id`.
 
 `ensure_user` / `ensure_thread` are idempotent create-then-catch-conflict helpers. Both return `True` when newly created and `False` when the resource already exists; genuine failures raise.
 
-Call them out-of-band before the first turn so misconfiguration surfaces loudly. `ZepMemoryStore.initialize()` (invoked by `MemoryManager`) also provisions lazily when you skip the helpers.
+Call them out-of-band before the first turn so misconfiguration surfaces loudly. If you skip them, the store provisions itself on its first search or write instead.
+
+`ZepMemoryStore.initialize()` deliberately makes **no** Zep calls. `Agent.__init__` is synchronous, so Strands runs that hook on a throwaway event loop in a worker thread; calling Zep there would drive your `AsyncZep` client from a second event loop and raise `RuntimeError: ... is bound to a different event loop` for any connection you had already opened. Deferring to first use keeps every Zep call on the agent's own loop, so one client can safely be shared between your application code and the store.
 
 ```python
 from zep_strands import ensure_thread, ensure_user

--- a/integrations/strands/python/README.md
+++ b/integrations/strands/python/README.md
@@ -47,7 +47,7 @@ agent = Agent(
 )
 ```
 
-With no further configuration, the manager injects relevant Zep context before each user turn and runs server-side extraction every few turns. Enable `add_tool_config=True` on the manager to also let the model call `add_memory`.
+With no further configuration, the manager injects relevant Zep context before each user turn and runs server-side extraction on Strands' default cadence (**every 5 turns**). That means conversation turns are buffered and only sent to Zep when the trigger fires (or when you call `memory_manager.flush()`), so graph building is delayed relative to turn-by-turn persistence — and Zep's own ingestion remains asynchronous after messages arrive. Enable `add_tool_config=True` on the manager to also let the model call `add_memory`.
 
 ## How it works
 
@@ -61,7 +61,33 @@ With no further configuration, the manager injects relevant Zep context before e
 
 Context comes from the **whole user graph**; the thread only scopes relevance and records the conversation. A new thread for the same user still recalls earlier facts.
 
-Ingestion is asynchronous — a just-added fact is not instantly retrievable. Design for eventual availability.
+## Automatic extraction and delayed graph building
+
+`extraction=True` (the default when the store is writable with `user_id` + `thread_id`) opts into Strands' automatic extraction loop. With the manager's defaults that means:
+
+1. Conversation turns are buffered in the manager.
+2. Every **5 turns**, Strands calls `add_messages`, which posts the batch to Zep via `thread.add_messages`.
+3. Zep then processes the batch asynchronously into the user graph.
+
+Until step 2 runs, **nothing has been sent to Zep**, so the graph does not grow turn-by-turn. After step 2, facts are still not instantly searchable (Zep ingestion is async). Plan for both delays:
+
+- Call `await memory_manager.flush()` at session boundaries (required after `invoke_async` / `stream_async` if you need pending turns persisted before shutdown).
+- Or pass an every-turn trigger if you need messages sent to Zep more often:
+
+```python
+from strands.memory.extraction.triggers import InvocationTrigger
+from strands.memory.extraction.types import ExtractionConfig
+
+store = ZepMemoryStore(
+    zep_client=zep,
+    user_id="user-123",
+    thread_id="thread-abc",
+    writable=True,
+    extraction=ExtractionConfig(trigger=InvocationTrigger()),  # after every turn
+)
+```
+
+`extraction=True` (or an `ExtractionConfig`) **requires** writable user-graph mode with both `user_id` and `thread_id`. Construction raises `ValueError` otherwise — use `extraction=False` for standalone graphs or read-only stores.
 
 ## Scoping modes
 

--- a/integrations/strands/python/README.md
+++ b/integrations/strands/python/README.md
@@ -188,7 +188,8 @@ One store instance is bound to one `user_id`/`thread_id` (or `graph_id`) at cons
 ## Features
 
 - Native Strands `MemoryStore` — works with `MemoryManager` injection, tools, and extraction
-- Server-side extraction via Zep threads (`add_messages`)
+- Server-side extraction via Zep threads (`add_messages`); default cadence every 5 turns (delayed graph building)
+- Fail-fast validation when `extraction` is enabled without a writable user/thread
 - Whole-user-graph recall across threads
 - Standalone-graph mode for shared knowledge
 - Optional pin-or-expose `zep_search` tool

--- a/integrations/strands/python/README.md
+++ b/integrations/strands/python/README.md
@@ -179,6 +179,22 @@ await store.add('{"plan": "premium"}', metadata={"type": "json"})
 
 `metadata["type"]` selects the Zep data type (`text` default, `json`, or `message`). Remaining metadata keys are forwarded as episode metadata.
 
+Oversized `text`/`message` payloads are truncated to Zep's `graph.add` limit with a warning. Oversized `json` is **rejected with a `ValueError`** instead — slicing JSON strips its closing syntax, so a truncated document would just be rejected by Zep. Split large JSON into smaller documents before adding (see [chunking](https://help.getzep.com/chunking-large-documents)).
+
+## Error handling
+
+Zep SDK errors propagate out of the store methods deliberately: in Strands the **framework** owns failure isolation, and swallowing them breaks it.
+
+| Path | Framework behavior on a raise |
+|------|-------------------------------|
+| `search` | `MemoryManager.search` logs and skips the failing store; injection additionally fails open, so the turn proceeds without memory |
+| `add` | Surfaced as `AggregateMemoryError` so a failed write is never silent |
+| `add_messages` | `ExtractionCoordinator` catches it and **rolls back its high-water mark so the batch retries** |
+
+That last one matters most: returning `None` after swallowing an error would be read as success, advancing the mark and discarding those messages permanently. This matches the SDK's own vended stores, which raise rather than degrade.
+
+The one exception is the model-callable `zep_search` tool, which catches Zep errors and returns an error string — a raw tool has no framework layer above it.
+
 ## Identity
 
 Pass real names (`first_name`, `last_name`, `email`) so Zep anchors the user graph node. Display names on persisted messages default to the user's full name / `"Assistant"`.

--- a/integrations/strands/python/README.md
+++ b/integrations/strands/python/README.md
@@ -1,0 +1,204 @@
+# zep-strands
+
+Add long-term agent memory to [Strands Agents](https://strandsagents.com) via Zep's temporal Context Graph.
+
+`ZepMemoryStore` implements Strands' [`MemoryStore`](https://strandsagents.com/docs/user-guide/concepts/memory/overview/) interface, so it plugs into `MemoryManager` for automatic recall (injection + `search_memory`), server-side extraction (`add_messages` → Zep threads), and optional on-demand graph search.
+
+## Installation
+
+```bash
+pip install zep-strands
+```
+
+Requires Python 3.11+, `strands-agents>=1.45.0`, `zep-cloud>=3.23.0`, and a Zep Cloud API key from [app.getzep.com](https://app.getzep.com/).
+
+## Quick start
+
+```python
+from strands import Agent
+from strands.memory import MemoryManager
+from zep_cloud.client import AsyncZep
+from zep_strands import ZepMemoryStore, ensure_thread, ensure_user
+
+zep = AsyncZep(api_key="your-api-key")
+
+await ensure_user(
+    zep,
+    user_id="user-123",
+    first_name="Jane",
+    last_name="Smith",
+    email="jane@example.com",
+)
+await ensure_thread(zep, thread_id="thread-abc", user_id="user-123")
+
+store = ZepMemoryStore(
+    zep_client=zep,
+    user_id="user-123",
+    thread_id="thread-abc",
+    first_name="Jane",
+    last_name="Smith",
+    writable=True,
+    extraction=True,  # server-side via add_messages
+)
+
+agent = Agent(
+    system_prompt="You are a helpful assistant with long-term memory.",
+    memory_manager=MemoryManager(stores=[store]),
+)
+```
+
+With no further configuration, the manager injects relevant Zep context before each user turn and runs server-side extraction every few turns. Enable `add_tool_config=True` on the manager to also let the model call `add_memory`.
+
+## How it works
+
+| Strands hook | Zep call | Purpose |
+|--------------|----------|---------|
+| `MemoryStore.search` | `graph.search` | Recall for injection and the `search_memory` tool |
+| `MemoryStore.add_messages` | `thread.add_messages` | Server-side extraction from conversation turns |
+| `MemoryStore.add` | `graph.add` | Single-fact writes (`add_memory` tool / programmatic) |
+| `MemoryStore.initialize` | `user.add` + `thread.create` | Provision resources before the agent runs |
+| `MemoryStore.get_tools` | `create_zep_search_tool` | Optional on-demand graph search (when enabled) |
+
+Context comes from the **whole user graph**; the thread only scopes relevance and records the conversation. A new thread for the same user still recalls earlier facts.
+
+Ingestion is asynchronous — a just-added fact is not instantly retrievable. Design for eventual availability.
+
+## Scoping modes
+
+**User graph** (default for conversational agents) — pass `user_id` and `thread_id`:
+
+```python
+ZepMemoryStore(zep_client=zep, user_id="user-123", thread_id="thread-abc", ...)
+```
+
+**Standalone graph** (shared / domain knowledge) — pass `graph_id`. Supports `search` and `add` only (no `add_messages`):
+
+```python
+ZepMemoryStore(zep_client=zep, graph_id="company-kb", writable=True, extraction=False)
+```
+
+Provide exactly one of `user_id` or `graph_id`.
+
+## Provisioning users and threads
+
+`ensure_user` / `ensure_thread` are idempotent create-then-catch-conflict helpers. Both return `True` when newly created and `False` when the resource already exists; genuine failures raise.
+
+Call them out-of-band before the first turn so misconfiguration surfaces loudly. `ZepMemoryStore.initialize()` (invoked by `MemoryManager`) also provisions lazily when you skip the helpers.
+
+```python
+from zep_strands import ensure_thread, ensure_user
+
+created = await ensure_user(
+    zep,
+    user_id="user-123",
+    first_name="Jane",
+    last_name="Smith",
+    on_created=configure_ontology,  # optional async hook
+)
+await ensure_thread(zep, thread_id="thread-abc", user_id="user-123")
+```
+
+## Search and injection
+
+By default `search_scope="auto"`, so injection receives Zep's assembled Context Block as a single `MemoryEntry`. Pin a scoped search when you want discrete facts:
+
+```python
+store = ZepMemoryStore(
+    zep_client=zep,
+    user_id="user-123",
+    thread_id="thread-abc",
+    search_scope="edges",
+    search_filters={"edge_types": ["PREFERS"]},
+)
+```
+
+## On-demand graph search tool
+
+Set `expose_search_tool=True` to register a model-callable `zep_search` tool via `get_tools()`:
+
+```python
+store = ZepMemoryStore(
+    zep_client=zep,
+    user_id="user-123",
+    thread_id="thread-abc",
+    expose_search_tool=True,
+    search_pinned_params={"scope": "auto", "limit": 10},
+)
+```
+
+Or build the tool yourself:
+
+```python
+from zep_strands import create_zep_search_tool
+
+tool = create_zep_search_tool(
+    zep_client=zep,
+    user_id="user-123",
+    search_pinned_params={"scope": "edges"},
+)
+agent = Agent(tools=[tool])
+```
+
+**Pin-or-expose.** Every `graph.search` parameter (`scope`, `reranker`, `limit`, `mmr_lambda`, `center_node_uuid`) is model-exposed by default. `search_pinned_params` fixes a value and hides it; `search_hidden_params` hides without pinning (Zep's default applies). `search_filters` and `bfs_origin_node_uuids` are always constructor-only.
+
+## Writing facts
+
+```python
+# Text fact into the user graph
+await store.add("Prefers aisle seats", metadata={"source": "prefs"})
+
+# JSON payload
+await store.add('{"plan": "premium"}', metadata={"type": "json"})
+```
+
+`metadata["type"]` selects the Zep data type (`text` default, `json`, or `message`). Remaining metadata keys are forwarded as episode metadata.
+
+## Identity
+
+Pass real names (`first_name`, `last_name`, `email`) so Zep anchors the user graph node. Display names on persisted messages default to the user's full name / `"Assistant"`.
+
+One store instance is bound to one `user_id`/`thread_id` (or `graph_id`) at construction.
+
+## Features
+
+- Native Strands `MemoryStore` — works with `MemoryManager` injection, tools, and extraction
+- Server-side extraction via Zep threads (`add_messages`)
+- Whole-user-graph recall across threads
+- Standalone-graph mode for shared knowledge
+- Optional pin-or-expose `zep_search` tool
+- Idempotent `ensure_user` / `ensure_thread` provisioning
+- Message and graph payload truncation with length-only warnings
+
+## Configuration
+
+```bash
+export ZEP_API_KEY="your-zep-api-key"
+```
+
+## Examples
+
+See [`examples/basic_agent.py`](examples/basic_agent.py) for an end-to-end multi-thread recall demo. Setup steps are in [`SETUP.md`](SETUP.md).
+
+## Development
+
+```bash
+cd integrations/strands/python
+make install      # uv sync --extra dev
+make all          # format + lint + type-check + test
+```
+
+## Requirements
+
+- Python 3.11+
+- `strands-agents>=1.45.0`
+- `zep-cloud>=3.23.0`
+
+## Support
+
+- [Zep Documentation](https://help.getzep.com)
+- [Strands Memory guide](https://strandsagents.com/docs/user-guide/concepts/memory/overview/)
+- [GitHub Issues](https://github.com/getzep/zep/issues)
+
+## License
+
+Apache 2.0 — see the repository [`LICENSE`](../../../LICENSE).

--- a/integrations/strands/python/SETUP.md
+++ b/integrations/strands/python/SETUP.md
@@ -82,10 +82,13 @@ uv run pytest tests/test_integration.py -v -s -m integration
 
 - **`ZepDependencyError` on import** — Strands Agents is not installed. Run
   `pip install zep-strands` (which pulls `strands-agents`).
-- **Recall returns nothing** — Zep ingestion is asynchronous; a just-added fact
-  is not instantly retrievable. The example waits ~20s; increase the wait if
-  your graph is large or under load.
+- **Recall returns nothing** — two delays apply. First, Strands' default
+  extraction only sends conversation batches to Zep every **5 turns** (or on
+  `memory_manager.flush()`). Second, Zep ingestion is asynchronous after
+  messages arrive. The example waits ~20s after seeding; increase the wait or
+  flush / use an every-turn trigger if your graph is large or under load.
 - **Authentication errors** — confirm `ZEP_API_KEY` is set in the same shell and
   belongs to the intended project.
-- **`add_messages` errors about `thread_id`** — user-graph mode with extraction
-  requires both `user_id` and `thread_id`. Standalone graphs use `add()` only.
+- **`extraction=True` / `add_messages` errors about `thread_id`** — user-graph
+  mode with extraction requires both `user_id` and `thread_id` at construction.
+  Standalone graphs must use `extraction=False` and `add()` only.

--- a/integrations/strands/python/SETUP.md
+++ b/integrations/strands/python/SETUP.md
@@ -72,10 +72,15 @@ Mock-based tests (no API keys needed):
 make test
 ```
 
-Live integration test (requires `ZEP_API_KEY`):
+Live integration tests:
 
 ```bash
+# Store round-trip (ZEP_API_KEY only)
+# Full agent lifecycle (also needs OPENAI_API_KEY)
 uv run pytest tests/test_integration.py -v -s -m integration
+
+# Or run the agent lifecycle as a standalone script:
+uv run python tests/test_integration.py
 ```
 
 ## Troubleshooting

--- a/integrations/strands/python/SETUP.md
+++ b/integrations/strands/python/SETUP.md
@@ -1,0 +1,91 @@
+# Setup Guide
+
+This guide walks you from a fresh machine to running the example agent with Zep memory.
+
+## 1. Sign up for Zep and create an API key
+
+1. Go to [https://www.getzep.com](https://www.getzep.com) and create an account.
+2. Open the [Zep dashboard](https://app.getzep.com) and select (or create) a project.
+3. In the project settings, go to **API Keys** and create a new key.
+4. Copy the key — you will set it as `ZEP_API_KEY` below.
+
+Zep is a paid product; see [getzep.com](https://www.getzep.com) for plan details.
+
+## 2. Get an OpenAI API key (for the example)
+
+The integration itself is model-agnostic, but the bundled example and live tests
+drive the agent with OpenAI via `strands-agents[openai]`. Create a key at
+[platform.openai.com/api-keys](https://platform.openai.com/api-keys) and copy it
+for `OPENAI_API_KEY`.
+
+## 3. Install
+
+Using `pip`:
+
+```bash
+pip install zep-strands 'strands-agents[openai]'
+```
+
+Or, to work from the repository with `uv`:
+
+```bash
+git clone https://github.com/getzep/zep.git
+cd zep/integrations/strands/python
+make install        # uv sync --extra dev (includes strands-agents[openai])
+```
+
+Requirements: Python 3.11+, `strands-agents>=1.45.0`, `zep-cloud>=3.23.0`.
+
+## 4. Configure environment variables
+
+```bash
+export ZEP_API_KEY="your-zep-api-key"
+export OPENAI_API_KEY="your-openai-api-key"
+```
+
+## 5. Run the example
+
+From the repository:
+
+```bash
+uv run python examples/basic_agent.py
+```
+
+Or, if you installed with `pip`:
+
+```bash
+python examples/basic_agent.py
+```
+
+The example:
+
+1. Seeds facts about a user across two turns in one thread.
+2. Waits for Zep to process the knowledge graph (ingestion is asynchronous).
+3. Starts a **new** thread for the same user and asks recall questions — the
+   agent answers using facts fused into the user's graph from the first thread.
+
+## 6. Run the tests
+
+Mock-based tests (no API keys needed):
+
+```bash
+make test
+```
+
+Live integration test (requires `ZEP_API_KEY`):
+
+```bash
+uv run pytest tests/test_integration.py -v -s -m integration
+```
+
+## Troubleshooting
+
+- **`ZepDependencyError` on import** — Strands Agents is not installed. Run
+  `pip install zep-strands` (which pulls `strands-agents`).
+- **Recall returns nothing** — Zep ingestion is asynchronous; a just-added fact
+  is not instantly retrievable. The example waits ~20s; increase the wait if
+  your graph is large or under load.
+- **Authentication errors** — confirm `ZEP_API_KEY` is set in the same shell and
+  belongs to the intended project.
+- **`add_messages` errors about `thread_id`** — user-graph mode with extraction
+  requires both `user_id` and `thread_id`. Standalone graphs use `add()` only.

--- a/integrations/strands/python/examples/basic_agent.py
+++ b/integrations/strands/python/examples/basic_agent.py
@@ -26,6 +26,7 @@ from uuid import uuid4
 
 from strands import Agent
 from strands.memory import MemoryManager
+from strands.models.openai import OpenAIModel
 from strands.types.content import Message
 from zep_cloud.client import AsyncZep
 
@@ -49,6 +50,7 @@ def _message_text(message: Message | object) -> str:
 # ---------------------------------------------------------------------------
 ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5-mini")
 
 if not ZEP_API_KEY:
     raise SystemExit("ZEP_API_KEY is not set.")
@@ -85,6 +87,7 @@ async def build_agent(zep: AsyncZep, thread_id: str) -> Agent:
         search_pinned_params={"scope": "auto"},
     )
     return Agent(
+        model=OpenAIModel(client_args={"api_key": OPENAI_API_KEY}, model_id=OPENAI_MODEL),
         system_prompt=(
             "You are a helpful assistant with access to long-term memory. "
             "When memory context is provided, use it to give personalised, "

--- a/integrations/strands/python/examples/basic_agent.py
+++ b/integrations/strands/python/examples/basic_agent.py
@@ -1,15 +1,15 @@
 """
 Basic Strands Agents agent with Zep long-term memory via MemoryManager.
 
-This example wires a ``ZepMemoryStore`` into Strands' ``MemoryManager`` so the
-agent automatically:
+Wires a ``ZepMemoryStore`` into Strands' ``MemoryManager`` so the agent:
 
 * injects relevant Zep context before each model call
-* extracts conversation turns into the user graph (server-side, via
-  ``add_messages``) on the manager's default cadence
+* extracts conversation turns into the user graph (server-side via
+  ``add_messages``) on an every-turn trigger, then ``flush()`` after each
+  ``invoke_async`` so nothing is left buffered
 
-Earlier turns seed facts about the user; a later turn -- in a *new* conversation
-thread -- shows the agent recalling those facts from Zep's user graph.
+Earlier turns seed facts about the user; a later turn on a *new* thread shows
+cross-session recall from Zep's user graph.
 
 Prerequisites:
     pip install zep-strands 'strands-agents[openai]'
@@ -26,27 +26,13 @@ from uuid import uuid4
 
 from strands import Agent
 from strands.memory import MemoryManager
+from strands.memory.extraction.triggers import InvocationTrigger
+from strands.memory.extraction.types import ExtractionConfig
 from strands.types.content import Message
 from zep_cloud.client import AsyncZep
 
 from zep_strands import ZepMemoryStore, ensure_thread, ensure_user
 
-
-def _message_text(message: Message | object) -> str:
-    """Extract joined text blocks from an agent result message."""
-    if not isinstance(message, dict):
-        return str(message)
-    parts = [
-        block["text"]
-        for block in message.get("content") or []
-        if isinstance(block, dict) and "text" in block
-    ]
-    return "\n".join(parts) if parts else str(message)
-
-
-# ---------------------------------------------------------------------------
-# Configuration
-# ---------------------------------------------------------------------------
 ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
 
@@ -59,6 +45,18 @@ _suffix = uuid4().hex[:8]
 USER_ID = f"strands-example-user-{_suffix}"
 THREAD_1 = f"strands-example-thread1-{_suffix}"
 THREAD_2 = f"strands-example-thread2-{_suffix}"
+
+
+def _message_text(message: Message | object) -> str:
+    """Extract joined text blocks from an agent result message."""
+    if not isinstance(message, dict):
+        return str(message)
+    parts = [
+        block["text"]
+        for block in message.get("content") or []
+        if isinstance(block, dict) and "text" in block
+    ]
+    return "\n".join(parts) if parts else str(message)
 
 
 async def build_agent(zep: AsyncZep, thread_id: str) -> Agent:
@@ -80,7 +78,9 @@ async def build_agent(zep: AsyncZep, thread_id: str) -> Agent:
         last_name="Nguyen",
         email="alice@example.com",
         writable=True,
-        extraction=True,
+        # Every-turn extraction so the demo does not wait on the default
+        # 5-turn cadence; still flush after invoke_async (see main).
+        extraction=ExtractionConfig(trigger=InvocationTrigger()),
         expose_search_tool=True,
         search_pinned_params={"scope": "auto"},
     )
@@ -92,6 +92,14 @@ async def build_agent(zep: AsyncZep, thread_id: str) -> Agent:
         ),
         memory_manager=MemoryManager(stores=[store], add_tool_config=True),
     )
+
+
+async def chat(agent: Agent, message: str) -> str:
+    """Send one message and flush pending extraction writes."""
+    result = await agent.invoke_async(message)
+    if agent.memory_manager is not None:
+        await agent.memory_manager.flush()
+    return _message_text(result.message)
 
 
 async def main() -> None:
@@ -107,17 +115,12 @@ async def main() -> None:
 
     print("--- Conversation 1: seeding facts ---\n")
     agent1 = await build_agent(zep, THREAD_1)
-    seed_messages = [
+    for message in (
         "Hi! I'm Alice, a data scientist living in Portland, Oregon.",
         "On weekends I love hiking and landscape photography.",
-    ]
-    for message in seed_messages:
+    ):
         print(f"User:  {message}")
-        result = await agent1.invoke_async(message)
-        # Flush pending extraction writes before moving on.
-        if agent1.memory_manager is not None:
-            await agent1.memory_manager.flush()
-        print(f"Agent: {_message_text(result.message)}\n")
+        print(f"Agent: {await chat(agent1, message)}\n")
 
     wait_seconds = 20
     print(f"--- Waiting {wait_seconds}s for Zep to process the graph ---\n")
@@ -127,8 +130,7 @@ async def main() -> None:
     agent2 = await build_agent(zep, THREAD_2)
     recall = "Where do I live, and what do I like to do on weekends?"
     print(f"User:  {recall}")
-    result = await agent2.invoke_async(recall)
-    print(f"Agent: {_message_text(result.message)}\n")
+    print(f"Agent: {await chat(agent2, recall)}\n")
 
 
 if __name__ == "__main__":

--- a/integrations/strands/python/examples/basic_agent.py
+++ b/integrations/strands/python/examples/basic_agent.py
@@ -43,6 +43,7 @@ def _message_text(message: Message | object) -> str:
     ]
     return "\n".join(parts) if parts else str(message)
 
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -116,8 +117,7 @@ async def main() -> None:
         # Flush pending extraction writes before moving on.
         if agent1.memory_manager is not None:
             await agent1.memory_manager.flush()
-        text = getattr(result, "message", None) or result
-        print(f"Agent: {text}\n")
+        print(f"Agent: {_message_text(result.message)}\n")
 
     wait_seconds = 20
     print(f"--- Waiting {wait_seconds}s for Zep to process the graph ---\n")
@@ -128,8 +128,7 @@ async def main() -> None:
     recall = "Where do I live, and what do I like to do on weekends?"
     print(f"User:  {recall}")
     result = await agent2.invoke_async(recall)
-    text = getattr(result, "message", None) or result
-    print(f"Agent: {text}\n")
+    print(f"Agent: {_message_text(result.message)}\n")
 
 
 if __name__ == "__main__":

--- a/integrations/strands/python/examples/basic_agent.py
+++ b/integrations/strands/python/examples/basic_agent.py
@@ -1,15 +1,15 @@
 """
 Basic Strands Agents agent with Zep long-term memory via MemoryManager.
 
-Wires a ``ZepMemoryStore`` into Strands' ``MemoryManager`` so the agent:
+This example wires a ``ZepMemoryStore`` into Strands' ``MemoryManager`` so the
+agent automatically:
 
 * injects relevant Zep context before each model call
-* extracts conversation turns into the user graph (server-side via
-  ``add_messages``) on an every-turn trigger, then ``flush()`` after each
-  ``invoke_async`` so nothing is left buffered
+* extracts conversation turns into the user graph (server-side, via
+  ``add_messages``) on the manager's default cadence
 
-Earlier turns seed facts about the user; a later turn on a *new* thread shows
-cross-session recall from Zep's user graph.
+Earlier turns seed facts about the user; a later turn -- in a *new* conversation
+thread -- shows the agent recalling those facts from Zep's user graph.
 
 Prerequisites:
     pip install zep-strands 'strands-agents[openai]'
@@ -26,25 +26,10 @@ from uuid import uuid4
 
 from strands import Agent
 from strands.memory import MemoryManager
-from strands.memory.extraction.triggers import InvocationTrigger
-from strands.memory.extraction.types import ExtractionConfig
 from strands.types.content import Message
 from zep_cloud.client import AsyncZep
 
 from zep_strands import ZepMemoryStore, ensure_thread, ensure_user
-
-ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
-OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
-
-if not ZEP_API_KEY:
-    raise SystemExit("ZEP_API_KEY is not set.")
-if not OPENAI_API_KEY:
-    raise SystemExit("OPENAI_API_KEY is not set.")
-
-_suffix = uuid4().hex[:8]
-USER_ID = f"strands-example-user-{_suffix}"
-THREAD_1 = f"strands-example-thread1-{_suffix}"
-THREAD_2 = f"strands-example-thread2-{_suffix}"
 
 
 def _message_text(message: Message | object) -> str:
@@ -57,6 +42,23 @@ def _message_text(message: Message | object) -> str:
         if isinstance(block, dict) and "text" in block
     ]
     return "\n".join(parts) if parts else str(message)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+
+if not ZEP_API_KEY:
+    raise SystemExit("ZEP_API_KEY is not set.")
+if not OPENAI_API_KEY:
+    raise SystemExit("OPENAI_API_KEY is not set.")
+
+_suffix = uuid4().hex[:8]
+USER_ID = f"strands-example-user-{_suffix}"
+THREAD_1 = f"strands-example-thread1-{_suffix}"
+THREAD_2 = f"strands-example-thread2-{_suffix}"
 
 
 async def build_agent(zep: AsyncZep, thread_id: str) -> Agent:
@@ -78,9 +80,7 @@ async def build_agent(zep: AsyncZep, thread_id: str) -> Agent:
         last_name="Nguyen",
         email="alice@example.com",
         writable=True,
-        # Every-turn extraction so the demo does not wait on the default
-        # 5-turn cadence; still flush after invoke_async (see main).
-        extraction=ExtractionConfig(trigger=InvocationTrigger()),
+        extraction=True,
         expose_search_tool=True,
         search_pinned_params={"scope": "auto"},
     )
@@ -92,14 +92,6 @@ async def build_agent(zep: AsyncZep, thread_id: str) -> Agent:
         ),
         memory_manager=MemoryManager(stores=[store], add_tool_config=True),
     )
-
-
-async def chat(agent: Agent, message: str) -> str:
-    """Send one message and flush pending extraction writes."""
-    result = await agent.invoke_async(message)
-    if agent.memory_manager is not None:
-        await agent.memory_manager.flush()
-    return _message_text(result.message)
 
 
 async def main() -> None:
@@ -115,12 +107,19 @@ async def main() -> None:
 
     print("--- Conversation 1: seeding facts ---\n")
     agent1 = await build_agent(zep, THREAD_1)
-    for message in (
+    seed_messages = [
         "Hi! I'm Alice, a data scientist living in Portland, Oregon.",
         "On weekends I love hiking and landscape photography.",
-    ):
+    ]
+    for message in seed_messages:
         print(f"User:  {message}")
-        print(f"Agent: {await chat(agent1, message)}\n")
+        result = await agent1.invoke_async(message)
+        print(f"Agent: {_message_text(result.message)}\n")
+
+    # Flush at the session boundary: invoke_async does not flush, and flushing
+    # every turn would defeat the extraction trigger's schedule.
+    if agent1.memory_manager is not None:
+        await agent1.memory_manager.flush()
 
     wait_seconds = 20
     print(f"--- Waiting {wait_seconds}s for Zep to process the graph ---\n")
@@ -130,7 +129,8 @@ async def main() -> None:
     agent2 = await build_agent(zep, THREAD_2)
     recall = "Where do I live, and what do I like to do on weekends?"
     print(f"User:  {recall}")
-    print(f"Agent: {await chat(agent2, recall)}\n")
+    result = await agent2.invoke_async(recall)
+    print(f"Agent: {_message_text(result.message)}\n")
 
 
 if __name__ == "__main__":

--- a/integrations/strands/python/examples/basic_agent.py
+++ b/integrations/strands/python/examples/basic_agent.py
@@ -26,9 +26,22 @@ from uuid import uuid4
 
 from strands import Agent
 from strands.memory import MemoryManager
+from strands.types.content import Message
 from zep_cloud.client import AsyncZep
 
 from zep_strands import ZepMemoryStore, ensure_thread, ensure_user
+
+
+def _message_text(message: Message | object) -> str:
+    """Extract joined text blocks from an agent result message."""
+    if not isinstance(message, dict):
+        return str(message)
+    parts = [
+        block["text"]
+        for block in message.get("content") or []
+        if isinstance(block, dict) and "text" in block
+    ]
+    return "\n".join(parts) if parts else str(message)
 
 # ---------------------------------------------------------------------------
 # Configuration

--- a/integrations/strands/python/examples/basic_agent.py
+++ b/integrations/strands/python/examples/basic_agent.py
@@ -1,0 +1,123 @@
+"""
+Basic Strands Agents agent with Zep long-term memory via MemoryManager.
+
+This example wires a ``ZepMemoryStore`` into Strands' ``MemoryManager`` so the
+agent automatically:
+
+* injects relevant Zep context before each model call
+* extracts conversation turns into the user graph (server-side, via
+  ``add_messages``) on the manager's default cadence
+
+Earlier turns seed facts about the user; a later turn -- in a *new* conversation
+thread -- shows the agent recalling those facts from Zep's user graph.
+
+Prerequisites:
+    pip install zep-strands 'strands-agents[openai]'
+
+    export ZEP_API_KEY="your-zep-api-key"
+    export OPENAI_API_KEY="your-openai-api-key"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from uuid import uuid4
+
+from strands import Agent
+from strands.memory import MemoryManager
+from zep_cloud.client import AsyncZep
+
+from zep_strands import ZepMemoryStore, ensure_thread, ensure_user
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+
+if not ZEP_API_KEY:
+    raise SystemExit("ZEP_API_KEY is not set.")
+if not OPENAI_API_KEY:
+    raise SystemExit("OPENAI_API_KEY is not set.")
+
+_suffix = uuid4().hex[:8]
+USER_ID = f"strands-example-user-{_suffix}"
+THREAD_1 = f"strands-example-thread1-{_suffix}"
+THREAD_2 = f"strands-example-thread2-{_suffix}"
+
+
+async def build_agent(zep: AsyncZep, thread_id: str) -> Agent:
+    """Build an agent whose memory is scoped to USER_ID on the given thread."""
+    await ensure_user(
+        zep,
+        user_id=USER_ID,
+        first_name="Alice",
+        last_name="Nguyen",
+        email="alice@example.com",
+    )
+    await ensure_thread(zep, thread_id=thread_id, user_id=USER_ID)
+
+    store = ZepMemoryStore(
+        zep_client=zep,
+        user_id=USER_ID,
+        thread_id=thread_id,
+        first_name="Alice",
+        last_name="Nguyen",
+        email="alice@example.com",
+        writable=True,
+        extraction=True,
+        expose_search_tool=True,
+        search_pinned_params={"scope": "auto"},
+    )
+    return Agent(
+        system_prompt=(
+            "You are a helpful assistant with access to long-term memory. "
+            "When memory context is provided, use it to give personalised, "
+            "memory-aware answers. Be concise."
+        ),
+        memory_manager=MemoryManager(stores=[store], add_tool_config=True),
+    )
+
+
+async def main() -> None:
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+
+    print("=" * 64)
+    print("Strands Agents + Zep MemoryStore Example")
+    print("=" * 64)
+    print(f"  User ID:   {USER_ID}")
+    print(f"  Thread 1:  {THREAD_1}")
+    print(f"  Thread 2:  {THREAD_2}")
+    print("=" * 64, "\n")
+
+    print("--- Conversation 1: seeding facts ---\n")
+    agent1 = await build_agent(zep, THREAD_1)
+    seed_messages = [
+        "Hi! I'm Alice, a data scientist living in Portland, Oregon.",
+        "On weekends I love hiking and landscape photography.",
+    ]
+    for message in seed_messages:
+        print(f"User:  {message}")
+        result = await agent1.invoke_async(message)
+        # Flush pending extraction writes before moving on.
+        if agent1.memory_manager is not None:
+            await agent1.memory_manager.flush()
+        text = getattr(result, "message", None) or result
+        print(f"Agent: {text}\n")
+
+    wait_seconds = 20
+    print(f"--- Waiting {wait_seconds}s for Zep to process the graph ---\n")
+    await asyncio.sleep(wait_seconds)
+
+    print("--- Conversation 2: recall in a brand-new thread ---\n")
+    agent2 = await build_agent(zep, THREAD_2)
+    recall = "Where do I live, and what do I like to do on weekends?"
+    print(f"User:  {recall}")
+    result = await agent2.invoke_async(recall)
+    text = getattr(result, "message", None) or result
+    print(f"Agent: {text}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/strands/python/pyproject.toml
+++ b/integrations/strands/python/pyproject.toml
@@ -1,0 +1,90 @@
+[project]
+name = "zep-strands"
+version = "0.1.0"
+description = "Strands Agents memory-store integration for Zep"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "strands-agents>=1.45.0",
+    "zep-cloud>=3.23.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/getzep/zep"
+Documentation = "https://help.getzep.com"
+Repository = "https://github.com/getzep/zep"
+"Bug Tracker" = "https://github.com/getzep/zep/issues"
+Changelog = "https://github.com/getzep/zep/blob/main/integrations/strands/python/CHANGELOG.md"
+
+[project.optional-dependencies]
+# The example and live integration test drive the agent with a model provider;
+# the core package itself depends only on strands-agents (no model provider).
+dev = [
+    "strands-agents[openai]>=1.45.0",
+    "pytest>=7.0.0",
+    "pytest-cov",
+    "pytest-asyncio",
+    "ruff>=0.1.0",
+    "mypy>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/zep_strands"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+asyncio_mode = "strict"
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"
+]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C4", # flake8-comprehensions
+    "UP", # pyupgrade
+]
+ignore = [
+    "E501", # line too long, handled by formatter
+    "B008", # do not perform function calls in argument defaults
+    "C901", # too complex
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["zep_strands"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.mypy]
+python_version = "3.11"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = [
+    "strands.*",
+    "zep_cloud.*",
+]
+ignore_missing_imports = true

--- a/integrations/strands/python/src/zep_strands/__init__.py
+++ b/integrations/strands/python/src/zep_strands/__init__.py
@@ -1,0 +1,78 @@
+"""
+Zep Strands Agents Integration.
+
+This package provides a :class:`~strands.memory.types.MemoryStore` backed by
+`Zep <https://www.getzep.com>`_'s temporal Context Graph, for use with the
+`Strands Agents <https://strandsagents.com>`_ ``MemoryManager``.
+
+Installation::
+
+    pip install zep-strands
+
+Usage::
+
+    from strands import Agent
+    from strands.memory import MemoryManager
+    from zep_cloud.client import AsyncZep
+    from zep_strands import ZepMemoryStore
+
+    zep = AsyncZep(api_key="your-api-key")
+    store = ZepMemoryStore(
+        zep_client=zep,
+        user_id="user-123",
+        thread_id="thread-abc",
+        first_name="Jane",
+        last_name="Smith",
+        writable=True,
+        extraction=True,
+    )
+    agent = Agent(memory_manager=MemoryManager(stores=[store]))
+"""
+
+__version__ = "0.1.0"
+__author__ = "Zep AI"
+__description__ = "Strands Agents memory-store integration for Zep"
+
+from .exceptions import ZepDependencyError
+
+# Guard ONLY the Strands import here. A failure importing the integration's
+# own modules (e.g. a broken ``zep_cloud``) must surface as its own error
+# rather than being mislabeled as a missing Strands dependency.
+try:
+    import strands  # noqa: F401
+except ImportError as e:
+    raise ZepDependencyError(
+        framework="Strands Agents",
+        install_command="pip install zep-strands",
+    ) from e
+
+from .memory_store import (
+    ADD_TYPE_METADATA_KEY,
+    DEFAULT_MAX_SEARCH_RESULTS,
+    DEFAULT_STORE_DESCRIPTION,
+    DEFAULT_STORE_NAME,
+    ZepMemoryStore,
+)
+from .provisioning import UserSetupHook, ensure_thread, ensure_user
+from .search import (
+    Reranker,
+    Scope,
+    ZepSearchTool,
+    create_zep_search_tool,
+)
+
+__all__ = [
+    "ADD_TYPE_METADATA_KEY",
+    "DEFAULT_MAX_SEARCH_RESULTS",
+    "DEFAULT_STORE_DESCRIPTION",
+    "DEFAULT_STORE_NAME",
+    "Reranker",
+    "Scope",
+    "UserSetupHook",
+    "ZepDependencyError",
+    "ZepMemoryStore",
+    "ZepSearchTool",
+    "create_zep_search_tool",
+    "ensure_user",
+    "ensure_thread",
+]

--- a/integrations/strands/python/src/zep_strands/_text.py
+++ b/integrations/strands/python/src/zep_strands/_text.py
@@ -1,0 +1,111 @@
+"""Internal text helpers for safely persisting content to Zep.
+
+Zep enforces hard size limits and returns a ``400 Bad Request`` when they are
+exceeded:
+
+* A single thread message's ``content`` must be at most **4,096** characters
+  (see https://help.getzep.com/adding-messages#message-limits).
+* A single ``graph.add`` payload must be at most **10,000** characters.
+
+This module centralises the size guards so they are not duplicated across the
+store's write paths.  Rather than letting an oversize payload trigger a 400 that
+gets swallowed (silently losing the write), we truncate to a safe ceiling and
+emit a warning.
+
+The warning carries **only** lengths -- never message content or any PII --
+to comply with the repository's logging rules.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+#: Hard per-message content limit enforced by Zep's thread API.
+ZEP_MESSAGE_CONTENT_LIMIT = 4096
+
+#: Truncation ceiling for thread messages.  Kept below the hard 4,096 limit so
+#: there is headroom and the persisted content is comfortably within bounds.
+MESSAGE_TRUNCATE_LIMIT = 4000
+
+#: Hard per-call content limit enforced by Zep's ``graph.add`` API.
+ZEP_GRAPH_DATA_LIMIT = 10_000
+
+#: Truncation ceiling for ``graph.add`` payloads.  Kept below the hard 10,000
+#: limit so there is headroom.
+GRAPH_DATA_TRUNCATE_LIMIT = 9900
+
+
+def truncate_message_content(
+    content: str,
+    *,
+    label: str,
+    limit: int = MESSAGE_TRUNCATE_LIMIT,
+) -> str:
+    """Truncate ``content`` to ``limit`` characters, warning if truncation occurs.
+
+    Zep rejects messages whose content exceeds 4,096 characters with a 400 error.
+    Truncating here keeps the turn within bounds so it is persisted rather than
+    silently lost.
+
+    Args:
+        content: The raw message text.
+        label: A short, non-sensitive identifier for the message kind (e.g.
+            ``"user message"`` or ``"assistant message"``) used only in the log
+            line.  Must not contain content or PII.
+        limit: The maximum number of characters to keep.  Defaults to
+            :data:`MESSAGE_TRUNCATE_LIMIT`.
+
+    Returns:
+        The original content when within ``limit``, otherwise the first
+        ``limit`` characters.
+    """
+    original_length = len(content)
+    if original_length <= limit:
+        return content
+
+    # Log lengths only -- never the content itself (PII / repo rule).
+    logger.warning(
+        "Truncating %s before persisting to Zep: %d chars exceeds limit of %d; "
+        "keeping first %d chars.",
+        label,
+        original_length,
+        limit,
+        limit,
+    )
+    return content[:limit]
+
+
+def truncate_graph_data(
+    content: str,
+    *,
+    label: str = "graph data",
+    limit: int = GRAPH_DATA_TRUNCATE_LIMIT,
+) -> str:
+    """Truncate ``content`` for ``graph.add``, warning if truncation occurs.
+
+    Args:
+        content: The raw graph payload text.
+        label: A short, non-sensitive identifier used only in the log line.
+            Must not contain content or PII.
+        limit: The maximum number of characters to keep.  Defaults to
+            :data:`GRAPH_DATA_TRUNCATE_LIMIT`.
+
+    Returns:
+        The original content when within ``limit``, otherwise the first
+        ``limit`` characters.
+    """
+    original_length = len(content)
+    if original_length <= limit:
+        return content
+
+    logger.warning(
+        "Truncating %s before graph.add to Zep: %d chars exceeds limit of %d; "
+        "keeping first %d chars.",
+        label,
+        original_length,
+        limit,
+        limit,
+    )
+    return content[:limit]

--- a/integrations/strands/python/src/zep_strands/exceptions.py
+++ b/integrations/strands/python/src/zep_strands/exceptions.py
@@ -1,0 +1,10 @@
+"""Exception classes for the Strands Agents integration."""
+
+
+class ZepDependencyError(ImportError):
+    """Raised when required Strands Agents dependencies are not installed."""
+
+    def __init__(self, framework: str, install_command: str):
+        self.framework = framework
+        self.install_command = install_command
+        super().__init__(f"{framework} dependencies not found. Install with: {install_command}")

--- a/integrations/strands/python/src/zep_strands/memory_store.py
+++ b/integrations/strands/python/src/zep_strands/memory_store.py
@@ -9,8 +9,10 @@ other store:
 * :meth:`add_messages` ingests conversation turns for **server-side**
   extraction via ``thread.add_messages`` (user-graph mode)
 * :meth:`add` writes a single text/JSON fact via ``graph.add``
-* :meth:`initialize` provisions the Zep user and thread out-of-band
 * :meth:`get_tools` optionally registers an on-demand graph-search tool
+
+The Zep user and thread are provisioned on the store's first search or write.
+:meth:`initialize` is deliberately inert; see its docstring for why.
 
 When ``extraction`` is enabled (the default in writable user/thread mode),
 Strands' ``MemoryManager`` batches conversation turns and only calls
@@ -413,26 +415,20 @@ class ZepMemoryStore:
     # ------------------------------------------------------------------
 
     async def initialize(self) -> None:
-        """Provision the Zep user and thread when in user-graph mode.
+        """Intentionally performs no Zep calls; provisioning is deferred.
 
-        Called by ``MemoryManager`` during ``init_agent``. Standalone-graph
-        mode is a no-op (the graph must already exist). Genuine provisioning
-        failures propagate so misconfiguration is caught before the agent runs.
+        ``Agent.__init__`` is synchronous, so Strands runs this hook on a
+        throwaway event loop in a worker thread. Issuing Zep calls here would
+        drive the caller's ``AsyncZep`` client from a second event loop, and
+        any connection the caller already opened raises ``RuntimeError: ... is
+        bound to a different event loop``. Provisioning therefore happens on
+        the first search or write, which always runs on the agent's own loop.
+
+        Call :func:`~zep_strands.provisioning.ensure_user` and
+        :func:`~zep_strands.provisioning.ensure_thread` before constructing the
+        agent to provision eagerly instead.
         """
-        if self.graph_id:
-            return
-        assert self.user_id is not None  # validated in __init__
-        await _ensure_user(
-            self._zep,
-            user_id=self.user_id,
-            first_name=self.first_name,
-            last_name=self.last_name,
-            email=self.email,
-            on_created=self.on_user_created,
-        )
-        if self.thread_id:
-            await _ensure_thread(self._zep, thread_id=self.thread_id, user_id=self.user_id)
-        self._resources_ready = True
+        return
 
     async def search(self, query: str, options: SearchOptions | None = None) -> list[MemoryEntry]:
         """Search the Zep graph for entries matching ``query``.
@@ -481,6 +477,8 @@ class ZepMemoryStore:
             search_kwargs["graph_id"] = self.graph_id
         else:
             search_kwargs["user_id"] = self.user_id
+
+        await self._ensure_resources_lazy()
 
         results = await self._zep.graph.search(**search_kwargs)
         return _results_to_entries(results, self.search_scope, limit=limit)
@@ -625,15 +623,26 @@ class ZepMemoryStore:
     # ------------------------------------------------------------------
 
     async def _ensure_resources_lazy(self) -> None:
-        """Ensure user/thread exist; raise on genuine failure.
+        """Provision the Zep user and thread once, on first use.
 
-        ``MemoryManager.initialize`` normally calls :meth:`initialize` first.
-        This lazy path covers programmatic ``add`` / ``add_messages`` calls
-        made without going through the manager.
+        Standalone-graph mode is a no-op (the graph must already exist).
+        Genuine provisioning failures propagate, so misconfiguration surfaces
+        on the first turn rather than being swallowed.
         """
         if self._resources_ready or self.graph_id:
             return
-        await self.initialize()
+        assert self.user_id is not None  # validated in __init__
+        await _ensure_user(
+            self._zep,
+            user_id=self.user_id,
+            first_name=self.first_name,
+            last_name=self.last_name,
+            email=self.email,
+            on_created=self.on_user_created,
+        )
+        if self.thread_id:
+            await _ensure_thread(self._zep, thread_id=self.thread_id, user_id=self.user_id)
+        self._resources_ready = True
 
     def _to_zep_messages(self, messages: list[Message]) -> list[ZepMessage]:
         """Convert Strands messages to Zep ``Message`` objects, dropping empties."""

--- a/integrations/strands/python/src/zep_strands/memory_store.py
+++ b/integrations/strands/python/src/zep_strands/memory_store.py
@@ -54,9 +54,9 @@ from .provisioning import UserSetupHook
 from .provisioning import ensure_thread as _ensure_thread
 from .provisioning import ensure_user as _ensure_user
 from .search import (
+    _AUTO_INCOMPATIBLE_RERANKERS,
     MAX_SEARCH_LIMIT,
     Scope,
-    _AUTO_INCOMPATIBLE_RERANKERS,
     _name_summary_text,
     create_zep_search_tool,
 )

--- a/integrations/strands/python/src/zep_strands/memory_store.py
+++ b/integrations/strands/python/src/zep_strands/memory_store.py
@@ -1,0 +1,562 @@
+"""Zep ``MemoryStore`` for Strands Agents.
+
+:class:`ZepMemoryStore` implements Strands'
+:class:`~strands.memory.types.MemoryStore` Protocol so a Zep user graph (or
+standalone graph) plugs into :class:`~strands.memory.MemoryManager` like any
+other store:
+
+* :meth:`search` recalls relevant knowledge via ``graph.search``
+* :meth:`add_messages` ingests conversation turns for **server-side**
+  extraction via ``thread.add_messages`` (user-graph mode)
+* :meth:`add` writes a single text/JSON fact via ``graph.add``
+* :meth:`initialize` provisions the Zep user and thread out-of-band
+* :meth:`get_tools` optionally registers an on-demand graph-search tool
+
+Attach it through a ``MemoryManager``::
+
+    from strands import Agent
+    from strands.memory import MemoryManager
+    from zep_cloud.client import AsyncZep
+    from zep_strands import ZepMemoryStore
+
+    zep = AsyncZep(api_key="...")
+    store = ZepMemoryStore(
+        zep_client=zep,
+        user_id="user-123",
+        thread_id="thread-abc",
+        first_name="Jane",
+        last_name="Smith",
+        writable=True,
+        extraction=True,  # server-side via add_messages
+    )
+    agent = Agent(memory_manager=MemoryManager(stores=[store]))
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal
+
+from strands.memory.types import (
+    AddMessagesContext,
+    MemoryEntry,
+    Metadata,
+    SearchOptions,
+)
+from strands.types.content import Message
+from strands.types.tools import AgentTool
+from zep_cloud import Message as ZepMessage
+from zep_cloud.client import AsyncZep
+
+from ._text import truncate_graph_data, truncate_message_content
+from .provisioning import UserSetupHook
+from .provisioning import ensure_thread as _ensure_thread
+from .provisioning import ensure_user as _ensure_user
+from .search import (
+    MAX_SEARCH_LIMIT,
+    Scope,
+    _AUTO_INCOMPATIBLE_RERANKERS,
+    _name_summary_text,
+    create_zep_search_tool,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STORE_NAME = "zep"
+DEFAULT_STORE_DESCRIPTION = (
+    "Long-term memory backed by Zep's temporal Context Graph — facts, "
+    "entities, and prior conversations about the user."
+)
+DEFAULT_MAX_SEARCH_RESULTS = 10
+
+#: Metadata key that selects the ``graph.add`` data type for :meth:`ZepMemoryStore.add`.
+#: Values: ``"text"`` (default), ``"json"``, or ``"message"``.
+ADD_TYPE_METADATA_KEY = "type"
+
+GraphAddType = Literal["text", "json", "message"]
+
+
+def _extract_text(message: Message) -> str:
+    """Join text content blocks from a Strands ``Message`` into one string."""
+    parts: list[str] = []
+    for block in message.get("content") or []:
+        text = block.get("text") if isinstance(block, dict) else None
+        if isinstance(text, str) and text.strip():
+            parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def _role_to_zep(role: str) -> str:
+    """Map a Strands message role onto a Zep thread-message role."""
+    normalised = role.lower().strip()
+    if normalised in {"user", "assistant", "system", "tool", "function", "norole"}:
+        return normalised
+    # Strands may emit other roles; keep them as free-text under norole rather
+    # than dropping the turn.
+    return "norole"
+
+
+def _results_to_entries(result: Any, scope: str, *, limit: int) -> list[MemoryEntry]:
+    """Convert a Zep ``graph.search`` response into Strands ``MemoryEntry`` rows.
+
+    For ``scope="auto"``, prefer Zep's assembled Context Block as a single
+    entry (the shape Zep designs for prompt injection). For scoped searches,
+    expand individual edges / nodes / episodes / observations / thread
+    summaries into separate entries so ``MemoryManager`` can cap and format
+    them independently.
+    """
+    if scope == "auto":
+        context = getattr(result, "context", None)
+        if context and str(context).strip():
+            return [MemoryEntry(content=str(context).strip(), metadata={"scope": "auto"})]
+        # Fall through to expand any populated collections when context is empty.
+
+    entries: list[MemoryEntry] = []
+
+    if result.edges:
+        for edge in result.edges:
+            fact = getattr(edge, "fact", None)
+            if fact:
+                entries.append(
+                    MemoryEntry(
+                        content=str(fact),
+                        metadata={
+                            "scope": "edges",
+                            "uuid": getattr(edge, "uuid_", None) or getattr(edge, "uuid", None),
+                        },
+                    )
+                )
+
+    if result.nodes:
+        for node in result.nodes:
+            text = _name_summary_text(getattr(node, "name", None), getattr(node, "summary", None))
+            if text:
+                entries.append(
+                    MemoryEntry(
+                        content=text,
+                        metadata={
+                            "scope": "nodes",
+                            "uuid": getattr(node, "uuid_", None) or getattr(node, "uuid", None),
+                        },
+                    )
+                )
+
+    if result.episodes:
+        for ep in result.episodes:
+            content = getattr(ep, "content", None)
+            if content:
+                entries.append(
+                    MemoryEntry(
+                        content=str(content),
+                        metadata={
+                            "scope": "episodes",
+                            "uuid": getattr(ep, "uuid_", None) or getattr(ep, "uuid", None),
+                        },
+                    )
+                )
+
+    if getattr(result, "observations", None):
+        for obs in result.observations:
+            text = _name_summary_text(getattr(obs, "name", None), getattr(obs, "summary", None))
+            if text:
+                entries.append(
+                    MemoryEntry(
+                        content=text,
+                        metadata={
+                            "scope": "observations",
+                            "uuid": getattr(obs, "uuid_", None) or getattr(obs, "uuid", None),
+                        },
+                    )
+                )
+
+    if getattr(result, "thread_summaries", None):
+        for ts in result.thread_summaries:
+            summary = getattr(ts, "summary", None) or getattr(ts, "name", None)
+            if summary:
+                entries.append(
+                    MemoryEntry(
+                        content=str(summary),
+                        metadata={
+                            "scope": "thread_summaries",
+                            "uuid": getattr(ts, "uuid_", None) or getattr(ts, "uuid", None),
+                        },
+                    )
+                )
+
+    return entries[:limit]
+
+
+class ZepMemoryStore:
+    """Strands :class:`~strands.memory.types.MemoryStore` backed by Zep.
+
+    Two scoping modes:
+
+    * **User graph** (``user_id``, optionally ``thread_id``) — conversational
+      agent memory. ``thread_id`` is required for :meth:`add_messages`
+      (server-side extraction).
+    * **Standalone graph** (``graph_id``) — shared / domain knowledge. Supports
+      :meth:`search` and :meth:`add` only.
+
+    Provide exactly one of ``user_id`` or ``graph_id``.
+
+    Attributes:
+        name: Unique store identifier used by ``MemoryManager`` tools.
+        description: Human-readable summary folded into tool descriptions.
+        max_search_results: Default result cap when a caller omits one.
+        writable: Whether the store accepts writes.
+        extraction: Automatic-extraction config. ``True`` (default when
+            writable + user/thread mode) enables server-side extraction via
+            :meth:`add_messages` on the manager's default cadence.
+    """
+
+    def __init__(
+        self,
+        *,
+        zep_client: AsyncZep,
+        user_id: str | None = None,
+        thread_id: str | None = None,
+        graph_id: str | None = None,
+        name: str = DEFAULT_STORE_NAME,
+        description: str | None = DEFAULT_STORE_DESCRIPTION,
+        max_search_results: int | None = DEFAULT_MAX_SEARCH_RESULTS,
+        writable: bool = True,
+        extraction: Any = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        email: str | None = None,
+        user_message_name: str | None = None,
+        assistant_message_name: str = "Assistant",
+        ignore_roles: list[str] | None = None,
+        on_user_created: UserSetupHook | None = None,
+        search_scope: Scope = "auto",
+        search_reranker: str | None = None,
+        search_filters: dict[str, Any] | None = None,
+        bfs_origin_node_uuids: list[str] | None = None,
+        expose_search_tool: bool = False,
+        search_pinned_params: dict[str, Any] | None = None,
+        search_hidden_params: set[str] | None = None,
+    ) -> None:
+        """Initialise the store.
+
+        Args:
+            zep_client: An initialised ``AsyncZep`` client (caller owns lifecycle).
+            user_id: Zep user ID for user-graph mode.
+            thread_id: Zep thread ID used by :meth:`add_messages`. Required for
+                server-side extraction in user-graph mode.
+            graph_id: Standalone graph ID (mutually exclusive with ``user_id``).
+            name: Store name exposed to ``MemoryManager`` tools.
+            description: Store description exposed to ``MemoryManager`` tools.
+            max_search_results: Default search result cap.
+            writable: Whether writes are accepted.
+            extraction: Extraction config shorthand. Defaults to ``True`` when
+                the store is writable and has a ``thread_id`` (so
+                :meth:`add_messages` can run server-side); otherwise ``None``.
+            first_name: User first name — helps Zep anchor identity.
+            last_name: User last name.
+            email: User email.
+            user_message_name: Display name on persisted user messages.
+                Defaults to the user's full name when available.
+            assistant_message_name: Display name on persisted assistant messages.
+            ignore_roles: Roles to exclude from graph ingestion (still stored in
+                thread history).
+            on_user_created: Async hook run once after a new user is created.
+            search_scope: Default ``graph.search`` scope for :meth:`search`.
+                Defaults to ``"auto"`` (Zep's assembled Context Block).
+            search_reranker: Optional default reranker for :meth:`search`.
+            search_filters: Optional filters applied to every search.
+            bfs_origin_node_uuids: Optional BFS seed node UUIDs for search.
+            expose_search_tool: When ``True``, :meth:`get_tools` returns a
+                model-callable graph-search tool.
+            search_pinned_params: Pin-or-expose config for the search tool.
+            search_hidden_params: Hide search-tool parameters without pinning.
+
+        Raises:
+            ValueError: On invalid scoping (neither/both of ``user_id``/
+                ``graph_id``, empty ``name``, or ``max_search_results < 1``).
+        """
+        if not user_id and not graph_id:
+            raise ValueError("ZepMemoryStore requires either user_id or graph_id")
+        if user_id and graph_id:
+            raise ValueError("ZepMemoryStore accepts only one of user_id or graph_id")
+        if not name.strip():
+            raise ValueError("ZepMemoryStore: name must not be empty")
+        if max_search_results is not None and max_search_results < 1:
+            raise ValueError("ZepMemoryStore: max_search_results must be at least 1")
+
+        self._zep = zep_client
+        self.user_id = user_id
+        self.thread_id = thread_id
+        self.graph_id = graph_id
+
+        self.name = name
+        self.description = description
+        self.max_search_results = max_search_results
+        self.writable = writable
+
+        if extraction is None:
+            # Server-side extraction needs add_messages, which needs a thread.
+            self.extraction = True if (writable and user_id and thread_id) else None
+        else:
+            self.extraction = extraction
+
+        self.first_name = first_name
+        self.last_name = last_name
+        self.email = email
+        self.ignore_roles = ignore_roles
+        self.on_user_created = on_user_created
+        self.assistant_message_name = assistant_message_name
+
+        resolved_user_name: str | None
+        if user_message_name is not None:
+            resolved_user_name = user_message_name
+        else:
+            full = " ".join(part for part in (first_name, last_name) if part)
+            resolved_user_name = full or None
+        self.user_message_name = resolved_user_name
+
+        self.search_scope: Scope = search_scope
+        self.search_reranker = search_reranker
+        self.search_filters = search_filters
+        self.bfs_origin_node_uuids = bfs_origin_node_uuids
+        self.expose_search_tool = expose_search_tool
+        self.search_pinned_params = search_pinned_params
+        self.search_hidden_params = search_hidden_params
+
+        self._resources_ready = False
+
+    # ------------------------------------------------------------------
+    # MemoryStore contract
+    # ------------------------------------------------------------------
+
+    async def initialize(self) -> None:
+        """Provision the Zep user and thread when in user-graph mode.
+
+        Called by ``MemoryManager`` during ``init_agent``. Standalone-graph
+        mode is a no-op (the graph must already exist). Genuine provisioning
+        failures propagate so misconfiguration is caught before the agent runs.
+        """
+        if self.graph_id:
+            return
+        assert self.user_id is not None  # validated in __init__
+        await _ensure_user(
+            self._zep,
+            user_id=self.user_id,
+            first_name=self.first_name,
+            last_name=self.last_name,
+            email=self.email,
+            on_created=self.on_user_created,
+        )
+        if self.thread_id:
+            await _ensure_thread(self._zep, thread_id=self.thread_id, user_id=self.user_id)
+        self._resources_ready = True
+
+    async def search(self, query: str, options: SearchOptions | None = None) -> list[MemoryEntry]:
+        """Search the Zep graph for entries matching ``query``.
+
+        Args:
+            query: The search query text.
+            options: Optional search configuration (``max_search_results``).
+
+        Returns:
+            Matching memory entries ordered by relevance. For
+            ``search_scope="auto"`` this is typically a single entry holding
+            Zep's assembled Context Block.
+
+        Raises:
+            ValueError: If ``options.max_search_results`` is less than 1.
+        """
+        caller_max = options.get("max_search_results") if options is not None else None
+        if caller_max is not None and caller_max < 1:
+            raise ValueError("ZepMemoryStore: max_search_results must be at least 1")
+        limit = caller_max or self.max_search_results or DEFAULT_MAX_SEARCH_RESULTS
+        limit = min(max(limit, 1), MAX_SEARCH_LIMIT)
+
+        if not query or not query.strip():
+            return []
+
+        search_kwargs: dict[str, Any] = {
+            "query": query.strip()[:400],
+            "scope": self.search_scope,
+            "limit": limit,
+        }
+        if self.search_reranker is not None:
+            if self.search_scope == "auto" and self.search_reranker in _AUTO_INCOMPATIBLE_RERANKERS:
+                logger.warning(
+                    "ZepMemoryStore search_reranker %r is invalid for scope='auto'; omitting.",
+                    self.search_reranker,
+                )
+            elif self.search_scope != "auto":
+                search_kwargs["reranker"] = self.search_reranker
+            # auto + compatible reranker: still omit — auto ignores it.
+        if self.search_filters is not None:
+            search_kwargs["search_filters"] = self.search_filters
+        if self.bfs_origin_node_uuids is not None:
+            search_kwargs["bfs_origin_node_uuids"] = self.bfs_origin_node_uuids
+
+        if self.graph_id:
+            search_kwargs["graph_id"] = self.graph_id
+        else:
+            search_kwargs["user_id"] = self.user_id
+
+        results = await self._zep.graph.search(**search_kwargs)
+        return _results_to_entries(results, self.search_scope, limit=limit)
+
+    async def add(self, content: str, metadata: Metadata | None = None) -> Any:
+        """Add a single piece of content to the Zep graph via ``graph.add``.
+
+        Args:
+            content: Text (or JSON string) to ingest.
+            metadata: Optional metadata. Use ``metadata["type"]`` to select the
+                Zep data type (``"text"`` default, ``"json"``, or ``"message"``).
+                Remaining keys are forwarded as episode metadata when present.
+
+        Returns:
+            The Zep episode created by ``graph.add``.
+
+        Raises:
+            ValueError: If the store is not writable or ``content`` is empty.
+        """
+        if not self.writable:
+            raise ValueError(
+                "ZepMemoryStore: store is not writable. Set writable=True to enable add()."
+            )
+        if not content or not str(content).strip():
+            raise ValueError("ZepMemoryStore: content must not be empty")
+
+        meta = dict(metadata or {})
+        raw_type = meta.pop(ADD_TYPE_METADATA_KEY, "text")
+        data_type: GraphAddType
+        if raw_type in ("text", "json", "message"):
+            data_type = raw_type  # type: ignore[assignment]
+        else:
+            raise ValueError(
+                f"ZepMemoryStore: metadata['type'] must be 'text', 'json', or 'message'; "
+                f"got {raw_type!r}"
+            )
+
+        payload = str(content)
+        if data_type == "json" and not isinstance(content, str):
+            payload = json.dumps(content)
+        payload = truncate_graph_data(payload, label="add() content")
+
+        add_kwargs: dict[str, Any] = {"type": data_type, "data": payload}
+        if meta:
+            add_kwargs["metadata"] = meta
+        if self.graph_id:
+            add_kwargs["graph_id"] = self.graph_id
+        else:
+            await self._ensure_resources_lazy()
+            add_kwargs["user_id"] = self.user_id
+
+        return await self._zep.graph.add(**add_kwargs)
+
+    async def add_messages(
+        self, messages: list[Message], context: AddMessagesContext | None = None
+    ) -> Any:
+        """Ingest a batch of conversation messages for server-side extraction.
+
+        Converts Strands messages to Zep thread messages and calls
+        ``thread.add_messages``. Requires user-graph mode with a ``thread_id``.
+
+        Args:
+            messages: Strands conversation messages (role + content blocks).
+            context: Optional manager context (sequence numbers for idempotency;
+                currently unused — Zep deduplicates server-side).
+
+        Returns:
+            The Zep ``add_messages`` response, or ``None`` when there is nothing
+            to persist.
+
+        Raises:
+            ValueError: If the store is not writable, has no ``thread_id``, or
+                is in standalone-graph mode.
+        """
+        del context  # reserved for future idempotency keys
+        if not self.writable:
+            raise ValueError(
+                "ZepMemoryStore: store is not writable. Set writable=True to enable add_messages()."
+            )
+        if self.graph_id or not self.user_id:
+            raise ValueError(
+                "ZepMemoryStore.add_messages requires user-graph mode (user_id); "
+                "standalone graphs use add() instead."
+            )
+        if not self.thread_id:
+            raise ValueError(
+                "ZepMemoryStore.add_messages requires thread_id for conversation ingestion."
+            )
+
+        zep_messages = self._to_zep_messages(messages)
+        if not zep_messages:
+            return None
+
+        await self._ensure_resources_lazy()
+
+        add_kwargs: dict[str, Any] = {
+            "thread_id": self.thread_id,
+            "messages": zep_messages,
+        }
+        if self.ignore_roles:
+            add_kwargs["ignore_roles"] = self.ignore_roles
+
+        return await self._zep.thread.add_messages(**add_kwargs)
+
+    def get_tools(self) -> list[AgentTool]:
+        """Return store-specific tools when ``expose_search_tool`` is enabled."""
+        if not self.expose_search_tool:
+            return []
+        return [
+            create_zep_search_tool(
+                zep_client=self._zep,
+                user_id=self.user_id,
+                graph_id=self.graph_id,
+                search_pinned_params=self.search_pinned_params,
+                search_hidden_params=self.search_hidden_params,
+                search_filters=self.search_filters,
+                bfs_origin_node_uuids=self.bfs_origin_node_uuids,
+            )
+        ]
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _ensure_resources_lazy(self) -> None:
+        """Ensure user/thread exist; raise on genuine failure.
+
+        ``MemoryManager.initialize`` normally calls :meth:`initialize` first.
+        This lazy path covers programmatic ``add`` / ``add_messages`` calls
+        made without going through the manager.
+        """
+        if self._resources_ready or self.graph_id:
+            return
+        await self.initialize()
+
+    def _to_zep_messages(self, messages: list[Message]) -> list[ZepMessage]:
+        """Convert Strands messages to Zep ``Message`` objects, dropping empties."""
+        converted: list[ZepMessage] = []
+        for message in messages:
+            role = _role_to_zep(str(message.get("role", "norole")))
+            text = _extract_text(message)
+            if not text:
+                continue
+            text = truncate_message_content(text, label=f"{role} message")
+            name: str | None = None
+            if role == "user":
+                name = self.user_message_name
+            elif role == "assistant":
+                name = self.assistant_message_name
+            converted.append(ZepMessage(role=role, content=text, name=name))
+        return converted
+
+
+# Re-export helpers used by tests / advanced callers.
+__all__ = [
+    "ADD_TYPE_METADATA_KEY",
+    "DEFAULT_MAX_SEARCH_RESULTS",
+    "DEFAULT_STORE_DESCRIPTION",
+    "DEFAULT_STORE_NAME",
+    "ZepMemoryStore",
+    "_results_to_entries",
+]

--- a/integrations/strands/python/src/zep_strands/memory_store.py
+++ b/integrations/strands/python/src/zep_strands/memory_store.py
@@ -12,6 +12,13 @@ other store:
 * :meth:`initialize` provisions the Zep user and thread out-of-band
 * :meth:`get_tools` optionally registers an on-demand graph-search tool
 
+When ``extraction`` is enabled (the default in writable user/thread mode),
+Strands' ``MemoryManager`` batches conversation turns and only calls
+:meth:`add_messages` on its default cadence — **every 5 turns**. Until that
+flush (or an explicit ``memory_manager.flush()``), nothing has been sent to
+Zep, so the graph builds later than turn-by-turn persistence would. After
+messages do reach Zep, ingestion is still asynchronous.
+
 Attach it through a ``MemoryManager``::
 
     from strands import Agent
@@ -27,7 +34,7 @@ Attach it through a ``MemoryManager``::
         first_name="Jane",
         last_name="Smith",
         writable=True,
-        extraction=True,  # server-side via add_messages
+        extraction=True,  # server-side via add_messages; default cadence = every 5 turns
     )
     agent = Agent(memory_manager=MemoryManager(stores=[store]))
 """
@@ -75,6 +82,39 @@ DEFAULT_MAX_SEARCH_RESULTS = 10
 ADD_TYPE_METADATA_KEY = "type"
 
 GraphAddType = Literal["text", "json", "message"]
+
+
+def _extraction_enabled(extraction: Any) -> bool:
+    """Return whether ``extraction`` enables automatic extraction.
+
+    ``None`` / ``False`` are off; ``True`` or an ``ExtractionConfig`` are on.
+    """
+    return extraction is not None and extraction is not False
+
+
+def _require_extraction_support(
+    *,
+    writable: bool,
+    user_id: str | None,
+    thread_id: str | None,
+) -> None:
+    """Raise if extraction is enabled without a writable user/thread store.
+
+    Server-side extraction is implemented via :meth:`ZepMemoryStore.add_messages`,
+    which requires a Zep user thread. Fail at construction so ``MemoryManager``
+    never schedules extraction that would raise on every cycle.
+    """
+    if not writable:
+        raise ValueError(
+            "ZepMemoryStore: extraction requires writable=True "
+            "(server-side extraction writes via add_messages)."
+        )
+    if not user_id or not thread_id:
+        raise ValueError(
+            "ZepMemoryStore: extraction requires user-graph mode with both "
+            "user_id and thread_id (server-side via add_messages). "
+            "Pass extraction=False for standalone graphs or stores without a thread."
+        )
 
 
 def _extract_text(message: Message) -> str:
@@ -207,7 +247,8 @@ class ZepMemoryStore:
         writable: Whether the store accepts writes.
         extraction: Automatic-extraction config. ``True`` (default when
             writable + user/thread mode) enables server-side extraction via
-            :meth:`add_messages` on the manager's default cadence.
+            :meth:`add_messages` on the manager's default cadence (every 5
+            turns). Requires ``user_id`` and ``thread_id``.
     """
 
     def __init__(
@@ -252,6 +293,13 @@ class ZepMemoryStore:
             extraction: Extraction config shorthand. Defaults to ``True`` when
                 the store is writable and has a ``thread_id`` (so
                 :meth:`add_messages` can run server-side); otherwise ``None``.
+                ``True`` (or an ``ExtractionConfig``) requires writable
+                user-graph mode with ``user_id`` **and** ``thread_id`` —
+                construction fails fast otherwise. With Strands' default
+                trigger, extraction only fires every **5 turns**, so graph
+                building is delayed relative to turn-by-turn persistence;
+                call ``memory_manager.flush()`` (or use an every-turn
+                trigger) when you need messages sent to Zep sooner.
             first_name: User first name — helps Zep anchor identity.
             last_name: User last name.
             email: User email.
@@ -273,7 +321,8 @@ class ZepMemoryStore:
 
         Raises:
             ValueError: On invalid scoping (neither/both of ``user_id``/
-                ``graph_id``, empty ``name``, or ``max_search_results < 1``).
+                ``graph_id``, empty ``name``, ``max_search_results < 1``, or
+                extraction enabled without writable user/thread mode).
         """
         if not user_id and not graph_id:
             raise ValueError("ZepMemoryStore requires either user_id or graph_id")
@@ -298,6 +347,12 @@ class ZepMemoryStore:
             # Server-side extraction needs add_messages, which needs a thread.
             self.extraction = True if (writable and user_id and thread_id) else None
         else:
+            if _extraction_enabled(extraction):
+                _require_extraction_support(
+                    writable=writable,
+                    user_id=user_id,
+                    thread_id=thread_id,
+                )
             self.extraction = extraction
 
         self.first_name = first_name

--- a/integrations/strands/python/src/zep_strands/memory_store.py
+++ b/integrations/strands/python/src/zep_strands/memory_store.py
@@ -19,6 +19,30 @@ flush (or an explicit ``memory_manager.flush()``), nothing has been sent to
 Zep, so the graph builds later than turn-by-turn persistence would. After
 messages do reach Zep, ingestion is still asynchronous.
 
+Failure-handling contract
+-------------------------
+
+**Zep SDK errors propagate out of the store methods on purpose. Do not wrap
+them in ``try``/``except`` that returns an empty or ``None`` fallback** — in
+Strands the *framework* owns failure isolation, and swallowing breaks it:
+
+* :meth:`search` — ``MemoryManager.search`` gathers stores with
+  ``return_exceptions=True``, logs a failing store and skips it; context
+  injection additionally fails open. A Zep outage already degrades the turn to
+  a memoryless one without crashing the agent.
+* :meth:`add` — ``MemoryManager.add`` collects per-store failures into an
+  ``AggregateMemoryError`` specifically so a failed write is never silent.
+* :meth:`add_messages` — ``ExtractionCoordinator`` catches store exceptions
+  ("saving must never break the agent loop") and **rolls its per-store
+  high-water mark back so the batch retries**. Returning ``None`` after
+  swallowing an error would be read as success, advancing the mark and
+  discarding that batch permanently.
+
+This mirrors the SDK's own vended stores (``TestMemoryStore``,
+``BedrockKnowledgeBaseStore``), which raise rather than degrade. The one place
+this integration *does* swallow is the model-callable ``zep_search`` tool,
+which returns an error string — a raw tool has no framework layer above it.
+
 Attach it through a ``MemoryManager``::
 
     from strands import Agent
@@ -56,7 +80,11 @@ from strands.types.tools import AgentTool
 from zep_cloud import Message as ZepMessage
 from zep_cloud.client import AsyncZep
 
-from ._text import truncate_graph_data, truncate_message_content
+from ._text import (
+    GRAPH_DATA_TRUNCATE_LIMIT,
+    truncate_graph_data,
+    truncate_message_content,
+)
 from .provisioning import UserSetupHook
 from .provisioning import ensure_thread as _ensure_thread
 from .provisioning import ensure_user as _ensure_user
@@ -460,6 +488,14 @@ class ZepMemoryStore:
     async def add(self, content: str, metadata: Metadata | None = None) -> Any:
         """Add a single piece of content to the Zep graph via ``graph.add``.
 
+        ``text`` and ``message`` payloads over Zep's size limit are truncated
+        with a warning. ``json`` payloads are **not** truncated -- slicing JSON
+        strips its closing syntax and Zep would reject the result -- so an
+        oversize JSON document raises instead; split it before adding.
+
+        A Zep failure propagates to the caller by design; see the module
+        docstring for the failure-handling contract.
+
         Args:
             content: Text (or JSON string) to ingest.
             metadata: Optional metadata. Use ``metadata["type"]`` to select the
@@ -470,7 +506,8 @@ class ZepMemoryStore:
             The Zep episode created by ``graph.add``.
 
         Raises:
-            ValueError: If the store is not writable or ``content`` is empty.
+            ValueError: If the store is not writable, ``content`` is empty, or
+                a ``json`` payload exceeds the ``graph.add`` size limit.
         """
         if not self.writable:
             raise ValueError(
@@ -490,10 +527,20 @@ class ZepMemoryStore:
                 f"got {raw_type!r}"
             )
 
-        payload = str(content)
-        if data_type == "json" and not isinstance(content, str):
-            payload = json.dumps(content)
-        payload = truncate_graph_data(payload, label="add() content")
+        if data_type == "json":
+            payload = content if isinstance(content, str) else json.dumps(content)
+            # Truncating JSON would strip closing syntax and produce a payload Zep
+            # rejects, so the "guard" would guarantee a failed write. Structure-aware
+            # splitting needs the caller's schema knowledge -- surface it instead.
+            if len(payload) > GRAPH_DATA_TRUNCATE_LIMIT:
+                raise ValueError(
+                    f"ZepMemoryStore: JSON content is {len(payload)} characters, exceeding the "
+                    f"{GRAPH_DATA_TRUNCATE_LIMIT}-character graph.add limit. JSON cannot be "
+                    "truncated safely; split it into smaller documents before adding. See "
+                    "https://help.getzep.com/chunking-large-documents"
+                )
+        else:
+            payload = truncate_graph_data(str(content), label="add() content")
 
         add_kwargs: dict[str, Any] = {"type": data_type, "data": payload}
         if meta:

--- a/integrations/strands/python/src/zep_strands/provisioning.py
+++ b/integrations/strands/python/src/zep_strands/provisioning.py
@@ -1,0 +1,166 @@
+"""
+Explicit, out-of-band Zep resource provisioning.
+
+``ZepContextProvider``'s lazy call into these helpers (see
+``ZepContextProvider._ensure_resources``) is hot-path-wrapped and will never
+raise into an agent run. Callers who want provisioning failures (and
+``on_created`` hook failures) to surface loudly -- e.g. during account/session
+onboarding, before the first turn -- should call :func:`ensure_user` and
+:func:`ensure_thread` directly, out-of-band.
+
+Both helpers are **create-then-catch-conflict**: they call the Zep SDK's
+create method directly and treat an "already exists" error as success, rather
+than checking for existence first (which is racy and costs an extra
+round-trip). Genuine failures (auth, network, 5xx) always raise -- out-of-band
+provisioning is meant to fail loudly so misconfiguration is caught before the
+agent ever runs, not swallowed into a silent no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from zep_cloud.client import AsyncZep
+
+logger = logging.getLogger(__name__)
+
+#: Type alias for a user-setup hook that runs once after a Zep user is created.
+#:
+#: Receives the Zep client and the newly created user ID.  Use this to configure
+#: per-user ontology, custom instructions, or user summary instructions.
+UserSetupHook = Callable[[AsyncZep, str], Awaitable[None]]
+
+
+def _is_already_exists_error(exc: Exception) -> bool:
+    """Detect whether ``exc`` represents a "resource already exists" conflict.
+
+    Handles both typed and message-based shapes returned by the Zep SDK:
+
+    * A 409 status code (``zep_cloud.errors.ConflictError``, or any
+      ``ApiError``-like object exposing ``status_code == 409``).
+    * A 400 ``BadRequestError`` (or similar) whose message mentions
+      "already exists".
+    * An **untyped** exception (no ``status_code``) whose string
+      representation mentions "already exists" or "conflict" (fallback for
+      untyped/legacy error shapes).
+
+    A plain 404 (not found) or any other genuine failure is **not** treated
+    as an already-exists conflict.  In particular, a typed error with any
+    other status code (e.g. a 500 whose message happens to mention
+    "conflict") is a genuine failure and must propagate.
+    """
+    status_code: Any = getattr(exc, "status_code", None)
+    if status_code == 409:
+        return True
+
+    text = str(exc).lower()
+    if status_code == 400 and "already exists" in text:
+        return True
+
+    # Fallback heuristic for untyped/legacy error shapes only: an error that
+    # carries a known non-conflict status code is a genuine failure, no
+    # matter what its message says.
+    if status_code is not None:
+        return False
+    return "already exists" in text or "conflict" in text
+
+
+async def ensure_user(
+    client: AsyncZep,
+    *,
+    user_id: str,
+    first_name: str | None = None,
+    last_name: str | None = None,
+    email: str | None = None,
+    on_created: UserSetupHook | None = None,
+) -> bool:
+    """Idempotently ensure the Zep user exists.
+
+    Calls ``client.user.add(...)`` directly (create-then-catch-conflict).  If
+    the call fails with an "already exists" conflict, the user is assumed to
+    already be provisioned and the call returns ``False`` without raising.
+    Any other failure (auth, network, 5xx) propagates to the caller -- this
+    function never swallows genuine errors.
+
+    When the user is newly created and ``on_created`` is provided, the hook is
+    awaited (with ``(client, user_id)``) **before** this function returns.  If
+    the hook raises, the exception propagates to the caller even though the
+    user was successfully created.  A later ``ensure_user`` call will **not**
+    re-run the hook -- the user now exists, so it takes the already-exists
+    path.  To recover from a hook failure, re-run the hook logic directly
+    against the user (make it idempotent, i.e. safe to run against a user
+    whose setup only partially completed).
+
+    Args:
+        client: An initialised ``AsyncZep`` client.
+        user_id: The Zep user ID to create.
+        first_name: Optional first name, passed through to ``user.add``.
+        last_name: Optional last name, passed through to ``user.add``.
+        email: Optional email, passed through to ``user.add``.
+        on_created: Optional async hook run exactly once, only when the user
+            is newly created.
+
+    Returns:
+        ``True`` if the user was newly created, ``False`` if it already
+        existed.
+
+    Raises:
+        Exception: Any genuine failure from the Zep SDK (auth, network, 5xx),
+            or any exception raised by ``on_created``.
+    """
+    try:
+        await client.user.add(
+            user_id=user_id,
+            first_name=first_name,
+            last_name=last_name,
+            email=email,
+        )
+    except Exception as exc:
+        if _is_already_exists_error(exc):
+            logger.debug("Zep user %s already exists", user_id)
+            return False
+        raise
+
+    logger.info("Created Zep user: %s", user_id)
+
+    if on_created is not None:
+        await on_created(client, user_id)
+        logger.info("on_created hook completed for user %s", user_id)
+
+    return True
+
+
+async def ensure_thread(client: AsyncZep, *, thread_id: str, user_id: str) -> bool:
+    """Idempotently ensure the Zep thread exists.
+
+    Calls ``client.thread.create(...)`` directly (create-then-catch-conflict).
+    If the call fails with an "already exists" conflict, the thread is
+    assumed to already be provisioned and the call returns ``False`` without
+    raising.  Any other failure (auth, network, 5xx) propagates to the
+    caller.
+
+    Args:
+        client: An initialised ``AsyncZep`` client.
+        thread_id: The Zep thread ID to create.
+        user_id: The Zep user ID that owns the thread.  The user must already
+            exist (see :func:`ensure_user`).
+
+    Returns:
+        ``True`` if the thread was newly created, ``False`` if it already
+        existed.
+
+    Raises:
+        Exception: Any genuine failure from the Zep SDK (auth, network, 5xx).
+    """
+    try:
+        await client.thread.create(thread_id=thread_id, user_id=user_id)
+    except Exception as exc:
+        if _is_already_exists_error(exc):
+            logger.debug("Zep thread %s already exists", thread_id)
+            return False
+        raise
+
+    logger.info("Created Zep thread: %s", thread_id)
+    return True

--- a/integrations/strands/python/src/zep_strands/provisioning.py
+++ b/integrations/strands/python/src/zep_strands/provisioning.py
@@ -1,9 +1,9 @@
 """
 Explicit, out-of-band Zep resource provisioning.
 
-``ZepContextProvider``'s lazy call into these helpers (see
-``ZepContextProvider._ensure_resources``) is hot-path-wrapped and will never
-raise into an agent run. Callers who want provisioning failures (and
+``ZepMemoryStore.initialize`` (and its lazy ``_ensure_resources_lazy`` path)
+calls these helpers on the hot path and is wrapped so a Zep outage never
+raises into an agent turn. Callers who want provisioning failures (and
 ``on_created`` hook failures) to surface loudly -- e.g. during account/session
 onboarding, before the first turn -- should call :func:`ensure_user` and
 :func:`ensure_thread` directly, out-of-band.

--- a/integrations/strands/python/src/zep_strands/provisioning.py
+++ b/integrations/strands/python/src/zep_strands/provisioning.py
@@ -1,12 +1,11 @@
 """
 Explicit, out-of-band Zep resource provisioning.
 
-``ZepMemoryStore.initialize`` (and its lazy ``_ensure_resources_lazy`` path)
-calls these helpers on the hot path and is wrapped so a Zep outage never
-raises into an agent turn. Callers who want provisioning failures (and
-``on_created`` hook failures) to surface loudly -- e.g. during account/session
-onboarding, before the first turn -- should call :func:`ensure_user` and
-:func:`ensure_thread` directly, out-of-band.
+``ZepMemoryStore`` calls these helpers itself on its first search or write.
+Callers who want provisioning failures (and ``on_created`` hook failures) to
+surface loudly -- e.g. during account/session onboarding, before the first
+turn -- should call :func:`ensure_user` and :func:`ensure_thread` directly,
+out-of-band.
 
 Both helpers are **create-then-catch-conflict**: they call the Zep SDK's
 create method directly and treat an "already exists" error as success, rather

--- a/integrations/strands/python/src/zep_strands/search.py
+++ b/integrations/strands/python/src/zep_strands/search.py
@@ -353,8 +353,17 @@ def create_zep_search_tool(
         try:
             results = await zep_client.graph.search(**search_kwargs)
         except Exception as exc:
-            logger.warning("Zep graph search failed: %s", exc, exc_info=True)
-            return f"Graph search failed: {exc}"
+            status = getattr(exc, "status_code", None)
+            if status is not None:
+                logger.warning(
+                    "Zep graph search failed type=%s status=%s",
+                    type(exc).__name__,
+                    status,
+                )
+            else:
+                logger.warning("Zep graph search failed type=%s", type(exc).__name__)
+            logger.debug("Zep graph search failed", exc_info=True)
+            return "Graph search failed."
 
         return _format_results(results, str(effective_scope))
 

--- a/integrations/strands/python/src/zep_strands/search.py
+++ b/integrations/strands/python/src/zep_strands/search.py
@@ -1,0 +1,369 @@
+"""A Strands Agents tool for searching a Zep knowledge graph on demand.
+
+:class:`~zep_strands.memory_store.ZepMemoryStore` injects recalled context via
+the ``MemoryManager`` search/injection path.  This module provides the
+complementary *pull* path: a model-callable tool that lets the agent decide
+when to search the graph for specific facts, entities, or prior episodes.
+
+:func:`create_zep_search_tool` returns a Strands ``@tool``-decorated
+:class:`~strands.types.tools.AgentTool`.  Strands derives the tool schema from
+the wrapped function's typed signature (there is no raw-JSON-schema
+constructor), so pin-or-expose works by *dynamically building the wrapped
+function's signature*: exposed parameters become real, typed parameters of
+the function Strands introspects, while pinned/hidden parameters are never
+parameters of the function at all -- they are merged in as constants (or
+omitted) when the tool actually calls ``graph.search``.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Annotated, Any, Literal
+
+from strands import tool
+from strands.types.tools import AgentTool
+from zep_cloud.client import AsyncZep
+
+logger = logging.getLogger(__name__)
+
+Scope = Literal[
+    "edges",
+    "nodes",
+    "episodes",
+    "observations",
+    "thread_summaries",
+    "auto",
+]
+Reranker = Literal["rrf", "mmr", "node_distance", "episode_mentions", "cross_encoder"]
+
+#: Zep caps ``graph.search`` ``limit`` at 50; larger values are rejected.
+MAX_SEARCH_LIMIT = 50
+
+#: Rerankers Zep rejects when ``scope == "auto"`` (auto always uses RRF
+#: retrieval and applies its own internal cross-scope rerank).
+_AUTO_INCOMPATIBLE_RERANKERS = ("node_distance", "episode_mentions")
+
+#: The type of tool ``create_zep_search_tool`` returns.
+ZepSearchTool = AgentTool
+
+# ---------------------------------------------------------------------------
+# Parameter definitions
+# ---------------------------------------------------------------------------
+# Each entry describes a graph.search parameter that can be pinned or exposed
+# to the model.  Keys match the Zep SDK's ``graph.search()`` kwargs.  Model-
+# exposed by default; hidden only when pinned or explicitly listed in
+# ``search_hidden_params``. ``annotation`` is the real typed annotation used
+# to build the dynamic function signature Strands introspects.
+
+_SEARCH_PARAM_SPECS: dict[str, dict[str, Any]] = {
+    "scope": {
+        "annotation": Scope,
+        "description": (
+            "What to search for: 'edges' for facts and relationships, "
+            "'nodes' for entities and their summaries, "
+            "'episodes' for raw text data (unstructured text, messages, or JSON), "
+            "'observations' for derived memories, "
+            "'thread_summaries' for incremental thread summaries, "
+            "'auto' to let Zep decide the best mix of results."
+        ),
+        "default": "edges",
+    },
+    "reranker": {
+        "annotation": Reranker,
+        "description": (
+            "Result ordering algorithm: 'rrf' (balanced), 'mmr' (diverse), "
+            "'cross_encoder' (highest accuracy), 'episode_mentions' "
+            "(frequently referenced), 'node_distance' (near a specific entity)."
+        ),
+        "default": "rrf",
+    },
+    "limit": {
+        "annotation": int,
+        "description": "Maximum number of results to return.",
+        "default": 10,
+    },
+    "mmr_lambda": {
+        "annotation": float | None,
+        "description": (
+            "Balance between diversity (0.0) and relevance (1.0). Only used when reranker is 'mmr'."
+        ),
+        "default": None,
+    },
+    "center_node_uuid": {
+        "annotation": str | None,
+        "description": (
+            "UUID of the center node for distance-based reranking. "
+            "Required when reranker is 'node_distance'."
+        ),
+        "default": None,
+    },
+}
+
+#: Parameters that are always constructor-only (complex types not suitable for
+#: model schema generation).
+_CONSTRUCTOR_ONLY_PARAMS = frozenset({"search_filters", "bfs_origin_node_uuids"})
+
+#: All parameters that may be pinned or hidden at construction.
+_PINNABLE_PARAMS = frozenset(_SEARCH_PARAM_SPECS.keys())
+
+
+def _name_summary_text(name: str | None, summary: str | None) -> str:
+    """Join a name and summary as ``"name: summary"``, falling back gracefully."""
+    if name and summary:
+        return f"{name}: {summary}"
+    if name:
+        return name
+    if summary:
+        return summary
+    return ""
+
+
+def _format_results(result: Any, scope: str) -> str:
+    """Render Zep search results as readable text for the model."""
+    if scope == "auto":
+        context = getattr(result, "context", None)
+        if context and str(context).strip():
+            return str(context).strip()
+        return "No results found."
+
+    parts: list[str] = []
+    if scope == "edges" and result.edges:
+        parts = [f"- {edge.fact}" for edge in result.edges if edge.fact]
+    elif scope == "nodes" and result.nodes:
+        for node in result.nodes:
+            text = _name_summary_text(getattr(node, "name", None), getattr(node, "summary", None))
+            if text:
+                parts.append(f"- {text}")
+    elif scope == "episodes" and result.episodes:
+        parts = [f"- {ep.content}" for ep in result.episodes if ep.content]
+    elif scope == "observations" and result.observations:
+        for obs in result.observations:
+            text = _name_summary_text(getattr(obs, "name", None), getattr(obs, "summary", None))
+            if text:
+                parts.append(f"- {text}")
+    elif scope == "thread_summaries" and result.thread_summaries:
+        for ts in result.thread_summaries:
+            summary = getattr(ts, "summary", None)
+            summary_text = summary or getattr(ts, "name", None)
+            if summary_text:
+                parts.append(f"- {summary_text}")
+
+    return "\n".join(parts) if parts else "No results found."
+
+
+def _build_search_signature(
+    exposed: dict[str, dict[str, Any]],
+) -> tuple[inspect.Signature, dict[str, Any]]:
+    """Build the typed signature Strands ``@tool`` will introspect.
+
+    ``query`` is always present and required; ``exposed`` params (those not
+    pinned or hidden) become real, defaulted parameters annotated with
+    ``Annotated[<type>, <description>]`` so schema generation picks up both
+    the type/enum and the description.
+    """
+    params: list[inspect.Parameter] = [
+        inspect.Parameter(
+            "query",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            annotation=Annotated[str, "Search query text (max 400 characters)."],
+        )
+    ]
+    for name, spec in exposed.items():
+        base_type = spec["annotation"]
+        param_description = spec["description"]
+        params.append(
+            inspect.Parameter(
+                name,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=spec["default"],
+                annotation=Annotated[base_type, param_description],
+            )
+        )
+    signature = inspect.Signature(params)
+    annotations = {p.name: p.annotation for p in params}
+    return signature, annotations
+
+
+def create_zep_search_tool(
+    *,
+    zep_client: AsyncZep,
+    user_id: str | None = None,
+    graph_id: str | None = None,
+    search_pinned_params: dict[str, Any] | None = None,
+    search_hidden_params: set[str] | None = None,
+    search_filters: dict[str, Any] | None = None,
+    bfs_origin_node_uuids: list[str] | None = None,
+    name: str = "zep_search",
+    description: str = (
+        "Search the knowledge graph for facts, entities, or prior context. "
+        "Use this to look up specific details the user has shared before, or "
+        "domain knowledge stored in the graph."
+    ),
+) -> ZepSearchTool:
+    """Build a Strands tool that searches a Zep knowledge graph.
+
+    Register the returned tool with an agent, or return it from
+    :meth:`~zep_strands.memory_store.ZepMemoryStore.get_tools`::
+
+        from zep_strands import create_zep_search_tool
+
+        tool = create_zep_search_tool(zep_client=zep, user_id="user-123")
+        agent = Agent(tools=[tool])
+
+    By default the tool searches the **given user's** graph (``user_id``
+    fixed at construction time). Pass ``graph_id`` to target a shared
+    standalone graph instead; provide exactly one of ``user_id`` / ``graph_id``.
+
+    **Pin-or-expose.** Every ``graph.search`` parameter (``scope``,
+    ``reranker``, ``limit``, ``mmr_lambda``, ``center_node_uuid``) is exposed
+    to the model in the tool's schema by default. Use
+    ``search_pinned_params`` to fix a parameter to a constant value and remove
+    it from the schema; use ``search_hidden_params`` to remove a parameter
+    without pinning it -- Zep's own server-side default applies.
+
+    ``search_filters`` and ``bfs_origin_node_uuids`` are always
+    constructor-only.
+
+    Args:
+        zep_client: An initialised ``AsyncZep`` client.
+        user_id: The Zep user ID whose graph is searched. Required unless
+            ``graph_id`` is set.
+        graph_id: Optional standalone graph ID. When set, all searches target
+            this graph; mutually exclusive with ``user_id``.
+        search_pinned_params: Optional mapping of ``graph.search`` parameter
+            name to a fixed value. Pinned parameters are hidden from the
+            model's tool schema and always sent with the given value.
+        search_hidden_params: Optional set of ``graph.search`` parameter
+            names to hide from the model's tool schema without pinning them.
+        search_filters: Optional Zep search filters (constructor-only).
+        bfs_origin_node_uuids: Optional list of node UUIDs for BFS seeding
+            (constructor-only).
+        name: The tool name exposed to the model. Defaults to ``"zep_search"``.
+        description: The tool description exposed to the model.
+
+    Returns:
+        A Strands ``AgentTool``. Calling it executes ``graph.search`` with
+        pinned/model-provided/default parameters merged; Zep failures are
+        caught and returned as an error string -- the tool never raises.
+
+    Raises:
+        ValueError: If neither or both of ``user_id``/``graph_id`` are
+            provided, or ``search_pinned_params``/``search_hidden_params``
+            contains an unknown parameter name.
+    """
+    if not user_id and not graph_id:
+        raise ValueError("Either user_id or graph_id must be provided when creating the tool")
+    if user_id and graph_id:
+        raise ValueError(
+            "Only one of user_id or graph_id should be provided when creating the tool"
+        )
+
+    pinned: dict[str, Any] = dict(search_pinned_params or {})
+    hidden: set[str] = set(search_hidden_params or ())
+
+    unknown_pinned = set(pinned.keys()) - _PINNABLE_PARAMS
+    if unknown_pinned:
+        raise ValueError(
+            f"Unknown pinned parameters: {unknown_pinned}. Allowed: {sorted(_PINNABLE_PARAMS)}"
+        )
+    unknown_hidden = hidden - _PINNABLE_PARAMS
+    if unknown_hidden:
+        raise ValueError(
+            f"Unknown hidden parameters: {unknown_hidden}. Allowed: {sorted(_PINNABLE_PARAMS)}"
+        )
+
+    if "limit" in pinned:
+        pinned_limit = pinned["limit"]
+        if pinned_limit > MAX_SEARCH_LIMIT:
+            logger.warning(
+                "zep_search limit %d exceeds Zep ceiling %d; clamping to %d",
+                pinned_limit,
+                MAX_SEARCH_LIMIT,
+                MAX_SEARCH_LIMIT,
+            )
+            pinned["limit"] = MAX_SEARCH_LIMIT
+        elif pinned_limit < 1:
+            pinned["limit"] = 1
+
+    if pinned.get("scope") == "auto" and "reranker" in pinned:
+        if pinned["reranker"] in _AUTO_INCOMPATIBLE_RERANKERS:
+            logger.warning(
+                "zep_search reranker %r is invalid for scope='auto'; "
+                "omitting reranker (auto search uses RRF).",
+                pinned["reranker"],
+            )
+        del pinned["reranker"]
+        hidden.add("reranker")
+
+    exposed = {
+        param_name: spec
+        for param_name, spec in _SEARCH_PARAM_SPECS.items()
+        if param_name not in pinned and param_name not in hidden
+    }
+    signature, annotations = _build_search_signature(exposed)
+
+    constructor_only: dict[str, Any] = {}
+    if search_filters is not None:
+        constructor_only["search_filters"] = search_filters
+    if bfs_origin_node_uuids is not None:
+        constructor_only["bfs_origin_node_uuids"] = bfs_origin_node_uuids
+
+    async def zep_search(*args: Any, **kwargs: Any) -> str:
+        bound = signature.bind(*args, **kwargs)
+        bound.apply_defaults()
+        call_args = dict(bound.arguments)
+
+        query = str(call_args.pop("query", ""))[:400]
+        search_kwargs: dict[str, Any] = {"query": query}
+
+        for param_name in _SEARCH_PARAM_SPECS:
+            if param_name in pinned:
+                search_kwargs[param_name] = pinned[param_name]
+            elif param_name in hidden:
+                continue
+            elif param_name in call_args:
+                value = call_args[param_name]
+                # Never forward explicit None -- omit so Zep's default applies.
+                if value is not None:
+                    search_kwargs[param_name] = value
+
+        if "limit" in search_kwargs:
+            search_kwargs["limit"] = min(max(int(search_kwargs["limit"]), 1), MAX_SEARCH_LIMIT)
+
+        effective_scope = search_kwargs.get("scope", "edges")
+        if effective_scope == "auto" and "reranker" in search_kwargs:
+            dropped_reranker = search_kwargs.pop("reranker")
+            if dropped_reranker in _AUTO_INCOMPATIBLE_RERANKERS:
+                logger.warning(
+                    "zep_search reranker %r is invalid for scope='auto'; omitting reranker.",
+                    dropped_reranker,
+                )
+
+        if graph_id:
+            search_kwargs["graph_id"] = graph_id
+        else:
+            search_kwargs["user_id"] = user_id
+
+        search_kwargs.update(constructor_only)
+
+        if not search_kwargs.get("query"):
+            return "Error: No search query provided."
+
+        try:
+            results = await zep_client.graph.search(**search_kwargs)
+        except Exception as exc:
+            logger.warning("Zep graph search failed: %s", exc, exc_info=True)
+            return f"Graph search failed: {exc}"
+
+        return _format_results(results, str(effective_scope))
+
+    zep_search.__signature__ = signature  # type: ignore[attr-defined]
+    zep_search.__annotations__ = annotations
+    zep_search.__name__ = name
+    zep_search.__doc__ = description
+
+    # Runtime ``tool`` accepts ``func, name=, description=``; the published
+    # overloads only type the decorator form, so cast the result.
+    decorated = tool(name=name, description=description)(zep_search)
+    return decorated  # type: ignore[no-any-return]

--- a/integrations/strands/python/tests/test_basic.py
+++ b/integrations/strands/python/tests/test_basic.py
@@ -1,0 +1,92 @@
+"""Basic structure / import tests for the zep-strands package."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_package_import() -> None:
+    import zep_strands
+
+    assert zep_strands is not None
+
+
+def test_public_exports() -> None:
+    from zep_strands import (
+        ZepMemoryStore,
+        create_zep_search_tool,
+        ensure_thread,
+        ensure_user,
+    )
+
+    assert ZepMemoryStore is not None
+    assert create_zep_search_tool is not None
+    assert ensure_user is not None
+    assert ensure_thread is not None
+
+
+class TestPackageMetadata:
+    def test_version_exists(self) -> None:
+        import zep_strands
+
+        assert zep_strands.__version__ == "0.1.0"
+
+    def test_author_and_description(self) -> None:
+        import zep_strands
+
+        assert hasattr(zep_strands, "__author__")
+        assert hasattr(zep_strands, "__description__")
+
+
+class TestZepMemoryStoreInit:
+    def test_construct_user_mode(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        store = ZepMemoryStore(
+            zep_client=MagicMock(),
+            user_id="u1",
+            thread_id="t1",
+            first_name="Jane",
+            last_name="Smith",
+        )
+        assert store.name == "zep"
+        assert store.writable is True
+        assert store.extraction is True
+        assert store.user_message_name == "Jane Smith"
+        assert store.search_scope == "auto"
+
+    def test_construct_graph_mode(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        store = ZepMemoryStore(
+            zep_client=MagicMock(),
+            graph_id="g1",
+            writable=True,
+        )
+        assert store.graph_id == "g1"
+        # No thread → no default server-side extraction.
+        assert store.extraction is None
+
+    def test_rejects_neither_scope(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        with pytest.raises(ValueError, match="user_id or graph_id"):
+            ZepMemoryStore(zep_client=MagicMock())
+
+    def test_rejects_both_scopes(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        with pytest.raises(ValueError, match="only one"):
+            ZepMemoryStore(zep_client=MagicMock(), user_id="u", graph_id="g")
+
+    def test_rejects_empty_name(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        with pytest.raises(ValueError, match="name"):
+            ZepMemoryStore(zep_client=MagicMock(), user_id="u", name="  ")
+
+    def test_rejects_invalid_max_search_results(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        with pytest.raises(ValueError, match="max_search_results"):
+            ZepMemoryStore(zep_client=MagicMock(), user_id="u", max_search_results=0)

--- a/integrations/strands/python/tests/test_basic.py
+++ b/integrations/strands/python/tests/test_basic.py
@@ -90,3 +90,48 @@ class TestZepMemoryStoreInit:
 
         with pytest.raises(ValueError, match="max_search_results"):
             ZepMemoryStore(zep_client=MagicMock(), user_id="u", max_search_results=0)
+
+    def test_rejects_extraction_without_thread(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        with pytest.raises(ValueError, match="user_id and thread_id"):
+            ZepMemoryStore(
+                zep_client=MagicMock(),
+                user_id="u1",
+                thread_id=None,
+                extraction=True,
+            )
+
+    def test_rejects_extraction_on_standalone_graph(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        with pytest.raises(ValueError, match="user_id and thread_id"):
+            ZepMemoryStore(
+                zep_client=MagicMock(),
+                graph_id="g1",
+                writable=True,
+                extraction=True,
+            )
+
+    def test_rejects_extraction_when_not_writable(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        with pytest.raises(ValueError, match="writable=True"):
+            ZepMemoryStore(
+                zep_client=MagicMock(),
+                user_id="u1",
+                thread_id="t1",
+                writable=False,
+                extraction=True,
+            )
+
+    def test_allows_explicit_extraction_false_without_thread(self) -> None:
+        from zep_strands import ZepMemoryStore
+
+        store = ZepMemoryStore(
+            zep_client=MagicMock(),
+            graph_id="g1",
+            writable=True,
+            extraction=False,
+        )
+        assert store.extraction is False

--- a/integrations/strands/python/tests/test_integration.py
+++ b/integrations/strands/python/tests/test_integration.py
@@ -45,8 +45,6 @@ if not ZEP_API_KEY:
 
 from strands import Agent  # noqa: E402
 from strands.memory import MemoryManager  # noqa: E402
-from strands.memory.extraction.triggers import InvocationTrigger  # noqa: E402
-from strands.memory.extraction.types import ExtractionConfig  # noqa: E402
 from strands.types.content import Message  # noqa: E402
 from zep_cloud.client import AsyncZep  # noqa: E402
 
@@ -129,8 +127,8 @@ async def build_agent(
 ) -> Agent:
     """Build an agent whose memory is scoped to USER_ID on the given thread.
 
-    Uses every-turn extraction so the test is not flaky on Strands' default
-    5-turn cadence; callers still ``flush()`` after ``invoke_async``.
+    Configured exactly as the example is: default extraction cadence, with
+    callers flushing at the session boundary.
     """
     await ensure_user(
         zep,
@@ -150,7 +148,7 @@ async def build_agent(
         last_name=LAST_NAME,
         email=EMAIL,
         writable=True,
-        extraction=ExtractionConfig(trigger=InvocationTrigger()),
+        extraction=True,
         expose_search_tool=True,
         search_pinned_params={"scope": "auto"},
     )
@@ -165,11 +163,19 @@ async def build_agent(
 
 
 async def chat(agent: Agent, message: str) -> str:
-    """Send one message and flush pending extraction writes."""
+    """Send one message to the agent and return its text reply."""
     result = await agent.invoke_async(message)
+    return _message_text(result.message)
+
+
+async def flush(agent: Agent) -> None:
+    """Force buffered extraction writes out at a session boundary.
+
+    ``invoke_async`` never flushes on its own, and the default trigger only
+    fires every 5 turns, so without this the seeded turns never reach Zep.
+    """
     if agent.memory_manager is not None:
         await agent.memory_manager.flush()
-    return _message_text(result.message)
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +267,7 @@ async def test_integration_full_lifecycle() -> None:
             agent1, "My name is IntegTest. I work at Acme Corp as a data scientist."
         )
         reply2 = await chat(agent1, "I live in Portland, Oregon and I love hiking and photography.")
+        await flush(agent1)
         assert reply1
         assert reply2
         assert hook_calls == [USER_ID]
@@ -324,6 +331,8 @@ async def main() -> None:
             reply = await chat(agent1, msg)
             print(f"  Agent: {reply}\n")
             passed &= check("Agent returned a non-empty response", len(reply) > 0)
+
+        await flush(agent1)
 
         passed &= check(
             "on_user_created hook fired exactly once",

--- a/integrations/strands/python/tests/test_integration.py
+++ b/integrations/strands/python/tests/test_integration.py
@@ -1,70 +1,388 @@
-"""Live integration tests against Zep Cloud (skipped without ZEP_API_KEY)."""
+"""
+End-to-end integration tests for the Zep Strands Agents integration.
+
+Two layers:
+
+  1. ``test_store_round_trip`` — store-only against live Zep (``ZEP_API_KEY``).
+     Exercises ``ensure_user`` / ``ensure_thread``, ``add_messages``, ``add``,
+     and ``search`` without a model provider.
+  2. ``test_integration_full_lifecycle`` — full agent loop against live Zep and
+     OpenAI (``ZEP_API_KEY`` + ``OPENAI_API_KEY``):
+       * ``MemoryManager`` + ``ZepMemoryStore`` inject context and extract turns
+       * Both sides of the conversation land on the thread after ``flush()``
+       * Cross-thread recall from the user graph
+       * ``on_user_created`` fires exactly once
+
+Requires:
+    ZEP_API_KEY (all tests) and OPENAI_API_KEY (agent-driven tests only).
+
+Usage:
+    uv run pytest tests/test_integration.py -v -s -m integration
+    # or standalone (agent lifecycle):
+    uv run python tests/test_integration.py
+"""
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import os
+import sys
+import time
 from uuid import uuid4
 
 import pytest
 
+# ---------------------------------------------------------------------------
+# Configuration — skip the module when no Zep API key is available.
+# Agent-driven tests additionally gate on OPENAI_API_KEY.
+# ---------------------------------------------------------------------------
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+
+if not ZEP_API_KEY:
+    pytest.skip("ZEP_API_KEY required for integration tests", allow_module_level=True)
+
+from strands import Agent  # noqa: E402
+from strands.memory import MemoryManager  # noqa: E402
+from strands.memory.extraction.triggers import InvocationTrigger  # noqa: E402
+from strands.memory.extraction.types import ExtractionConfig  # noqa: E402
+from strands.types.content import Message  # noqa: E402
+from zep_cloud.client import AsyncZep  # noqa: E402
+
+from zep_strands import (  # noqa: E402
+    ZepMemoryStore,
+    ensure_thread,
+    ensure_user,
+)
+from zep_strands.provisioning import UserSetupHook  # noqa: E402
+
 pytestmark = pytest.mark.integration
 
-ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+_suffix = uuid4().hex[:8]
+USER_ID = f"strands-integ-{_suffix}"
+THREAD_1 = f"strands-integ-t1-{_suffix}"
+THREAD_2 = f"strands-integ-t2-{_suffix}"
+
+FIRST_NAME = "IntegTest"
+LAST_NAME = "User"
+EMAIL = f"integtest-{_suffix}@example.com"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+logger = logging.getLogger("test_integration")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("openai").setLevel(logging.WARNING)
 
 
-@pytest.fixture
-def zep_client():  # type: ignore[no-untyped-def]
-    if not ZEP_API_KEY:
-        pytest.skip("ZEP_API_KEY not set")
-    from zep_cloud.client import AsyncZep
+def check(description: str, condition: bool, detail: str = "") -> bool:
+    """Print a PASS/FAIL line and return the condition."""
+    status = "PASS" if condition else "FAIL"
+    msg = f"  {status}: {description}"
+    if detail:
+        msg += f" ({detail})"
+    print(msg)
+    return condition
 
-    return AsyncZep(api_key=ZEP_API_KEY)
+
+def _message_text(message: Message | object) -> str:
+    """Extract joined text blocks from an agent result message."""
+    if not isinstance(message, dict):
+        return str(message)
+    parts = [
+        block["text"]
+        for block in message.get("content") or []
+        if isinstance(block, dict) and "text" in block
+    ]
+    return "\n".join(parts) if parts else str(message)
+
+
+async def wait_for_episodes_processed(
+    zep: AsyncZep,
+    user_id: str,
+    timeout_seconds: int = 120,
+    poll_interval: float = 3.0,
+) -> None:
+    """Poll Zep episodes until all are processed or the timeout is reached."""
+    start = time.monotonic()
+    while True:
+        if time.monotonic() - start > timeout_seconds:
+            logger.warning("Timed out waiting for episode processing; continuing.")
+            return
+        try:
+            resp = await zep.graph.episode.get_by_user_id(user_id=user_id, lastn=20)
+        except Exception as exc:
+            logger.warning("Episode poll failed (%s); retrying.", exc)
+            await asyncio.sleep(poll_interval)
+            continue
+        episodes = resp.episodes or []
+        if episodes and all(e.processed for e in episodes):
+            logger.info("All %d episodes processed.", len(episodes))
+            return
+        await asyncio.sleep(poll_interval)
+
+
+async def build_agent(
+    zep: AsyncZep,
+    thread_id: str,
+    *,
+    on_user_created: UserSetupHook | None = None,
+) -> Agent:
+    """Build an agent whose memory is scoped to USER_ID on the given thread.
+
+    Uses every-turn extraction so the test is not flaky on Strands' default
+    5-turn cadence; callers still ``flush()`` after ``invoke_async``.
+    """
+    await ensure_user(
+        zep,
+        user_id=USER_ID,
+        first_name=FIRST_NAME,
+        last_name=LAST_NAME,
+        email=EMAIL,
+        on_created=on_user_created,
+    )
+    await ensure_thread(zep, thread_id=thread_id, user_id=USER_ID)
+
+    store = ZepMemoryStore(
+        zep_client=zep,
+        user_id=USER_ID,
+        thread_id=thread_id,
+        first_name=FIRST_NAME,
+        last_name=LAST_NAME,
+        email=EMAIL,
+        writable=True,
+        extraction=ExtractionConfig(trigger=InvocationTrigger()),
+        expose_search_tool=True,
+        search_pinned_params={"scope": "auto"},
+    )
+    return Agent(
+        system_prompt=(
+            "You are a helpful assistant with access to long-term memory. "
+            "When memory context is provided, use it to give personalised, "
+            "memory-aware answers. Be concise."
+        ),
+        memory_manager=MemoryManager(stores=[store], add_tool_config=True),
+    )
+
+
+async def chat(agent: Agent, message: str) -> str:
+    """Send one message and flush pending extraction writes."""
+    result = await agent.invoke_async(message)
+    if agent.memory_manager is not None:
+        await agent.memory_manager.flush()
+    return _message_text(result.message)
+
+
+# ---------------------------------------------------------------------------
+# Store-only path (ZEP_API_KEY)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_store_round_trip(zep_client) -> None:  # type: ignore[no-untyped-def]
-    from zep_strands import ZepMemoryStore, ensure_thread, ensure_user
+async def test_store_round_trip() -> None:
+    """Exercise store methods against live Zep without a model provider."""
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+    user_id = f"{USER_ID}-store"
+    thread_id = f"{THREAD_1}-store"
 
-    suffix = uuid4().hex[:8]
-    user_id = f"strands-it-user-{suffix}"
-    thread_id = f"strands-it-thread-{suffix}"
+    try:
+        created_user = await ensure_user(
+            zep,
+            user_id=user_id,
+            first_name=FIRST_NAME,
+            last_name=LAST_NAME,
+            email=f"store-{_suffix}@example.com",
+        )
+        assert created_user is True
+        assert await ensure_user(zep, user_id=user_id) is False
 
-    await ensure_user(
-        zep_client,
-        user_id=user_id,
-        first_name="Integration",
-        last_name="Tester",
-        email=f"strands-{suffix}@example.com",
-    )
-    await ensure_thread(zep_client, thread_id=thread_id, user_id=user_id)
+        created_thread = await ensure_thread(zep, thread_id=thread_id, user_id=user_id)
+        assert created_thread is True
 
-    store = ZepMemoryStore(
-        zep_client=zep_client,
-        user_id=user_id,
-        thread_id=thread_id,
-        first_name="Integration",
-        last_name="Tester",
-        writable=True,
-        extraction=True,
-        search_scope="edges",
-    )
+        store = ZepMemoryStore(
+            zep_client=zep,
+            user_id=user_id,
+            thread_id=thread_id,
+            first_name=FIRST_NAME,
+            last_name=LAST_NAME,
+            writable=True,
+            extraction=True,
+            search_scope="edges",
+        )
 
-    await store.add_messages(
-        [
-            {
-                "role": "user",
-                "content": [{"text": "I am a ceramicist based in Santa Fe."}],
-            },
-            {
-                "role": "assistant",
-                "content": [{"text": "I'll remember that."}],
-            },
+        await store.add_messages(
+            [
+                {
+                    "role": "user",
+                    "content": [{"text": "I am a ceramicist based in Santa Fe."}],
+                },
+                {
+                    "role": "assistant",
+                    "content": [{"text": "I'll remember that."}],
+                },
+            ]
+        )
+        await store.add("Prefers matte glazes over glossy finishes.")
+
+        # Search may be empty immediately (async ingestion); just assert no raise.
+        entries = await store.search("ceramics")
+        assert isinstance(entries, list)
+
+        t = await zep.thread.get(thread_id=thread_id, lastn=20)
+        messages = t.messages or []
+        assert any(m.role == "user" for m in messages)
+        assert any(m.role == "assistant" for m in messages)
+    finally:
+        try:
+            await zep.user.delete(user_id=user_id)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Full agent lifecycle (ZEP_API_KEY + OPENAI_API_KEY)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_integration_full_lifecycle() -> None:
+    """Pytest entry point for the live agent integration test."""
+    if not OPENAI_API_KEY:
+        pytest.skip("OPENAI_API_KEY required for this test")
+
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+    hook_calls: list[str] = []
+
+    async def on_user_created(client: AsyncZep, user_id: str) -> None:
+        hook_calls.append(user_id)
+
+    try:
+        agent1 = await build_agent(zep, THREAD_1, on_user_created=on_user_created)
+        reply1 = await chat(
+            agent1, "My name is IntegTest. I work at Acme Corp as a data scientist."
+        )
+        reply2 = await chat(agent1, "I live in Portland, Oregon and I love hiking and photography.")
+        assert reply1
+        assert reply2
+        assert hook_calls == [USER_ID]
+
+        user = await zep.user.get(user_id=USER_ID)
+        assert user.first_name == FIRST_NAME
+        assert user.last_name == LAST_NAME
+        assert user.email == EMAIL
+
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        assert any(m.role == "user" for m in messages)
+        assert any(m.role == "assistant" for m in messages)
+
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        agent2 = await build_agent(zep, THREAD_2, on_user_created=on_user_created)
+        recall = (await chat(agent2, "What do you know about me?")).lower()
+
+        # Existing user — hook must not fire again.
+        assert hook_calls == [USER_ID]
+
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        assert any(kw in recall for kw in keywords), f"no recall in: {recall}"
+    finally:
+        try:
+            await zep.user.delete(user_id=USER_ID)
+        except Exception:
+            pass
+
+
+async def main() -> None:
+    """Standalone runner for the agent lifecycle (mirrors pytest asserts)."""
+    if not OPENAI_API_KEY:
+        print("OPENAI_API_KEY not set; skipping the agent-driven lifecycle test.")
+        sys.exit(0)
+
+    zep = AsyncZep(api_key=ZEP_API_KEY)
+    passed = True
+    hook_calls: list[str] = []
+
+    async def on_user_created(client: AsyncZep, user_id: str) -> None:
+        hook_calls.append(user_id)
+        logger.info("on_user_created fired for %s", user_id)
+
+    print(f"\n{'=' * 70}")
+    print("Zep Strands Agents Integration Test")
+    print(f"  User:    {USER_ID}")
+    print(f"  Threads: {THREAD_1}, {THREAD_2}")
+    print(f"{'=' * 70}\n")
+
+    try:
+        print("[Step 1] Conversation 1: seeding facts...")
+        agent1 = await build_agent(zep, THREAD_1, on_user_created=on_user_created)
+        seeds = [
+            "My name is IntegTest. I work at Acme Corp as a data scientist.",
+            "I live in Portland, Oregon and I love hiking and photography.",
         ]
-    )
+        for msg in seeds:
+            print(f"  User:  {msg}")
+            reply = await chat(agent1, msg)
+            print(f"  Agent: {reply}\n")
+            passed &= check("Agent returned a non-empty response", len(reply) > 0)
 
-    # Also exercise the single-content write path.
-    await store.add("Prefers matte glazes over glossy finishes.")
+        passed &= check(
+            "on_user_created hook fired exactly once",
+            len(hook_calls) == 1 and hook_calls[0] == USER_ID,
+            f"calls={hook_calls}",
+        )
 
-    # Search may be empty immediately (async ingestion); just assert no raise.
-    entries = await store.search("ceramics")
-    assert isinstance(entries, list)
+        print("[Step 2] Verifying Zep user metadata...")
+        user = await zep.user.get(user_id=USER_ID)
+        passed &= check("first_name matches", user.first_name == FIRST_NAME, str(user.first_name))
+        passed &= check("last_name matches", user.last_name == LAST_NAME, str(user.last_name))
+        passed &= check("email matches", user.email == EMAIL, str(user.email))
+
+        print("\n[Step 3] Verifying thread 1 messages...")
+        t1 = await zep.thread.get(thread_id=THREAD_1, lastn=20)
+        messages = t1.messages or []
+        user_msgs = [m for m in messages if m.role == "user"]
+        asst_msgs = [m for m in messages if m.role == "assistant"]
+        print(f"  {len(user_msgs)} user, {len(asst_msgs)} assistant messages")
+        passed &= check("Thread 1 has user messages", len(user_msgs) >= 2, f"{len(user_msgs)}")
+        passed &= check("Thread 1 has assistant messages", len(asst_msgs) >= 2, f"{len(asst_msgs)}")
+
+        print("\n[Step 4] Waiting for Zep to process episodes...")
+        await wait_for_episodes_processed(zep, USER_ID, timeout_seconds=120)
+
+        print("\n[Step 5] Conversation 2: cross-thread memory recall...")
+        agent2 = await build_agent(zep, THREAD_2, on_user_created=on_user_created)
+        recall_text = await chat(agent2, "What do you know about me?")
+        print(f"  Agent: {recall_text}\n")
+
+        passed &= check(
+            "on_user_created did NOT fire again for existing user",
+            len(hook_calls) == 1,
+            f"calls={len(hook_calls)}",
+        )
+
+        recall = recall_text.lower()
+        keywords = ["acme", "data scientist", "portland", "hiking", "photography"]
+        found = [kw for kw in keywords if kw in recall]
+        print(f"  Recalled keywords: {found}")
+        passed &= check(
+            "Agent recalled facts from conversation 1",
+            len(found) > 0,
+            f"found={found}",
+        )
+
+    finally:
+        print("\n[Cleanup] Deleting test user...")
+        try:
+            await zep.user.delete(user_id=USER_ID)
+            print(f"  Deleted {USER_ID}")
+        except Exception as exc:
+            print(f"  Warning: could not delete user: {exc}")
+
+    print(f"\n{'=' * 70}")
+    print("RESULT:", "ALL CHECKS PASSED" if passed else "SOME CHECKS FAILED")
+    print("=" * 70)
+    sys.exit(0 if passed else 1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/integrations/strands/python/tests/test_integration.py
+++ b/integrations/strands/python/tests/test_integration.py
@@ -1,0 +1,70 @@
+"""Live integration tests against Zep Cloud (skipped without ZEP_API_KEY)."""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
+
+
+@pytest.fixture
+def zep_client():  # type: ignore[no-untyped-def]
+    if not ZEP_API_KEY:
+        pytest.skip("ZEP_API_KEY not set")
+    from zep_cloud.client import AsyncZep
+
+    return AsyncZep(api_key=ZEP_API_KEY)
+
+
+@pytest.mark.asyncio
+async def test_store_round_trip(zep_client) -> None:  # type: ignore[no-untyped-def]
+    from zep_strands import ZepMemoryStore, ensure_thread, ensure_user
+
+    suffix = uuid4().hex[:8]
+    user_id = f"strands-it-user-{suffix}"
+    thread_id = f"strands-it-thread-{suffix}"
+
+    await ensure_user(
+        zep_client,
+        user_id=user_id,
+        first_name="Integration",
+        last_name="Tester",
+        email=f"strands-{suffix}@example.com",
+    )
+    await ensure_thread(zep_client, thread_id=thread_id, user_id=user_id)
+
+    store = ZepMemoryStore(
+        zep_client=zep_client,
+        user_id=user_id,
+        thread_id=thread_id,
+        first_name="Integration",
+        last_name="Tester",
+        writable=True,
+        extraction=True,
+        search_scope="edges",
+    )
+
+    await store.add_messages(
+        [
+            {
+                "role": "user",
+                "content": [{"text": "I am a ceramicist based in Santa Fe."}],
+            },
+            {
+                "role": "assistant",
+                "content": [{"text": "I'll remember that."}],
+            },
+        ]
+    )
+
+    # Also exercise the single-content write path.
+    await store.add("Prefers matte glazes over glossy finishes.")
+
+    # Search may be empty immediately (async ingestion); just assert no raise.
+    entries = await store.search("ceramics")
+    assert isinstance(entries, list)

--- a/integrations/strands/python/tests/test_integration.py
+++ b/integrations/strands/python/tests/test_integration.py
@@ -39,12 +39,14 @@ import pytest
 # ---------------------------------------------------------------------------
 ZEP_API_KEY = os.environ.get("ZEP_API_KEY", "")
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-5-mini")
 
 if not ZEP_API_KEY:
     pytest.skip("ZEP_API_KEY required for integration tests", allow_module_level=True)
 
 from strands import Agent  # noqa: E402
 from strands.memory import MemoryManager  # noqa: E402
+from strands.models.openai import OpenAIModel  # noqa: E402
 from strands.types.content import Message  # noqa: E402
 from zep_cloud.client import AsyncZep  # noqa: E402
 
@@ -153,6 +155,7 @@ async def build_agent(
         search_pinned_params={"scope": "auto"},
     )
     return Agent(
+        model=OpenAIModel(client_args={"api_key": OPENAI_API_KEY}, model_id=OPENAI_MODEL),
         system_prompt=(
             "You are a helpful assistant with access to long-term memory. "
             "When memory context is provided, use it to give personalised, "
@@ -173,6 +176,8 @@ async def flush(agent: Agent) -> None:
 
     ``invoke_async`` never flushes on its own, and the default trigger only
     fires every 5 turns, so without this the seeded turns never reach Zep.
+    Flushing also drains in-flight background saves before the agent is
+    discarded.
     """
     if agent.memory_manager is not None:
         await agent.memory_manager.flush()
@@ -286,6 +291,7 @@ async def test_integration_full_lifecycle() -> None:
 
         agent2 = await build_agent(zep, THREAD_2, on_user_created=on_user_created)
         recall = (await chat(agent2, "What do you know about me?")).lower()
+        await flush(agent2)
 
         # Existing user — hook must not fire again.
         assert hook_calls == [USER_ID]
@@ -362,6 +368,7 @@ async def main() -> None:
         agent2 = await build_agent(zep, THREAD_2, on_user_created=on_user_created)
         recall_text = await chat(agent2, "What do you know about me?")
         print(f"  Agent: {recall_text}\n")
+        await flush(agent2)
 
         passed &= check(
             "on_user_created did NOT fire again for existing user",

--- a/integrations/strands/python/tests/test_limits.py
+++ b/integrations/strands/python/tests/test_limits.py
@@ -1,0 +1,24 @@
+"""Tests for message / graph payload truncation helpers."""
+
+from zep_strands._text import (
+    GRAPH_DATA_TRUNCATE_LIMIT,
+    MESSAGE_TRUNCATE_LIMIT,
+    truncate_graph_data,
+    truncate_message_content,
+)
+
+
+def test_truncate_message_content_passthrough() -> None:
+    assert truncate_message_content("hello", label="user message") == "hello"
+
+
+def test_truncate_message_content_cuts_long() -> None:
+    long = "x" * (MESSAGE_TRUNCATE_LIMIT + 50)
+    out = truncate_message_content(long, label="user message")
+    assert len(out) == MESSAGE_TRUNCATE_LIMIT
+
+
+def test_truncate_graph_data_cuts_long() -> None:
+    long = "y" * (GRAPH_DATA_TRUNCATE_LIMIT + 100)
+    out = truncate_graph_data(long, label="graph data")
+    assert len(out) == GRAPH_DATA_TRUNCATE_LIMIT

--- a/integrations/strands/python/tests/test_memory_store.py
+++ b/integrations/strands/python/tests/test_memory_store.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from zep_strands import ZepMemoryStore
+from zep_strands._text import GRAPH_DATA_TRUNCATE_LIMIT
 from zep_strands.memory_store import _extract_text, _results_to_entries, _role_to_zep
 
 
@@ -168,6 +170,37 @@ class TestAdd:
         assert kwargs["graph_id"] == "kb-1"
         assert "user_id" not in kwargs
 
+    @pytest.mark.asyncio
+    async def test_add_truncates_oversize_text(self) -> None:
+        store = _make_store()
+        await store.add("z" * (GRAPH_DATA_TRUNCATE_LIMIT + 500))
+        kwargs = store._zep.graph.add.await_args.kwargs
+        assert len(kwargs["data"]) == GRAPH_DATA_TRUNCATE_LIMIT
+
+    @pytest.mark.asyncio
+    async def test_add_rejects_oversize_json_instead_of_corrupting_it(self) -> None:
+        """Valid-but-oversize JSON must raise, not be sliced into invalid JSON."""
+        store = _make_store()
+        payload = json.dumps({"notes": ["x" * 200 for _ in range(60)]})
+        assert len(payload) > GRAPH_DATA_TRUNCATE_LIMIT
+        json.loads(payload)  # the input itself is valid JSON
+
+        with pytest.raises(ValueError, match="cannot be truncated safely"):
+            await store.add(payload, metadata={"type": "json"})
+
+        store._zep.graph.add.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_add_allows_json_at_the_limit(self) -> None:
+        store = _make_store()
+        filler = "a" * (GRAPH_DATA_TRUNCATE_LIMIT - len(json.dumps({"k": ""})))
+        payload = json.dumps({"k": filler})
+        assert len(payload) == GRAPH_DATA_TRUNCATE_LIMIT
+
+        await store.add(payload, metadata={"type": "json"})
+        sent = store._zep.graph.add.await_args.kwargs["data"]
+        assert json.loads(sent) == {"k": filler}
+
 
 class TestAddMessages:
     @pytest.mark.asyncio
@@ -210,6 +243,37 @@ class TestAddMessages:
         client = _make_mock_client()
         store = ZepMemoryStore(zep_client=client, graph_id="g1", writable=True)
         with pytest.raises(ValueError, match="user-graph"):
+            await store.add_messages([{"role": "user", "content": [{"text": "hi"}]}])  # type: ignore[arg-type]
+
+
+class TestZepFailuresPropagate:
+    """Zep SDK errors must reach the framework, which owns failure isolation.
+
+    ``MemoryManager.search`` skips failing stores, ``MemoryManager.add`` raises
+    ``AggregateMemoryError``, and ``ExtractionCoordinator`` rolls its high-water
+    mark back so a failed batch retries. Swallowing here would turn a retryable
+    extraction failure into permanent, silent message loss.
+    """
+
+    @pytest.mark.asyncio
+    async def test_search_propagates(self) -> None:
+        store = _make_store()
+        store._zep.graph.search.side_effect = RuntimeError("zep down")
+        with pytest.raises(RuntimeError, match="zep down"):
+            await store.search("anything")
+
+    @pytest.mark.asyncio
+    async def test_add_propagates(self) -> None:
+        store = _make_store()
+        store._zep.graph.add.side_effect = RuntimeError("zep down")
+        with pytest.raises(RuntimeError, match="zep down"):
+            await store.add("a fact")
+
+    @pytest.mark.asyncio
+    async def test_add_messages_propagates_so_the_batch_retries(self) -> None:
+        store = _make_store()
+        store._zep.thread.add_messages.side_effect = RuntimeError("zep down")
+        with pytest.raises(RuntimeError, match="zep down"):
             await store.add_messages([{"role": "user", "content": [{"text": "hi"}]}])  # type: ignore[arg-type]
 
 

--- a/integrations/strands/python/tests/test_memory_store.py
+++ b/integrations/strands/python/tests/test_memory_store.py
@@ -1,0 +1,224 @@
+"""Tests for ``ZepMemoryStore`` search / add / add_messages / initialize."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from zep_strands import ZepMemoryStore
+from zep_strands.memory_store import _extract_text, _results_to_entries, _role_to_zep
+
+
+def _make_mock_client() -> MagicMock:
+    client = MagicMock()
+    client.user = MagicMock()
+    client.user.add = AsyncMock()
+    client.thread = MagicMock()
+    client.thread.create = AsyncMock()
+    client.thread.add_messages = AsyncMock(return_value=SimpleNamespace(message_uuids=["m1"]))
+    client.graph = MagicMock()
+    client.graph.search = AsyncMock()
+    client.graph.add = AsyncMock(return_value=SimpleNamespace(uuid_="ep-1"))
+    return client
+
+
+def _make_store(**kwargs: object) -> ZepMemoryStore:
+    defaults: dict[str, object] = {
+        "zep_client": _make_mock_client(),
+        "user_id": "user-1",
+        "thread_id": "thread-1",
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+    }
+    defaults.update(kwargs)
+    return ZepMemoryStore(**defaults)  # type: ignore[arg-type]
+
+
+class TestHelpers:
+    def test_extract_text_joins_blocks(self) -> None:
+        message = {
+            "role": "user",
+            "content": [{"text": "Hello"}, {"text": "world"}, {"toolUse": {}}],
+        }
+        assert _extract_text(message) == "Hello\nworld"  # type: ignore[arg-type]
+
+    def test_role_to_zep_passthrough(self) -> None:
+        assert _role_to_zep("user") == "user"
+        assert _role_to_zep("Assistant") == "assistant"
+        assert _role_to_zep("mystery") == "norole"
+
+    def test_results_to_entries_auto_prefers_context(self) -> None:
+        result = SimpleNamespace(
+            context="assembled context",
+            edges=[SimpleNamespace(fact="ignored", uuid_="e1")],
+            nodes=None,
+            episodes=None,
+            observations=None,
+            thread_summaries=None,
+        )
+        entries = _results_to_entries(result, "auto", limit=5)
+        assert len(entries) == 1
+        assert entries[0].content == "assembled context"
+
+    def test_results_to_entries_edges(self) -> None:
+        result = SimpleNamespace(
+            context=None,
+            edges=[
+                SimpleNamespace(fact="Ada likes math", uuid_="e1"),
+                SimpleNamespace(fact="Ada lives in London", uuid_="e2"),
+            ],
+            nodes=None,
+            episodes=None,
+            observations=None,
+            thread_summaries=None,
+        )
+        entries = _results_to_entries(result, "edges", limit=1)
+        assert len(entries) == 1
+        assert entries[0].content == "Ada likes math"
+        assert entries[0].metadata is not None
+        assert entries[0].metadata["scope"] == "edges"
+
+
+class TestInitialize:
+    @pytest.mark.asyncio
+    async def test_initialize_provisions_user_and_thread(self) -> None:
+        store = _make_store()
+        await store.initialize()
+        store._zep.user.add.assert_awaited_once()
+        store._zep.thread.create.assert_awaited_once()
+        assert store._resources_ready is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_graph_mode_is_noop(self) -> None:
+        client = _make_mock_client()
+        store = ZepMemoryStore(zep_client=client, graph_id="g1")
+        await store.initialize()
+        client.user.add.assert_not_awaited()
+        client.thread.create.assert_not_awaited()
+
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_user_graph(self) -> None:
+        store = _make_store(search_scope="edges")
+        store._zep.graph.search.return_value = SimpleNamespace(
+            context=None,
+            edges=[SimpleNamespace(fact="Prefers dark mode", uuid_="e1")],
+            nodes=None,
+            episodes=None,
+            observations=None,
+            thread_summaries=None,
+        )
+        entries = await store.search("preferences")
+        assert len(entries) == 1
+        assert "dark mode" in entries[0].content
+        store._zep.graph.search.assert_awaited_once()
+        kwargs = store._zep.graph.search.await_args.kwargs
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["scope"] == "edges"
+        assert kwargs["query"] == "preferences"
+
+    @pytest.mark.asyncio
+    async def test_search_empty_query_returns_empty(self) -> None:
+        store = _make_store()
+        assert await store.search("   ") == []
+        store._zep.graph.search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_search_rejects_invalid_max(self) -> None:
+        store = _make_store()
+        with pytest.raises(ValueError, match="max_search_results"):
+            await store.search("q", {"max_search_results": 0})
+
+
+class TestAdd:
+    @pytest.mark.asyncio
+    async def test_add_text_to_user_graph(self) -> None:
+        store = _make_store()
+        await store.add("User prefers aisle seats", metadata={"source": "prefs"})
+        store._zep.graph.add.assert_awaited_once()
+        kwargs = store._zep.graph.add.await_args.kwargs
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["type"] == "text"
+        assert kwargs["data"] == "User prefers aisle seats"
+        assert kwargs["metadata"] == {"source": "prefs"}
+
+    @pytest.mark.asyncio
+    async def test_add_json_type(self) -> None:
+        store = _make_store()
+        await store.add('{"plan": "premium"}', metadata={"type": "json"})
+        kwargs = store._zep.graph.add.await_args.kwargs
+        assert kwargs["type"] == "json"
+        assert "metadata" not in kwargs  # type key consumed
+
+    @pytest.mark.asyncio
+    async def test_add_rejects_when_not_writable(self) -> None:
+        store = _make_store(writable=False, extraction=False)
+        with pytest.raises(ValueError, match="not writable"):
+            await store.add("x")
+
+    @pytest.mark.asyncio
+    async def test_add_to_standalone_graph(self) -> None:
+        client = _make_mock_client()
+        store = ZepMemoryStore(zep_client=client, graph_id="kb-1", writable=True)
+        await store.add("Company holiday is July 4")
+        kwargs = client.graph.add.await_args.kwargs
+        assert kwargs["graph_id"] == "kb-1"
+        assert "user_id" not in kwargs
+
+
+class TestAddMessages:
+    @pytest.mark.asyncio
+    async def test_add_messages_converts_and_persists(self) -> None:
+        store = _make_store()
+        messages = [
+            {"role": "user", "content": [{"text": "I love hiking"}]},
+            {"role": "assistant", "content": [{"text": "Noted!"}]},
+        ]
+        await store.add_messages(messages)  # type: ignore[arg-type]
+        store._zep.thread.add_messages.assert_awaited_once()
+        kwargs = store._zep.thread.add_messages.await_args.kwargs
+        assert kwargs["thread_id"] == "thread-1"
+        assert len(kwargs["messages"]) == 2
+        assert kwargs["messages"][0].role == "user"
+        assert kwargs["messages"][0].content == "I love hiking"
+        assert kwargs["messages"][0].name == "Ada Lovelace"
+        assert kwargs["messages"][1].role == "assistant"
+        assert kwargs["messages"][1].name == "Assistant"
+
+    @pytest.mark.asyncio
+    async def test_add_messages_skips_empty_and_tool_only(self) -> None:
+        store = _make_store()
+        messages = [
+            {"role": "assistant", "content": [{"toolUse": {"name": "x"}}]},
+            {"role": "user", "content": [{"text": "   "}]},
+        ]
+        result = await store.add_messages(messages)  # type: ignore[arg-type]
+        assert result is None
+        store._zep.thread.add_messages.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_add_messages_requires_thread(self) -> None:
+        store = _make_store(thread_id=None, extraction=False)
+        with pytest.raises(ValueError, match="thread_id"):
+            await store.add_messages([{"role": "user", "content": [{"text": "hi"}]}])  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_add_messages_rejects_graph_mode(self) -> None:
+        client = _make_mock_client()
+        store = ZepMemoryStore(zep_client=client, graph_id="g1", writable=True)
+        with pytest.raises(ValueError, match="user-graph"):
+            await store.add_messages([{"role": "user", "content": [{"text": "hi"}]}])  # type: ignore[arg-type]
+
+
+class TestGetTools:
+    def test_get_tools_empty_by_default(self) -> None:
+        store = _make_store()
+        assert store.get_tools() == []
+
+    def test_get_tools_when_exposed(self) -> None:
+        store = _make_store(expose_search_tool=True)
+        tools = store.get_tools()
+        assert len(tools) == 1

--- a/integrations/strands/python/tests/test_memory_store.py
+++ b/integrations/strands/python/tests/test_memory_store.py
@@ -85,18 +85,38 @@ class TestHelpers:
 
 class TestInitialize:
     @pytest.mark.asyncio
-    async def test_initialize_provisions_user_and_thread(self) -> None:
+    async def test_initialize_makes_no_zep_calls(self) -> None:
+        """Strands runs ``initialize`` on a throwaway event loop from
+        ``Agent.__init__``, so it must not touch the caller's client."""
         store = _make_store()
         await store.initialize()
+        store._zep.user.add.assert_not_awaited()
+        store._zep.thread.create.assert_not_awaited()
+        assert store._resources_ready is False
+
+    @pytest.mark.asyncio
+    async def test_first_search_provisions_user_and_thread(self) -> None:
+        store = _make_store()
+        await store.search("anything")
         store._zep.user.add.assert_awaited_once()
         store._zep.thread.create.assert_awaited_once()
         assert store._resources_ready is True
 
     @pytest.mark.asyncio
-    async def test_initialize_graph_mode_is_noop(self) -> None:
+    async def test_provisioning_happens_only_once(self) -> None:
+        store = _make_store()
+        await store.search("first")
+        await store.search("second")
+        await store.add("a fact")
+        store._zep.user.add.assert_awaited_once()
+        store._zep.thread.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_graph_mode_never_provisions(self) -> None:
         client = _make_mock_client()
         store = ZepMemoryStore(zep_client=client, graph_id="g1")
         await store.initialize()
+        await store.search("anything")
         client.user.add.assert_not_awaited()
         client.thread.create.assert_not_awaited()
 

--- a/integrations/strands/python/tests/test_provisioning.py
+++ b/integrations/strands/python/tests/test_provisioning.py
@@ -1,0 +1,121 @@
+"""
+Tests for out-of-band Zep resource provisioning: ``ensure_user``,
+``ensure_thread``, and the ``on_created`` hook contract.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from zep_strands.provisioning import (
+    _is_already_exists_error,
+    ensure_thread,
+    ensure_user,
+)
+
+
+def _make_mock_client() -> MagicMock:
+    client = MagicMock()
+    client.user = MagicMock()
+    client.user.add = AsyncMock()
+    client.thread = MagicMock()
+    client.thread.create = AsyncMock()
+    return client
+
+
+class _ApiError(Exception):
+    """Minimal stand-in for a typed Zep SDK error exposing ``status_code``."""
+
+    def __init__(self, status_code: int, message: str = "error") -> None:
+        self.status_code = status_code
+        super().__init__(message)
+
+
+class TestIsAlreadyExistsError:
+    def test_409_status_code_is_conflict(self) -> None:
+        assert _is_already_exists_error(_ApiError(409)) is True
+
+    def test_400_with_already_exists_message_is_conflict(self) -> None:
+        assert _is_already_exists_error(_ApiError(400, "user already exists")) is True
+
+    def test_400_without_already_exists_message_is_genuine(self) -> None:
+        assert _is_already_exists_error(_ApiError(400, "invalid payload")) is False
+
+    def test_404_is_genuine_failure(self) -> None:
+        assert _is_already_exists_error(_ApiError(404, "not found")) is False
+
+    def test_500_with_conflict_wording_is_genuine_failure(self) -> None:
+        assert _is_already_exists_error(_ApiError(500, "conflict while saving")) is False
+
+    def test_untyped_already_exists_message_is_conflict(self) -> None:
+        assert _is_already_exists_error(Exception("resource already exists")) is True
+
+    def test_untyped_conflict_message_is_conflict(self) -> None:
+        assert _is_already_exists_error(Exception("409 conflict")) is True
+
+    def test_untyped_unrelated_message_is_genuine_failure(self) -> None:
+        assert _is_already_exists_error(Exception("network timeout")) is False
+
+
+class TestEnsureUser:
+    @pytest.mark.asyncio
+    async def test_ensure_user_created_signal(self) -> None:
+        client = _make_mock_client()
+
+        created = await ensure_user(client, user_id="u1")
+        assert created is True
+        client.user.add.assert_called_once_with(
+            user_id="u1", first_name=None, last_name=None, email=None
+        )
+
+        client.user.add.side_effect = Exception("already exists")
+        already_existed = await ensure_user(client, user_id="u1")
+        assert already_existed is False
+
+    @pytest.mark.asyncio
+    async def test_ensure_user_propagates_genuine_failure(self) -> None:
+        client = _make_mock_client()
+        client.user.add.side_effect = _ApiError(500, "boom")
+        with pytest.raises(_ApiError):
+            await ensure_user(client, user_id="u1")
+
+    @pytest.mark.asyncio
+    async def test_on_created_runs_only_on_new_user(self) -> None:
+        client = _make_mock_client()
+        hook = AsyncMock()
+
+        await ensure_user(client, user_id="u1", on_created=hook)
+        hook.assert_awaited_once_with(client, "u1")
+
+        hook.reset_mock()
+        client.user.add.side_effect = Exception("already exists")
+        await ensure_user(client, user_id="u1", on_created=hook)
+        hook.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_on_created_failure_propagates(self) -> None:
+        client = _make_mock_client()
+        hook = AsyncMock(side_effect=RuntimeError("hook failed"))
+        with pytest.raises(RuntimeError, match="hook failed"):
+            await ensure_user(client, user_id="u1", on_created=hook)
+
+
+class TestEnsureThread:
+    @pytest.mark.asyncio
+    async def test_ensure_thread_created_signal(self) -> None:
+        client = _make_mock_client()
+
+        created = await ensure_thread(client, thread_id="t1", user_id="u1")
+        assert created is True
+        client.thread.create.assert_called_once_with(thread_id="t1", user_id="u1")
+
+        client.thread.create.side_effect = Exception("already exists")
+        already_existed = await ensure_thread(client, thread_id="t1", user_id="u1")
+        assert already_existed is False
+
+    @pytest.mark.asyncio
+    async def test_ensure_thread_propagates_genuine_failure(self) -> None:
+        client = _make_mock_client()
+        client.thread.create.side_effect = _ApiError(401, "unauthorized")
+        with pytest.raises(_ApiError):
+            await ensure_thread(client, thread_id="t1", user_id="u1")

--- a/integrations/strands/python/tests/test_search.py
+++ b/integrations/strands/python/tests/test_search.py
@@ -1,0 +1,84 @@
+"""Tests for pin-or-expose ``create_zep_search_tool``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from zep_strands import create_zep_search_tool
+
+
+def _make_client() -> MagicMock:
+    client = MagicMock()
+    client.graph = MagicMock()
+    client.graph.search = AsyncMock(
+        return_value=SimpleNamespace(
+            context="auto context",
+            edges=[SimpleNamespace(fact="a fact")],
+            nodes=None,
+            episodes=None,
+            observations=None,
+            thread_summaries=None,
+        )
+    )
+    return client
+
+
+class TestCreateZepSearchTool:
+    def test_requires_exactly_one_scope(self) -> None:
+        client = _make_client()
+        with pytest.raises(ValueError, match="user_id or graph_id"):
+            create_zep_search_tool(zep_client=client)
+        with pytest.raises(ValueError, match="Only one"):
+            create_zep_search_tool(zep_client=client, user_id="u", graph_id="g")
+
+    def test_rejects_unknown_pinned_params(self) -> None:
+        with pytest.raises(ValueError, match="Unknown pinned"):
+            create_zep_search_tool(
+                zep_client=_make_client(),
+                user_id="u",
+                search_pinned_params={"bogus": 1},
+            )
+
+    def test_rejects_unknown_hidden_params(self) -> None:
+        with pytest.raises(ValueError, match="Unknown hidden"):
+            create_zep_search_tool(
+                zep_client=_make_client(),
+                user_id="u",
+                search_hidden_params={"bogus"},
+            )
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_graph_search(self) -> None:
+        client = _make_client()
+        tool = create_zep_search_tool(
+            zep_client=client,
+            user_id="u1",
+            search_pinned_params={"scope": "edges", "limit": 5},
+        )
+        # Strands DecoratedFunctionTool exposes the underlying callable via
+        # various attributes depending on version; exercise through stream
+        # or direct function if available.
+        fn = getattr(tool, "original_function", None) or getattr(tool, "_func", None)
+        if fn is None:
+            # Fall back: tool may be the decorated function itself.
+            fn = tool
+        result = await fn(query="hiking")
+        assert "a fact" in result or result == "auto context" or "fact" in result
+        client.graph.search.assert_awaited_once()
+        kwargs = client.graph.search.await_args.kwargs
+        assert kwargs["user_id"] == "u1"
+        assert kwargs["query"] == "hiking"
+        assert kwargs["scope"] == "edges"
+        assert kwargs["limit"] == 5
+
+    @pytest.mark.asyncio
+    async def test_tool_returns_error_string_on_failure(self) -> None:
+        client = _make_client()
+        client.graph.search.side_effect = RuntimeError("network down")
+        tool = create_zep_search_tool(zep_client=client, user_id="u1")
+        fn = getattr(tool, "original_function", None) or getattr(tool, "_func", None) or tool
+        result = await fn(query="x")
+        assert "Graph search failed" in result


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `zep-strands`, a Strands Agents integration that implements the native [`MemoryStore`](https://strandsagents.com/docs/user-guide/concepts/memory/overview/) interface on top of Zep’s temporal Context Graph. This is the extension point the AWS Strands team uses for long-term memory (same surface as Bedrock KB / AgentCore Memory Store / community stores like Dakera).

## What’s included

Package: `integrations/strands/python/` → PyPI name `zep-strands`, import `zep_strands`

| API | Behavior |
|-----|----------|
| `ZepMemoryStore.search` | `graph.search` (default `scope="auto"` → Context Block) |
| `ZepMemoryStore.add_messages` | `thread.add_messages` for **server-side** extraction |
| `ZepMemoryStore.add` | `graph.add` for text/JSON/message facts |
| `ZepMemoryStore.initialize` | Provisions user + thread |
| `ensure_user` / `ensure_thread` | Idempotent out-of-band helpers |
| `create_zep_search_tool` | Optional pin-or-expose on-demand search tool |

Also supports standalone-graph mode via `graph_id` (search + add only).

## Extraction notes

- `extraction=True` (default in writable user/thread mode) uses Strands’ server-side path via `add_messages`.
- Construction **fails fast** if extraction is enabled without writable `user_id` + `thread_id`.
- Strands’ default cadence is **every 5 turns**, so conversation batches only reach Zep when the trigger fires (or on `flush()`) — graph building is delayed vs turn-by-turn persistence, and Zep ingestion remains async after that.

## Usage sketch

```python
from strands import Agent
from strands.memory import MemoryManager
from zep_cloud.client import AsyncZep
from zep_strands import ZepMemoryStore

store = ZepMemoryStore(
    zep_client=AsyncZep(api_key="..."),
    user_id="user-123",
    thread_id="thread-abc",
    first_name="Jane",
    last_name="Smith",
    writable=True,
    extraction=True,
)
agent = Agent(memory_manager=MemoryManager(stores=[store]))
```

## Validation

- `ruff check` + `ruff format --check` — pass
- `mypy src/` — pass
- `pytest` — **55 passed**, 1 integration test skipped without `ZEP_API_KEY`
- CI wired via `paths-filter` entry for `strands` in `test-integrations.yml`
- Docs index / `integrations/CLAUDE.md` updated

## Follow-ups (not in this PR)

- Docs page on help.getzep.com (`/strands-memory`) once the package is published
- Listing in Strands community memory-stores catalog after release

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca9f0305-6fa9-415d-992a-aee4f7c720c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca9f0305-6fa9-415d-992a-aee4f7c720c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

