### PR TITLE
ci: bump gh-action-pypi-publish to accept metadata 2.5

### DIFF
--- a/.github/workflows/release-ingestion.yml
+++ b/.github/workflows/release-ingestion.yml
@@ -192,6 +192,6 @@ jobs:
           name: ingestion-dist
           path: dist/
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/

--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -309,7 +309,7 @@ jobs:
           name: ${{ needs.detect.outputs.framework }}-python-dist
           path: dist/
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/
 


### PR DESCRIPTION
## Summary
- Bumps `pypa/gh-action-pypi-publish` from v1.14.0 to v1.14.2 in the ingestion and integrations release workflows.
- Fixes the failed `zep-ingest` 0.2.0 PyPI publish, which rejected Hatchling’s Metadata-Version 2.5; v1.14.2 ships Twine 7 that accepts it.
- After merge, re-run **Release Ingestion Package** on `main` to finish uploading `zep-ingest` 0.2.0 (tag/GitHub Release already exist).

## Test plan
- [ ] Merge to `main`
- [ ] Re-run **Release Ingestion Package** on `main`
- [ ] Confirm `zep-ingest` 0.2.0 appears on PyPI


Made with [Cursor](https://cursor.com)