### PR TITLE
ci(ingestion): publish to PyPI before creating the release tag

### DIFF
--- a/.github/workflows/release-ingestion.yml
+++ b/.github/workflows/release-ingestion.yml
@@ -148,6 +148,17 @@ jobs:
       name: release
       url: https://pypi.org/p/zep-ingest
     steps:
+      # Publish before creating the tag/release so a failed upload cannot leave an
+      # orphaned tag that blocks the next dispatch after main moves forward.
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ingestion-dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist/
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ needs.resolve-release.outputs.sha }}
@@ -186,12 +197,3 @@ jobs:
             fi
             gh release create "${RELEASE_ARGS[@]}"
           fi
-      - name: Download build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: ingestion-dist
-          path: dist/
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-        with:
-          packages-dir: dist/


### PR DESCRIPTION
## Summary
- Reorders the ingestion release job so PyPI upload happens before the GitHub tag/release is created.
- Prevents a failed upload from leaving an orphaned tag that blocks the next dispatch after main moves.

## Test plan
- [ ] Merge, then re-dispatch **Release Ingestion Package** from `main`
- [ ] Confirm `zep-ingest` 0.2.0 publishes to PyPI and the GitHub release/tag is created afterward


Made with [Cursor](https://cursor.com)