### PR TITLE
feat(ingestion): default batch rollover to 10,000 items

### DIFF
--- a/ingestion/CHANGELOG.md
+++ b/ingestion/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `zep-ingest` are documented here. The project follows
 [Semantic Versioning](https://semver.org); while at `0.x` the public API may
 still change between minor versions.
 
+## Unreleased
+
+- Batch submission now rolls over at 10,000 items by default
+  (`DEFAULT_ITEMS_PER_BATCH`) instead of filling to the API's 50,000-item cap.
+  Pass `max_items_per_batch` (up to `MAX_ITEMS_PER_BATCH`) to request a larger
+  batch.
+
 ## 0.2.0
 
 **Breaking:** Zep assigns node and fact UUIDs server-side. Matches the API

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -131,14 +131,15 @@ ingest_slack_export(
 )
 ```
 
-**Batch vs sequential:** the Batch API (fast, 50k items/batch) is the default
-high-throughput submission path. `method="auto"` tries batch and transparently
-falls back to sequential `graph.add` calls with rate-limit-aware pacing in
-exactly one case: the deployment has no batch endpoint to call (HTTP 404 — an
-older server, a self-hosted or Community deployment, or a base URL that doesn't
-route `/batches`). Authorization and quota errors are raised as errors instead
-of quietly downgrading the run. Every source here ingests fine without the
-Batch API — pass `method="sequential"` to take that path deliberately.
+**Batch vs sequential:** the Batch API is the high-throughput submission path
+(10k items/batch by default, up to the API's 50k cap). `method="auto"` tries
+batch and transparently falls back to sequential `graph.add` calls with
+rate-limit-aware pacing in exactly one case: the deployment has no batch
+endpoint to call (HTTP 404 — an older server, a self-hosted or Community
+deployment, or a base URL that doesn't route `/batches`). Authorization and
+quota errors are raised as errors instead of quietly downgrading the run.
+Every source here ingests fine without the Batch API — pass
+`method="sequential"` to take that path deliberately.
 
 ## The pipeline
 

--- a/ingestion/SETUP.md
+++ b/ingestion/SETUP.md
@@ -23,7 +23,8 @@ Requires Python ≥ 3.11.
 ## 3. Batch API vs sequential
 
 - The **Batch API** is the default submission path and the fastest way to run
-  large backfills (up to 50,000 items per batch).
+  large backfills (10,000 items per batch by default, up to the API's 50,000-item
+  cap).
 - **Everything in this package also works without it**: if the deployment has
   no batch endpoint to call (HTTP 404 — an older server, a self-hosted or
   Community deployment, or a base URL that doesn't route `/batches`), the

--- a/ingestion/src/zep_ingest/__init__.py
+++ b/ingestion/src/zep_ingest/__init__.py
@@ -65,6 +65,7 @@ from zep_ingest.transforms.contextualizer import DEFAULT_CONTEXT_PROMPT, LLMCont
 from zep_ingest.transforms.limits import LimitGuard
 from zep_ingest.triples import FactTriple, ingest_fact_triples
 from zep_ingest.types import (
+    DEFAULT_ITEMS_PER_BATCH,
     MAX_EPISODE_CHARS,
     MAX_ITEMS_PER_ADD,
     MAX_ITEMS_PER_BATCH,
@@ -82,6 +83,7 @@ except _PackageNotFoundError:  # source tree without an editable install
 
 __all__ = [
     "DEFAULT_CONTEXT_PROMPT",
+    "DEFAULT_ITEMS_PER_BATCH",
     "DEFAULT_RISKY_WORDS",
     "DEFAULT_SKIP_SUBTYPES",
     "MAX_EPISODE_CHARS",

--- a/ingestion/src/zep_ingest/submitters/__init__.py
+++ b/ingestion/src/zep_ingest/submitters/__init__.py
@@ -13,6 +13,7 @@ from zep_ingest.result import IngestResult
 from zep_ingest.submitters.batch import BatchSubmitter, is_batch_unavailable, require_batch_id
 from zep_ingest.submitters.sequential import SequentialSubmitter, call_with_retries
 from zep_ingest.types import (
+    DEFAULT_ITEMS_PER_BATCH,
     MAX_ITEMS_PER_ADD,
     MAX_ITEMS_PER_BATCH,
     Destination,
@@ -33,7 +34,7 @@ def submit_episodes(
     *,
     method: Method = "auto",
     page_size: int = MAX_ITEMS_PER_ADD,
-    max_items_per_batch: int = MAX_ITEMS_PER_BATCH,
+    max_items_per_batch: int = DEFAULT_ITEMS_PER_BATCH,
     batch_metadata: dict[str, Any] | None = None,
     max_add_retries: int = 3,
     max_retries: int = 5,

--- a/ingestion/src/zep_ingest/submitters/batch.py
+++ b/ingestion/src/zep_ingest/submitters/batch.py
@@ -1,12 +1,12 @@
 """BatchSubmitter: bulk submission via the Zep Batch API.
 
 Pages the episode stream at the API's 350-items-per-add limit and rolls over to
-a new batch at the 50k-items-per-batch limit. Nothing that happens after the
-first batch opens is allowed to crash the run: a page that keeps failing is
-recorded as an AddError and the run continues, and a rollover that cannot open
-its next batch stops the run with the reason recorded — because the batches
-already submitted are still processing, and their ids are the only handle on
-them.
+a new batch at max_items_per_batch (10k by default, up to the API's 50k cap).
+Nothing that happens after the first batch opens is allowed to crash the run:
+a page that keeps failing is recorded as an AddError and the run continues, and
+a rollover that cannot open its next batch stops the run with the reason
+recorded — because the batches already submitted are still processing, and
+their ids are the only handle on them.
 """
 
 from collections.abc import Iterable
@@ -23,6 +23,7 @@ from zep_ingest.exceptions import BatchUnavailableError, InvalidBatchResponseErr
 from zep_ingest.result import AddError, IngestResult
 from zep_ingest.submitters.sequential import call_with_retries
 from zep_ingest.types import (
+    DEFAULT_ITEMS_PER_BATCH,
     MAX_ITEMS_PER_ADD,
     MAX_ITEMS_PER_BATCH,
     Destination,
@@ -98,7 +99,7 @@ class BatchSubmitter:
         client: Zep,
         *,
         page_size: int = MAX_ITEMS_PER_ADD,
-        max_items_per_batch: int = MAX_ITEMS_PER_BATCH,
+        max_items_per_batch: int = DEFAULT_ITEMS_PER_BATCH,
         batch_metadata: dict[str, Any] | None = None,
         max_add_retries: int = 3,
         initial_batch_id: str | None = None,

--- a/ingestion/src/zep_ingest/threads.py
+++ b/ingestion/src/zep_ingest/threads.py
@@ -51,8 +51,8 @@ from zep_ingest.submitters.batch import (
 from zep_ingest.submitters.sequential import call_with_retries
 from zep_ingest.transforms._splitting import split_text
 from zep_ingest.types import (
+    DEFAULT_ITEMS_PER_BATCH,
     MAX_ITEMS_PER_ADD,
-    MAX_ITEMS_PER_BATCH,
     MAX_MESSAGES_PER_THREAD_ADD,
     MAX_METADATA_KEYS,
 )
@@ -215,7 +215,7 @@ def _submit_batch(
         page = list(islice(iterator, MAX_ITEMS_PER_ADD))
         if not page:
             break
-        if batch_id is not None and items_in_batch + len(page) > MAX_ITEMS_PER_BATCH:
+        if batch_id is not None and items_in_batch + len(page) > DEFAULT_ITEMS_PER_BATCH:
             process_batch(client, batch_id, result, max_retries=max_retries)
             batch_id = None
         if batch_id is None:

--- a/ingestion/src/zep_ingest/types.py
+++ b/ingestion/src/zep_ingest/types.py
@@ -13,7 +13,8 @@ from zep_ingest.exceptions import ConfigurationError
 MAX_EPISODE_CHARS = 10_000
 SAFE_EPISODE_CHARS = 9_500  # LimitGuard target; headroom for context prefixes
 MAX_ITEMS_PER_ADD = 350
-MAX_ITEMS_PER_BATCH = 50_000
+MAX_ITEMS_PER_BATCH = 50_000  # documented API cap
+DEFAULT_ITEMS_PER_BATCH = 10_000  # default rollover; configurable up to MAX_ITEMS_PER_BATCH
 MAX_MESSAGES_PER_THREAD_ADD = 30  # thread.add_messages per call; not MAX_ITEMS_PER_ADD
 MAX_METADATA_KEYS = 10
 

--- a/ingestion/tests/test_basic.py
+++ b/ingestion/tests/test_basic.py
@@ -19,6 +19,7 @@ def test_public_api_exports():
         "SAFE_EPISODE_CHARS",
         "MAX_ITEMS_PER_ADD",
         "MAX_ITEMS_PER_BATCH",
+        "DEFAULT_ITEMS_PER_BATCH",
         "MAX_METADATA_KEYS",
         # protocols
         "Loader",

--- a/ingestion/tests/test_batch_submitter.py
+++ b/ingestion/tests/test_batch_submitter.py
@@ -10,7 +10,7 @@ from zep_cloud.types.batch_summary import BatchSummary
 from tests.conftest import make_batch_summary
 from zep_ingest.exceptions import BatchUnavailableError, InvalidBatchResponseError
 from zep_ingest.submitters.batch import BatchSubmitter
-from zep_ingest.types import Destination, Episode
+from zep_ingest.types import DEFAULT_ITEMS_PER_BATCH, Destination, Episode
 
 
 @pytest.fixture(autouse=True)
@@ -60,6 +60,10 @@ class TestPaging:
         mock_zep.batch.add.assert_not_called()
         assert result.items_submitted == 0
         assert result.status == "succeeded"
+
+    def test_default_max_items_per_batch_is_ten_thousand(self, mock_zep):
+        submitter = BatchSubmitter(mock_zep)
+        assert submitter.max_items_per_batch == DEFAULT_ITEMS_PER_BATCH == 10_000
 
     def test_rollover_at_max_items_per_batch(self, mock_zep):
         mock_zep.batch.create.side_effect = [

--- a/ingestion/tests/test_threads.py
+++ b/ingestion/tests/test_threads.py
@@ -289,7 +289,7 @@ class TestSequentialPath:
         # stop the run — never fall back to sequential, which would re-submit the
         # messages already in flight — and must keep the ids of those batches
         monkeypatch.setattr("zep_ingest.threads.MAX_ITEMS_PER_ADD", 1)
-        monkeypatch.setattr("zep_ingest.threads.MAX_ITEMS_PER_BATCH", 1)
+        monkeypatch.setattr("zep_ingest.threads.DEFAULT_ITEMS_PER_BATCH", 1)
         mock_zep.batch.create.side_effect = [
             make_batch_summary("b1", "draft"),
             ApiError(status_code=404),

--- a/ingestion/tests/test_types.py
+++ b/ingestion/tests/test_types.py
@@ -7,6 +7,7 @@ from zep_cloud.types.batch_add_item import BatchAddItem
 
 from zep_ingest.exceptions import ConfigurationError
 from zep_ingest.types import (
+    DEFAULT_ITEMS_PER_BATCH,
     MAX_EPISODE_CHARS,
     MAX_ITEMS_PER_ADD,
     MAX_ITEMS_PER_BATCH,
@@ -24,7 +25,9 @@ class TestConstants:
         assert MAX_EPISODE_CHARS == 10_000
         assert SAFE_EPISODE_CHARS == 9_500
         assert MAX_ITEMS_PER_ADD == 350
+        assert DEFAULT_ITEMS_PER_BATCH == 10_000
         assert MAX_ITEMS_PER_BATCH == 50_000
+        assert DEFAULT_ITEMS_PER_BATCH < MAX_ITEMS_PER_BATCH
         assert MAX_METADATA_KEYS == 10
 
 


### PR DESCRIPTION
## Summary
- Batch submission now rolls over at 10,000 items by default (`DEFAULT_ITEMS_PER_BATCH`) instead of filling to the API's 50,000-item cap.
- The 50k API maximum remains available via `max_items_per_batch` on `BatchSubmitter` / `submit_episodes`; thread-message batches use the same 10k default.
- Docs, changelog, and tests cover the new default while still asserting the 50k cap.

## Test plan
- [ ] Confirm `BatchSubmitter` and `submit_episodes` default to 10,000 and still accept up to 50,000
- [ ] Confirm a run larger than 10k episodes creates multiple batches unless `max_items_per_batch` is raised


Made with [Cursor](https://cursor.com)