### PR TITLE
chore(ingestion): bump zep-ingest to 0.2.1

### DIFF
--- a/ingestion/CHANGELOG.md
+++ b/ingestion/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `zep-ingest` are documented here. The project follows
 [Semantic Versioning](https://semver.org); while at `0.x` the public API may
 still change between minor versions.
 
-## Unreleased
+## 0.2.1
 
 - Batch submission now rolls over at 10,000 items by default
   (`DEFAULT_ITEMS_PER_BATCH`) instead of filling to the API's 50,000-item cap.

--- a/ingestion/pyproject.toml
+++ b/ingestion/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-ingest"
-version = "0.2.0"
+version = "0.2.1"
 description = "Bulk data ingestion pipeline for Zep: chunk, contextualize, canonicalize, and submit unstructured and structured data"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bumps `zep-ingest` from 0.2.0 to 0.2.1 so the release workflow can publish the 10k default batch rollover already on main.
- Moves that changelog entry from Unreleased to 0.2.1.

## Test plan
- [ ] After merge, dispatch **Release Ingestion Package** from `main` (do not create the tag yourself)
- [ ] Confirm PyPI and the `zep-ingest-v0.2.1` GitHub Release land


Made with [Cursor](https://cursor.com)