### PR TITLE
feat(ingestion): submit all sources then poll the last episode (v0.3.0)

### DIFF
--- a/ingestion/CHANGELOG.md
+++ b/ingestion/CHANGELOG.md
@@ -24,8 +24,15 @@ still change between minor versions.
 - File one-liners and loaders accept a sequence of paths/globs in caller order
   (`ingest_json_records(client, [issues, prs, jira], graph_id=...)`).
 - `ConcatLoader` concatenates heterogeneous loaders into one submit stream.
-- `IngestResult.combine(...)` merges separate submits to the same graph so a
-  single `wait()` can cover all of them.
+- `IngestResult.combine(...)` merges poll handles for separate submits to the same
+  graph (`batch_ids`, `episode_uuids`, `task_ids`); it does not merge
+  `node_uuids` / `edge_uuids` (zip alignment). Prefer separate `wait()` calls
+  for seeding vs episode ingest.
+- Multi-thread sequential backfills poll the last message UUID **per thread**
+  (threads are independent sagas on the server). Regular `thread.add_messages`
+  returns `message_uuids` only — not `task_id`.
+- Production smoke script: `ingestion/scripts/release_smoke_prod.py` (requires
+  `ZEP_API_KEY`; run via KeyBank `zep-prod`).
 
 ## 0.2.1
 

--- a/ingestion/CHANGELOG.md
+++ b/ingestion/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `zep-ingest` are documented here. The project follows
 [Semantic Versioning](https://semver.org); while at `0.x` the public API may
 still change between minor versions.
 
+## 0.3.0
+
+- **Submit everything, then wait once.** Multiple files or loaders destined for
+  the same graph are submitted together. Sequential vs batch only chooses the
+  submit API (`graph.add` vs Batch API); neither waits for one file to finish
+  processing before the next is sent. If you do not need to block, submit and
+  return — `wait()` stays opt-in.
+- `wait()` polls only the last submitted episode (per-graph extraction is
+  ordered). The default timeout is `wait_timeout_seconds(items_submitted)` —
+  15s per item, minimum 120s. Pass `timeout=None` to wait without a deadline.
+  `IngestResult.from_batch_ids(...).wait()` has no item count, so auto timeout
+  does not invent a 120s cap.
+- File one-liners and loaders accept a sequence of paths/globs in caller order
+  (`ingest_json_records(client, [issues, prs, jira], graph_id=...)`).
+- `ConcatLoader` concatenates heterogeneous loaders into one submit stream.
+- `IngestResult.combine(...)` merges separate submits to the same graph so a
+  single `wait()` can cover all of them.
+
 ## 0.2.1
 
 - Batch submission now rolls over at 10,000 items by default

--- a/ingestion/CHANGELOG.md
+++ b/ingestion/CHANGELOG.md
@@ -13,7 +13,7 @@ still change between minor versions.
   return — `wait()` stays opt-in.
 - `wait()` polls only the last submitted episode (per-graph extraction is
   ordered). The default timeout is `wait_timeout_seconds(items_submitted)` —
-  15s per item, minimum 120s. Pass `timeout=None` to wait without a deadline.
+  60s per item, minimum 120s. Pass `timeout=None` to wait without a deadline.
   `IngestResult.from_batch_ids(...).wait()` has no item count, so auto timeout
   does not invent a 120s cap.
 - File one-liners and loaders accept a sequence of paths/globs in caller order

--- a/ingestion/CHANGELOG.md
+++ b/ingestion/CHANGELOG.md
@@ -14,7 +14,8 @@ still change between minor versions.
 - `wait()` aligns with [Check data ingestion status](https://help.getzep.com/check-data-ingestion-status):
   Batch API paths poll the last batch via `batch.get`; sequential `graph.add`
   polls the last-submitted episode; sequential `thread.add_messages` polls the
-  last message UUID in the last request; nodes/triples poll every task id.
+  last message UUID per thread (regular ``add_messages`` returns message UUIDs,
+  not ``task_id``); nodes/triples poll every task id.
   Default timeout is `wait_timeout_seconds(items_submitted)` — 60s per item,
   minimum 120s. Pass `timeout=None` to wait without a deadline.
   `IngestResult.from_batch_ids(...).wait()` has no item count, so auto timeout

--- a/ingestion/CHANGELOG.md
+++ b/ingestion/CHANGELOG.md
@@ -11,11 +11,15 @@ still change between minor versions.
   submit API (`graph.add` vs Batch API); neither waits for one file to finish
   processing before the next is sent. If you do not need to block, submit and
   return — `wait()` stays opt-in.
-- `wait()` polls only the last submitted episode (per-graph extraction is
-  ordered). The default timeout is `wait_timeout_seconds(items_submitted)` —
-  60s per item, minimum 120s. Pass `timeout=None` to wait without a deadline.
+- `wait()` aligns with [Check data ingestion status](https://help.getzep.com/check-data-ingestion-status):
+  Batch API paths poll the last batch via `batch.get`; sequential `graph.add`
+  polls the last-submitted episode; sequential `thread.add_messages` polls the
+  last message UUID in the last request; nodes/triples poll every task id.
+  Default timeout is `wait_timeout_seconds(items_submitted)` — 60s per item,
+  minimum 120s. Pass `timeout=None` to wait without a deadline.
   `IngestResult.from_batch_ids(...).wait()` has no item count, so auto timeout
-  does not invent a 120s cap.
+  does not invent a 120s cap. Do not mix Batch API and sequential `graph.add`
+  on the same graph and expect one `wait()` to cover both.
 - File one-liners and loaders accept a sequence of paths/globs in caller order
   (`ingest_json_records(client, [issues, prs, jira], graph_id=...)`).
 - `ConcatLoader` concatenates heterogeneous loaders into one submit stream.

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -143,8 +143,9 @@ Every source here ingests fine without the Batch API — pass
 mean "wait until this file has finished extracting before submitting the next."
 It only means each item is sent with `graph.add` (or `thread.add_messages`)
 instead of the Batch API. Submit every file into the graph first; `wait()` is
-opt-in and, when used, polls the last episode with a timeout that scales with
-how many episodes were queued.
+opt-in. On the default Batch path it monitors `batch.get` on the last batch;
+on sequential fallback it polls the last-submitted episode's `processed` flag
+(see [Check data ingestion status](https://help.getzep.com/check-data-ingestion-status)).
 
 ## The pipeline
 
@@ -171,7 +172,7 @@ pipeline = Pipeline(
 )
 report = pipeline.preview()  # NO Zep API calls: inspect episodes + warnings first
 result = pipeline.run(client, graph_id="company_kb")
-result.wait()  # opt-in; polls the last episode, timeout scales with item count
+result.wait()  # opt-in; batch.get tail or last-submitted episode; timeout scales with item count
 ```
 
 `preview()` shows the transformed episodes and validation warnings (including
@@ -406,7 +407,7 @@ result = ingest_json_records(
     ["data/issues.jsonl", "data/prs.jsonl", "data/jira.jsonl"],
     graph_id="engineering",
 )
-result.wait()  # polls the last episode; timeout scales with items_submitted
+result.wait()  # batch.get on the last batch (default path); timeout scales with items_submitted
 
 # Mixed sources, still one submit stream:
 from zep_ingest import JsonRecordsLoader, TextFileLoader
@@ -423,10 +424,11 @@ result = ingest(
 )
 result.wait()
 
-# Already-separate calls (e.g. nodes then episodes): submit all, then wait once.
+# Already-separate calls: prefer separate wait() for seeding vs episodes.
 nodes = ingest_nodes(client, node_items, graph_id="engineering")
+nodes.wait()
 docs = ingest_json_records(client, ["data/issues.jsonl", "data/prs.jsonl"], graph_id="engineering")
-nodes.combine(docs).wait()
+docs.wait()
 ```
 
 If you are not polling, stop after submit — there is nothing else to do.
@@ -522,6 +524,20 @@ but when it raises — a timeout, or a submission the API left untracked —
 nothing was ever bound, and `batch_ids` / `task_ids` are the only handles for
 resuming or diagnosing that run.
 
+**What `wait()` polls** (aligned with
+[Check data ingestion status](https://help.getzep.com/check-data-ingestion-status)):
+
+| Submission path | Monitor via `wait()` |
+| --- | --- |
+| Batch API (default for episodes and thread backfill) | Last `batch_id` via `batch.get` |
+| Sequential `graph.add` (batch fallback) | Last-submitted episode (`episode_uuids[-1]`) |
+| Sequential `thread.add_messages` | Last message UUID in the last request |
+| `ingest_nodes` / `ingest_fact_triples` | Every `task_id` (separate queue from episodes) |
+
+Do not mix Batch API and sequential `graph.add` into the same graph and expect
+one `wait()` to cover both. Seed nodes/triples first with their own `wait()`,
+then ingest episodes.
+
 Ingestion is asynchronous — a just-added fact is not instantly retrievable,
 even after `wait()`: search indexing lands a few seconds after processing.
 `search_when_ready` owns that gap so scripts don't hand-roll poll loops:
@@ -537,9 +553,9 @@ recorded as `AddError`s (indices and API messages only — never episode content
 and the run continues. `batch_ids` / `episode_uuids` / `task_ids` are the
 resume handles; `node_uuids` / `edge_uuids` record identities Zep assigned on
 `ingest_nodes` and completed `ingest_fact_triples` tasks (`None` slots mark
-failures so later successes stay zip-aligned). Task IDs are used by
-asynchronous operations such as fact triples, direct node creation, and
-sequential thread submissions, and `wait()` polls them through `client.task`.
+failures so later successes stay zip-aligned). Task IDs are used when
+``thread.add_messages`` returns no message UUIDs, and by asynchronous operations
+such as fact triples and direct node creation; ``wait()`` polls every task id.
 
 If the API accepts a task-backed submission without returning a completion
 handle, the result reports `status == "untracked"` instead of claiming success.

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -531,7 +531,7 @@ resuming or diagnosing that run.
 | --- | --- |
 | Batch API (default for episodes and thread backfill) | Last `batch_id` via `batch.get` |
 | Sequential `graph.add` (batch fallback) | Last-submitted episode (`episode_uuids[-1]`) |
-| Sequential `thread.add_messages` | Last message UUID in the last request |
+| Sequential `thread.add_messages` | Last message UUID per thread (`message_uuids`; no `task_id`) |
 | `ingest_nodes` / `ingest_fact_triples` | Every `task_id` (separate queue from episodes) |
 
 Do not mix Batch API and sequential `graph.add` into the same graph and expect
@@ -553,9 +553,9 @@ recorded as `AddError`s (indices and API messages only — never episode content
 and the run continues. `batch_ids` / `episode_uuids` / `task_ids` are the
 resume handles; `node_uuids` / `edge_uuids` record identities Zep assigned on
 `ingest_nodes` and completed `ingest_fact_triples` tasks (`None` slots mark
-failures so later successes stay zip-aligned). Task IDs are used when
-``thread.add_messages`` returns no message UUIDs, and by asynchronous operations
-such as fact triples and direct node creation; ``wait()`` polls every task id.
+failures so later successes stay zip-aligned). Task IDs come from
+``ingest_nodes``, ``ingest_fact_triples``, and ``add_messages_batch`` — not from
+regular ``thread.add_messages``, which returns message UUIDs instead.
 
 If the API accepts a task-backed submission without returning a completion
 handle, the result reports `status == "untracked"` instead of claiming success.

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -139,7 +139,12 @@ endpoint to call (HTTP 404 — an older server, a self-hosted or Community
 deployment, or a base URL that doesn't route `/batches`). Authorization and
 quota errors are raised as errors instead of quietly downgrading the run.
 Every source here ingests fine without the Batch API — pass
-`method="sequential"` to take that path deliberately.
+`method="sequential"` to take that path deliberately. Sequential does **not**
+mean "wait until this file has finished extracting before submitting the next."
+It only means each item is sent with `graph.add` (or `thread.add_messages`)
+instead of the Batch API. Submit every file into the graph first; `wait()` is
+opt-in and, when used, polls the last episode with a timeout that scales with
+how many episodes were queued.
 
 ## The pipeline
 
@@ -166,7 +171,7 @@ pipeline = Pipeline(
 )
 report = pipeline.preview()  # NO Zep API calls: inspect episodes + warnings first
 result = pipeline.run(client, graph_id="company_kb")
-result.wait(timeout=3600)  # submission returns immediately; blocking is opt-in
+result.wait()  # opt-in; polls the last episode, timeout scales with item count
 ```
 
 `preview()` shows the transformed episodes and validation warnings (including
@@ -383,7 +388,48 @@ graph):
    `source_node_uuid`/`target_node_uuid`. Extraction dedups against the existing
    graph, so known entities anchor resolution.
 5. Ingest the corpus with real `created_at` timestamps and alias
-   canonicalization, then block on the bound result with `result.wait(...)`.
+   canonicalization. Submit every source for a graph before waiting. Then, if
+   you need extraction to finish, block on the bound result with
+   `result.wait()` (or `combined.wait()` after `IngestResult.combine`).
+
+## Many files, one graph
+
+Do not wait for one file (or one graph) to finish processing before submitting
+the next. Create destinations and set ontology, then enqueue everything.
+
+```python
+from zep_ingest import ConcatLoader, ingest, ingest_json_records, ingest_nodes
+
+# Same loader, several files — submitted in this order, one wait:
+result = ingest_json_records(
+    client,
+    ["data/issues.jsonl", "data/prs.jsonl", "data/jira.jsonl"],
+    graph_id="engineering",
+)
+result.wait()  # polls the last episode; timeout scales with items_submitted
+
+# Mixed sources, still one submit stream:
+from zep_ingest import JsonRecordsLoader, TextFileLoader
+
+result = ingest(
+    client,
+    ConcatLoader(
+        [
+            JsonRecordsLoader(["data/issues.jsonl", "data/prs.jsonl"]),
+            TextFileLoader("data/runbooks/**/*.md"),
+        ]
+    ),
+    graph_id="engineering",
+)
+result.wait()
+
+# Already-separate calls (e.g. nodes then episodes): submit all, then wait once.
+nodes = ingest_nodes(client, node_items, graph_id="engineering")
+docs = ingest_json_records(client, ["data/issues.jsonl", "data/prs.jsonl"], graph_id="engineering")
+nodes.combine(docs).wait()
+```
+
+If you are not polling, stop after submit — there is nothing else to do.
 
 ## Fact triples
 
@@ -407,7 +453,7 @@ result = ingest_fact_triples(
     ],
     graph_id="org",
 )
-result.wait(timeout=600)
+result.wait()
 # Zep assigns the fact UUID; it lands in task params as edge_uuid after completion.
 # Parallel to the submitted triples — failed tasks leave None in that slot.
 result.edge_uuids
@@ -463,7 +509,7 @@ Sequential only (the Batch API doesn't take direct nodes).
 ```python
 result = ingest_slack_export(client, "export.zip", graph_id="g1")
 result.status  # queued | processing | untracked | succeeded | partial | failed | canceled
-result.wait(timeout=3600)
+result.wait()
 result.failed_items()  # Batch API item records and/or submission AddErrors
 result.warnings  # everything the pipeline noticed
 result.raise_for_status()  # opt-in strictness

--- a/ingestion/README.md
+++ b/ingestion/README.md
@@ -627,5 +627,13 @@ make install   # uv sync --extra dev
 make all       # format + lint + type-check + test
 ```
 
+Before a release, run the production smoke script against a throwaway graph
+(requires `ZEP_API_KEY` and `ZEP_API_URL`):
+
+```bash
+keybank run zep-prod -- env ZEP_API_URL=https://api.getzep.com \
+  uv run python scripts/release_smoke_prod.py
+```
+
 Live integration tests run only when `ZEP_API_KEY` is set. See
 [`SETUP.md`](https://github.com/getzep/zep/blob/main/ingestion/SETUP.md) for account setup.

--- a/ingestion/examples/documents_example.py
+++ b/ingestion/examples/documents_example.py
@@ -65,7 +65,7 @@ def main() -> None:
     )
     # Submission returns immediately; blocking is opt-in. Bind the result first
     # so a wait() timeout still leaves you the ids below to resume from.
-    result.wait(timeout=600)
+    result.wait()
     print(f"Submitted {result.items_submitted} chunks via {result.method}: {result.status}")
     for warning in result.warnings:
         print(f"WARNING: {warning}")

--- a/ingestion/examples/email_example.py
+++ b/ingestion/examples/email_example.py
@@ -49,7 +49,7 @@ def main() -> None:
     )
     # Submission returns immediately; blocking is opt-in. Bind the result first
     # so a wait() timeout still leaves you the ids below to resume from.
-    result.wait(timeout=600)
+    result.wait()
     print(f"Submitted {result.items_submitted} emails via {result.method}: {result.status}")
     for warning in result.warnings:
         print(f"WARNING: {warning}")

--- a/ingestion/examples/fact_triples_example.py
+++ b/ingestion/examples/fact_triples_example.py
@@ -157,7 +157,7 @@ def main() -> None:
     #    already happened at FactTriple construction — before any API call.
     triples = load_triples()
     result = ingest_fact_triples(client, triples, graph_id=graph_id)
-    result.wait(timeout=600)
+    result.wait()
     result.raise_for_status()
     print(f"Molded org_chart.json into {len(triples)} fact triples: {result.status}")
 

--- a/ingestion/examples/json_records_example.py
+++ b/ingestion/examples/json_records_example.py
@@ -52,7 +52,7 @@ def main() -> None:
     )
     # Submission returns immediately; blocking is opt-in. Bind the result first
     # so a wait() timeout still leaves you the ids below to resume from.
-    result.wait(timeout=600)
+    result.wait()
     print(f"Submitted {result.items_submitted} records via {result.method}: {result.status}")
     for warning in result.warnings:
         print(f"WARNING: {warning}")

--- a/ingestion/examples/slack_export_example.py
+++ b/ingestion/examples/slack_export_example.py
@@ -72,7 +72,7 @@ def main() -> None:
     )
     # Submission returns immediately; blocking is opt-in. Bind the result first
     # so a wait() timeout still leaves you the ids below to resume from.
-    result.wait(timeout=600)
+    result.wait()
     print(f"Submitted {result.items_submitted} episodes via {result.method}: {result.status}")
     for warning in result.warnings:
         print(f"WARNING: {warning}")

--- a/ingestion/examples/user_graph_example.py
+++ b/ingestion/examples/user_graph_example.py
@@ -85,7 +85,7 @@ def main() -> None:
         ),
     ]
     profile_result = ingest_fact_triples(client, profile, user_id=user_id)
-    profile_result.wait(timeout=600)
+    profile_result.wait()
     profile_result.raise_for_status()
     print(f"Seeded {len(profile)} profile facts")
 
@@ -108,7 +108,7 @@ def main() -> None:
         user_id=user_id,
         created_at="2025-06-20T00:00:00Z",  # generated source date
     )
-    docs.wait(timeout=600)
+    docs.wait()
     print(f"Ingested {docs.items_submitted} document chunks: {docs.status}")
 
     # Extraction is asynchronous; wait until facts are searchable, then pull

--- a/ingestion/pyproject.toml
+++ b/ingestion/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zep-ingest"
-version = "0.2.1"
+version = "0.3.0"
 description = "Bulk data ingestion pipeline for Zep: chunk, contextualize, canonicalize, and submit unstructured and structured data"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/ingestion/scripts/release_smoke_prod.py
+++ b/ingestion/scripts/release_smoke_prod.py
@@ -1,0 +1,377 @@
+"""Production smoke tests for zep-ingest 0.3.0 release candidates.
+
+Exercises submit-all-then-wait-once, tail polling, thread message UUIDs,
+multi-thread sagas, and phased node seeding. Requires ZEP_API_KEY (and
+ZEP_API_URL for zep-cloud). Run via KeyBank:
+
+    keybank run zep-prod -- env ZEP_API_URL=https://api.getzep.com \\
+      uv run --directory ingestion python scripts/release_smoke_prod.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import time
+import uuid
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from zep_cloud.client import Zep
+from zep_cloud.types import Message
+
+from zep_ingest import Episode, NodeItem, ingest, ingest_json_records, ingest_nodes
+from zep_ingest.exceptions import BatchUnavailableError
+from zep_ingest.threads import ThreadMessage, ingest_thread_messages
+
+
+@dataclass
+class PollStats:
+    batch_get: int = 0
+    episode_get: Counter[str] = field(default_factory=Counter)
+    task_get: int = 0
+
+
+def instrument_client(client: Zep) -> PollStats:
+    stats = PollStats()
+    orig_batch_get = client.batch.get
+    orig_episode_get = client.graph.episode.get
+    orig_task_get = client.task.get
+
+    def batch_get(batch_id: str, *args: Any, **kwargs: Any):
+        stats.batch_get += 1
+        return orig_batch_get(batch_id, *args, **kwargs)
+
+    def episode_get(*args: Any, **kwargs: Any):
+        uuid_ = kwargs.get("uuid_") or (args[0] if args else "?")
+        stats.episode_get[str(uuid_)] += 1
+        return orig_episode_get(*args, **kwargs)
+
+    def task_get(task_id: str, *args: Any, **kwargs: Any):
+        stats.task_get += 1
+        return orig_task_get(task_id, *args, **kwargs)
+
+    client.batch.get = batch_get  # type: ignore[method-assign]
+    client.graph.episode.get = episode_get  # type: ignore[method-assign]
+    client.task.get = task_get  # type: ignore[method-assign]
+    return stats
+
+
+class ListLoader:
+    def __init__(self, episodes: list[Episode]) -> None:
+        self.episodes = episodes
+
+    def load(self):
+        yield from self.episodes
+
+
+@dataclass
+class CaseResult:
+    name: str
+    ok: bool
+    seconds: float
+    detail: str
+
+
+def ok(name: str, seconds: float, detail: str) -> CaseResult:
+    return CaseResult(name=name, ok=True, seconds=seconds, detail=detail)
+
+
+def fail(name: str, seconds: float, detail: str) -> CaseResult:
+    return CaseResult(name=name, ok=False, seconds=seconds, detail=detail)
+
+
+def run_case(name: str, fn) -> CaseResult:
+    start = time.monotonic()
+    try:
+        detail = fn()
+        return ok(name, time.monotonic() - start, detail)
+    except Exception as exc:  # noqa: BLE001 — smoke script reports all failures
+        return fail(name, time.monotonic() - start, f"{type(exc).__name__}: {exc}")
+
+
+def main() -> int:
+    run_id = uuid.uuid4().hex[:10]
+    client = Zep()
+    stats_holder: list[PollStats] = []
+
+    graph_id = f"ingest-smoke-{run_id}"
+    user_id = f"ingest-smoke-user-{run_id}"
+    client.graph.create(graph_id=graph_id, name=f"ingest smoke {run_id}")
+    client.user.add(
+        user_id=user_id,
+        first_name="Ingest",
+        last_name="Smoke",
+        email=f"{user_id}@example.com",
+    )
+
+    results: list[CaseResult] = []
+
+    def case_thread_add_messages_no_task_id() -> str:
+        thread_id = f"probe-{run_id}"
+        client.thread.create(thread_id=thread_id, user_id=user_id)
+        response = client.thread.add_messages(
+            thread_id,
+            messages=[
+                Message(
+                    role="user",
+                    name="Smoke Tester",
+                    content="Probe: sequential thread.add_messages response shape.",
+                    created_at="2025-06-01T12:00:00Z",
+                )
+            ],
+        )
+        uuids = getattr(response, "message_uuids", None) or []
+        task_id = getattr(response, "task_id", None)
+        if not uuids:
+            raise AssertionError("expected message_uuids from thread.add_messages")
+        if task_id is not None:
+            raise AssertionError(f"expected task_id=None, got {task_id!r}")
+        return f"message_uuids={len(uuids)}, task_id=null"
+
+    def case_batch_submit_all_wait_once() -> str:
+        stats = instrument_client(client)
+        stats_holder.append(stats)
+        episodes = [
+            Episode(
+                data=f"Batch smoke episode {i}: employee {run_id} shipped feature {i}.",
+                created_at=f"2024-06-{10 + i:02d}T10:00:00Z",
+            )
+            for i in range(5)
+        ]
+        t0 = time.monotonic()
+        try:
+            result = ingest(client, ListLoader(episodes), graph_id=graph_id, method="batch")
+        except BatchUnavailableError as exc:
+            raise AssertionError("production must support batch API") from exc
+        submit_s = time.monotonic() - t0
+        assert result.items_submitted == 5
+        assert result.batch_ids, "expected batch_ids"
+        assert not result.episode_uuids
+        pre_wait_batch_calls = stats.batch_get
+        t1 = time.monotonic()
+        result.wait(poll_interval=5.0, timeout=600)
+        wait_s = time.monotonic() - t1
+        assert result.status in ("succeeded", "partial")
+        # Tail polling: should not call batch.get once per item per tick.
+        wait_batch_calls = stats.batch_get - pre_wait_batch_calls
+        return (
+            f"submit={submit_s:.1f}s wait={wait_s:.1f}s batch_ids={len(result.batch_ids)} "
+            f"batch.get during wait={wait_batch_calls} status={result.status}"
+        )
+
+    def case_sequential_tail_episode_poll() -> str:
+        stats = instrument_client(client)
+        stats_holder.append(stats)
+        episodes = [
+            Episode(
+                data=f"Sequential smoke {i}: project {run_id} milestone {i}.",
+                created_at=f"2024-07-{10 + i:02d}T09:00:00Z",
+            )
+            for i in range(3)
+        ]
+        result = ingest(client, ListLoader(episodes), graph_id=graph_id, method="sequential")
+        assert len(result.episode_uuids) == 3
+        tail = result.episode_uuids[-1]
+        pre = sum(stats.episode_get.values())
+        result.wait(poll_interval=5.0, timeout=300)
+        polled_uuids = set(stats.episode_get.keys())
+        assert result.status == "succeeded"
+        # Should poll mostly the tail until it completes.
+        assert tail in polled_uuids
+        assert stats.episode_get[tail] >= 1
+        assert stats.task_get == 0
+        return (
+            f"episodes={len(result.episode_uuids)} tail={tail[:8]}… "
+            f"episode.get calls={sum(stats.episode_get.values()) - pre} "
+            f"unique_uuids_polled={len(polled_uuids)} status={result.status}"
+        )
+
+    def case_phased_nodes_then_episodes() -> str:
+        stats = instrument_client(client)
+        stats_holder.append(stats)
+        nodes = ingest_nodes(
+            client,
+            [
+                NodeItem(name=f"Smoke Entity A {run_id}", label="Entity"),
+                NodeItem(name=f"Smoke Entity B {run_id}", label="Entity"),
+            ],
+            graph_id=graph_id,
+        )
+        assert nodes.task_ids, "add_nodes should return task_ids"
+        assert not nodes.episode_uuids
+        t0 = time.monotonic()
+        nodes.wait(poll_interval=5.0, timeout=300)
+        nodes_wait = time.monotonic() - t0
+        assert nodes.status == "succeeded"
+        assert all(nodes.node_uuids)
+        assert stats.task_get >= len(nodes.task_ids)
+        pre_tasks = stats.task_get
+
+        episodes = ingest(
+            client,
+            ListLoader(
+                [
+                    Episode(
+                        data=f"After seeding nodes, {run_id} closed the release checklist.",
+                        created_at="2024-08-01T12:00:00Z",
+                    )
+                ]
+            ),
+            graph_id=graph_id,
+            method="batch",
+        )
+        t1 = time.monotonic()
+        episodes.wait(poll_interval=5.0, timeout=300)
+        ep_wait = time.monotonic() - t1
+        assert episodes.status in ("succeeded", "partial")
+        return (
+            f"nodes.wait={nodes_wait:.1f}s node_uuids={nodes.node_uuids} "
+            f"episodes.wait={ep_wait:.1f}s tasks_during_ep_wait={stats.task_get - pre_tasks} "
+            f"status={episodes.status}"
+        )
+
+    def case_multi_file_one_wait() -> str:
+        stats = instrument_client(client)
+        stats_holder.append(stats)
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = []
+            for i in range(3):
+                path = Path(tmp) / f"records_{i}.jsonl"
+                path.write_text(
+                    json.dumps(
+                        {
+                            "id": f"{run_id}-{i}",
+                            "summary": f"JSONL file {i} for {run_id}: inventory update {i}.",
+                            "date": f"2024-09-{10 + i:02d}T00:00:00Z",
+                        }
+                    )
+                    + "\n"
+                )
+                paths.append(path)
+            t0 = time.monotonic()
+            result = ingest_json_records(
+                client,
+                paths,
+                graph_id=graph_id,
+                id_field="id",
+                created_at_field="date",
+            )
+            submit_s = time.monotonic() - t0
+            assert result.items_submitted == 3
+            t1 = time.monotonic()
+            result.wait(poll_interval=5.0, timeout=600)
+            wait_s = time.monotonic() - t1
+        assert result.status in ("succeeded", "partial")
+        return (
+            f"files=3 submit={submit_s:.1f}s wait={wait_s:.1f}s "
+            f"batch.get={stats.batch_get} status={result.status}"
+        )
+
+    def case_multi_thread_sequential_wait() -> str:
+        stats = instrument_client(client)
+        stats_holder.append(stats)
+        t1 = f"thread-a-{run_id}"
+        t2 = f"thread-b-{run_id}"
+        client.thread.create(thread_id=t1, user_id=user_id)
+        client.thread.create(thread_id=t2, user_id=user_id)
+        messages = [
+            ThreadMessage(
+                thread_id=t1,
+                role="user",
+                name="Alice",
+                content=f"Thread A message 1 for {run_id}.",
+                created_at="2025-01-01T10:00:00Z",
+            ),
+            ThreadMessage(
+                thread_id=t2,
+                role="user",
+                name="Bob",
+                content=f"Thread B message 1 for {run_id}.",
+                created_at="2025-01-01T10:01:00Z",
+            ),
+            ThreadMessage(
+                thread_id=t1,
+                role="user",
+                name="Alice",
+                content=f"Thread A message 2 for {run_id}.",
+                created_at="2025-01-01T10:02:00Z",
+            ),
+        ]
+        result = ingest_thread_messages(client, messages, user_id=user_id, method="sequential")
+        assert result.task_ids == []
+        assert len(result.episode_uuids) == 2
+        assert result._single_queue_episode_poll is False
+        result.wait(poll_interval=5.0, timeout=600)
+        assert result.status == "succeeded"
+        polled = set(stats.episode_get.keys())
+        assert polled == set(result.episode_uuids), f"polled {polled} vs {result.episode_uuids}"
+        return (
+            f"threads=2 poll_uuids={result.episode_uuids} "
+            f"episode.get total={sum(stats.episode_get.values())} status={result.status}"
+        )
+
+    def case_thread_batch_backfill() -> str:
+        stats = instrument_client(client)
+        stats_holder.append(stats)
+        thread_id = f"batch-thread-{run_id}"
+        client.thread.create(thread_id=thread_id, user_id=user_id)
+        messages = [
+            ThreadMessage(
+                thread_id=thread_id,
+                role="user",
+                name="Carol",
+                content=f"Batch thread message {i} for {run_id}.",
+                created_at=f"2025-02-{10 + i:02d}T12:00:00Z",
+            )
+            for i in range(4)
+        ]
+        try:
+            result = ingest_thread_messages(client, messages, user_id=user_id, method="batch")
+        except BatchUnavailableError as exc:
+            raise AssertionError("production must support batch for thread backfill") from exc
+        assert result.batch_ids
+        assert not result.episode_uuids
+        result.wait(poll_interval=5.0, timeout=600)
+        assert result.status in ("succeeded", "partial")
+        return (
+            f"messages=4 batch_ids={len(result.batch_ids)} "
+            f"batch.get={stats.batch_get} status={result.status}"
+        )
+
+    cases = [
+        ("thread.add_messages has message_uuids not task_id", case_thread_add_messages_no_task_id),
+        ("batch: submit 5 episodes then wait once", case_batch_submit_all_wait_once),
+        ("sequential graph.add: tail episode poll", case_sequential_tail_episode_poll),
+        ("phased: nodes.wait then episodes.wait", case_phased_nodes_then_episodes),
+        ("multi-file json: one submit one wait", case_multi_file_one_wait),
+        ("multi-thread sequential: poll each thread tail", case_multi_thread_sequential_wait),
+        ("thread batch backfill: batch.get wait", case_thread_batch_backfill),
+    ]
+
+    print(f"zep-ingest production smoke  run_id={run_id}  graph_id={graph_id}")
+    print("-" * 72)
+    for name, fn in cases:
+        result = run_case(name, fn)
+        results.append(result)
+        mark = "PASS" if result.ok else "FAIL"
+        print(f"[{mark}] {result.name} ({result.seconds:.1f}s)")
+        print(f"       {result.detail}")
+
+    print("-" * 72)
+    passed = sum(1 for r in results if r.ok)
+    print(f"{passed}/{len(results)} passed")
+
+    try:
+        client.graph.delete(graph_id)
+    except Exception:  # noqa: BLE001
+        print(f"warning: could not delete graph {graph_id}")
+
+    return 0 if passed == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ingestion/src/zep_ingest/__init__.py
+++ b/ingestion/src/zep_ingest/__init__.py
@@ -39,6 +39,7 @@ from zep_ingest.exceptions import (
     ZepDependencyError,
     ZepIngestError,
 )
+from zep_ingest.loaders.concat import ConcatLoader
 from zep_ingest.loaders.email import EmlLoader
 from zep_ingest.loaders.json_records import JsonRecordsLoader
 from zep_ingest.loaders.slack import DEFAULT_SKIP_SUBTYPES, SlackExportLoader, SlackMessage
@@ -56,7 +57,13 @@ from zep_ingest.pipeline import (
     ingest_transcripts,
 )
 from zep_ingest.protocols import LLMClient, Loader, Submitter, Transform
-from zep_ingest.result import AddError, IngestResult
+from zep_ingest.result import (
+    MIN_WAIT_TIMEOUT_SECONDS,
+    SECONDS_PER_SUBMITTED_ITEM,
+    AddError,
+    IngestResult,
+    wait_timeout_seconds,
+)
 from zep_ingest.submitters import BatchSubmitter, SequentialSubmitter
 from zep_ingest.threads import ThreadMessage, ingest_thread_messages
 from zep_ingest.transforms.canonicalizer import DEFAULT_RISKY_WORDS, AliasCanonicalizer
@@ -73,13 +80,14 @@ from zep_ingest.types import (
     SAFE_EPISODE_CHARS,
     Destination,
     Episode,
+    SourcePaths,
 )
 from zep_ingest.verify import search_when_ready
 
 try:
     __version__ = _version("zep-ingest")
 except _PackageNotFoundError:  # source tree without an editable install
-    __version__ = "0.1.0"
+    __version__ = "0.3.0"
 
 __all__ = [
     "DEFAULT_CONTEXT_PROMPT",
@@ -90,11 +98,14 @@ __all__ = [
     "MAX_ITEMS_PER_ADD",
     "MAX_ITEMS_PER_BATCH",
     "MAX_METADATA_KEYS",
+    "MIN_WAIT_TIMEOUT_SECONDS",
     "SAFE_EPISODE_CHARS",
+    "SECONDS_PER_SUBMITTED_ITEM",
     "AddError",
     "AliasCanonicalizer",
     "BatchSubmitter",
     "BatchUnavailableError",
+    "ConcatLoader",
     "ConfigurationError",
     "Destination",
     "EmlLoader",
@@ -117,6 +128,7 @@ __all__ = [
     "SequentialSubmitter",
     "SlackExportLoader",
     "SlackMessage",
+    "SourcePaths",
     "Submitter",
     "TextChunker",
     "TextFileLoader",
@@ -135,4 +147,5 @@ __all__ = [
     "ingest_thread_messages",
     "ingest_transcripts",
     "search_when_ready",
+    "wait_timeout_seconds",
 ]

--- a/ingestion/src/zep_ingest/_io.py
+++ b/ingestion/src/zep_ingest/_io.py
@@ -9,13 +9,66 @@ does accept CSV. The dispatch lives once, here, so behavior cannot drift
 between the paths.
 """
 
+import glob
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import MISSING, fields
 from pathlib import Path
 from typing import Any
 
 from zep_ingest.exceptions import ConfigurationError
+from zep_ingest.types import SourcePaths
+
+
+def source_paths_label(path_or_glob: SourcePaths) -> str:
+    if isinstance(path_or_glob, str | Path):
+        return str(path_or_glob)
+    return ", ".join(str(path) for path in path_or_glob)
+
+
+def resolve_source_files(
+    path_or_glob: SourcePaths,
+    *,
+    what: str = "files",
+) -> list[Path]:
+    """Resolve a glob, a path, or a sequence of either to existing files.
+
+    A single glob is sorted, matching prior loader behavior. A sequence keeps
+    caller order so issues.jsonl then prs.jsonl stay in that submission order;
+    matches within one glob entry are still sorted. Duplicates are dropped.
+    """
+    if isinstance(path_or_glob, str | Path):
+        patterns: list[str | Path] = [path_or_glob]
+    else:
+        if not isinstance(path_or_glob, Sequence):
+            raise ConfigurationError(
+                f"Source path must be a path, glob, or sequence of those, got "
+                f"{type(path_or_glob).__name__}"
+            )
+        patterns = list(path_or_glob)
+        if not patterns:
+            raise ConfigurationError(f"No {what} were provided.")
+        invalid = [item for item in patterns if not isinstance(item, str | Path)]
+        if invalid:
+            raise ConfigurationError(
+                f"Each source path must be a path or glob string, got {type(invalid[0]).__name__}"
+            )
+
+    files: list[Path] = []
+    seen: set[Path] = set()
+    for pattern in patterns:
+        matched = sorted(
+            Path(path) for path in glob.glob(str(pattern), recursive=True) if Path(path).is_file()
+        )
+        for file in matched:
+            resolved = file if file.is_absolute() else file.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            files.append(file)
+    if not files:
+        raise ConfigurationError(f"No {what} match {source_paths_label(path_or_glob)!r}.")
+    return files
 
 
 def load_rows(path: Path) -> list[dict[str, Any]]:

--- a/ingestion/src/zep_ingest/loaders/concat.py
+++ b/ingestion/src/zep_ingest/loaders/concat.py
@@ -1,0 +1,39 @@
+"""ConcatLoader: several loaders as one episode stream into one graph."""
+
+from collections.abc import Iterator, Sequence
+
+from zep_ingest.exceptions import ConfigurationError
+from zep_ingest.protocols import Loader
+from zep_ingest.types import Episode
+
+
+class ConcatLoader:
+    """Yield episodes from each loader in order as a single stream.
+
+    Use this when several sources (JSON records, documents, emails, …) belong
+    on the same graph: one ``Pipeline.run`` / ``ingest(...)`` submits everything
+    together. Sequential vs batch only chooses the submit API; neither waits
+    for one file to finish processing before the next is sent.
+    """
+
+    def __init__(self, loaders: Sequence[Loader]) -> None:
+        self.loaders = list(loaders)
+        if not self.loaders:
+            raise ConfigurationError("ConcatLoader requires at least one loader")
+
+    def load(self) -> Iterator[Episode]:
+        for loader in self.loaders:
+            yield from loader.load()
+
+    def flush_warnings(self) -> None:
+        for loader in self.loaders:
+            flush = getattr(loader, "flush_warnings", None)
+            if callable(flush):
+                flush()
+
+    @property
+    def warnings(self) -> list[str]:
+        collected: list[str] = []
+        for loader in self.loaders:
+            collected.extend(getattr(loader, "warnings", []))
+        return collected

--- a/ingestion/src/zep_ingest/loaders/email.py
+++ b/ingestion/src/zep_ingest/loaders/email.py
@@ -7,7 +7,6 @@ carries its real timeline; a missing Date surfaces through the pipeline's
 missing-timestamp warning.
 """
 
-import glob
 import html
 import re
 from collections.abc import Iterator
@@ -15,10 +14,9 @@ from datetime import UTC
 from email import policy
 from email.parser import BytesParser
 from email.utils import parsedate_to_datetime
-from pathlib import Path
 
-from zep_ingest.exceptions import ConfigurationError
-from zep_ingest.types import Episode
+from zep_ingest._io import resolve_source_files, source_paths_label
+from zep_ingest.types import Episode, SourcePaths
 
 _HTML_DROP = re.compile(r"<(script|style)\b.*?</\1>", re.IGNORECASE | re.DOTALL)
 _HTML_BREAK = re.compile(r"</?(?:p|div|br|li|tr|h[1-6])\b[^>]*>", re.IGNORECASE)
@@ -34,13 +32,9 @@ def _html_to_text(markup: str) -> str:
 
 
 class EmlLoader:
-    def __init__(self, path_or_glob: str | Path) -> None:
-        self.pattern = str(path_or_glob)
-        self.files = sorted(
-            Path(p) for p in glob.glob(self.pattern, recursive=True) if Path(p).is_file()
-        )
-        if not self.files:
-            raise ConfigurationError(f"No .eml files match {self.pattern!r}.")
+    def __init__(self, path_or_glob: SourcePaths) -> None:
+        self.pattern = source_paths_label(path_or_glob)
+        self.files = resolve_source_files(path_or_glob, what=".eml files")
 
     def load(self) -> Iterator[Episode]:
         for file in self.files:

--- a/ingestion/src/zep_ingest/loaders/json_records.py
+++ b/ingestion/src/zep_ingest/loaders/json_records.py
@@ -11,7 +11,6 @@ MAX_METADATA_FIELDS fields alongside it.
 """
 
 import csv
-import glob
 import json
 import math
 from collections.abc import Iterator, Sequence
@@ -19,9 +18,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
+from zep_ingest._io import resolve_source_files, source_paths_label
 from zep_ingest._validation import is_scalar_or_scalar_array
 from zep_ingest.exceptions import ConfigurationError
-from zep_ingest.types import MAX_METADATA_KEYS, Episode
+from zep_ingest.types import MAX_METADATA_KEYS, Episode, SourcePaths
 
 # provenance the loader stamps on every episode; record fields with these
 # names are not liftable, so what the episode reports about its own origin
@@ -74,7 +74,7 @@ def _find_non_finite(value: Any, path: str = "") -> tuple[str, float] | None:
 class JsonRecordsLoader:
     def __init__(
         self,
-        path_or_glob: str | Path,
+        path_or_glob: SourcePaths,
         *,
         format: Literal["auto", "jsonl", "csv", "json"] = "auto",
         id_field: str | None = None,
@@ -88,7 +88,7 @@ class JsonRecordsLoader:
             raise ConfigurationError(
                 f"format must be one of ['auto', 'csv', 'json', 'jsonl'], got {format!r}"
             )
-        self.pattern = str(path_or_glob)
+        self.pattern = source_paths_label(path_or_glob)
         self.format = format
         self.id_field = id_field
         self.name_field = name_field
@@ -110,11 +110,7 @@ class JsonRecordsLoader:
         ]
         self.record_type = record_type
         self.warnings: list[str] = []
-        self.files = sorted(
-            Path(p) for p in glob.glob(self.pattern, recursive=True) if Path(p).is_file()
-        )
-        if not self.files:
-            raise ConfigurationError(f"No files match {self.pattern!r}.")
+        self.files = resolve_source_files(path_or_glob)
 
     def load(self) -> Iterator[Episode]:
         # a collision is a property of metadata_fields, not of the records, so

--- a/ingestion/src/zep_ingest/loaders/text.py
+++ b/ingestion/src/zep_ingest/loaders/text.py
@@ -6,32 +6,26 @@ only with explicit ``use_file_mtime=True`` because copy time is not a reliable
 factual timestamp.
 """
 
-import glob
 from collections.abc import Iterator
 from datetime import UTC, datetime
-from pathlib import Path
 
-from zep_ingest.exceptions import ConfigurationError
-from zep_ingest.types import Episode
+from zep_ingest._io import resolve_source_files, source_paths_label
+from zep_ingest.types import Episode, SourcePaths
 
 
 class TextFileLoader:
     def __init__(
         self,
-        path_or_glob: str | Path,
+        path_or_glob: SourcePaths,
         *,
         created_at: str | None = None,
         use_file_mtime: bool = False,
     ) -> None:
-        self.pattern = str(path_or_glob)
+        self.pattern = source_paths_label(path_or_glob)
         self.created_at = created_at
         self.use_file_mtime = use_file_mtime
         self.warnings: list[str] = []
-        self.files = sorted(
-            Path(p) for p in glob.glob(self.pattern, recursive=True) if Path(p).is_file()
-        )
-        if not self.files:
-            raise ConfigurationError(f"No files match {self.pattern!r}.")
+        self.files = resolve_source_files(path_or_glob)
 
     def load(self) -> Iterator[Episode]:
         for file in self.files:

--- a/ingestion/src/zep_ingest/loaders/transcript.py
+++ b/ingestion/src/zep_ingest/loaders/transcript.py
@@ -4,16 +4,16 @@ Each turn is rendered inline as ``Speaker: text`` so the speaker attribution
 survives even though the episode is ingested as a plain-text episode.
 """
 
-import glob
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta
 from pathlib import Path
 
+from zep_ingest._io import resolve_source_files, source_paths_label
 from zep_ingest._validation import require_int_range
 from zep_ingest.exceptions import ConfigurationError
-from zep_ingest.types import Episode
+from zep_ingest.types import Episode, SourcePaths
 
 _TIMESTAMP = re.compile(r"^\s*(?:\*\*)?\[?(\d{1,2}):(\d{2}):(\d{2})\]?(?:\*\*)?\s*$")
 _VTT_TIME = r"(?:(?P<hours>\d{2,}):)?(?P<minutes>[0-5]\d):(?P<seconds>[0-5]\d)\.(?P<millis>\d{3})"
@@ -51,14 +51,14 @@ class _Turn:
 class TranscriptLoader:
     def __init__(
         self,
-        path_or_glob: str | Path,
+        path_or_glob: SourcePaths,
         *,
         chunk_chars: int = DEFAULT_CHUNK_CHARS,
         meeting_start: str | None = None,
         default_start_time: str | None = None,
     ) -> None:
         require_int_range("chunk_chars", chunk_chars, minimum=1)
-        self.pattern = str(path_or_glob)
+        self.pattern = source_paths_label(path_or_glob)
         self.chunk_chars = chunk_chars
         try:
             self._meeting_start = (
@@ -81,11 +81,7 @@ class TranscriptLoader:
         if self._default_start is not None and self._default_start.tzinfo is None:
             raise ConfigurationError("default_start_time must include a timezone offset")
         self.warnings: list[str] = []
-        self.files = sorted(
-            Path(p) for p in glob.glob(self.pattern, recursive=True) if Path(p).is_file()
-        )
-        if not self.files:
-            raise ConfigurationError(f"No transcript files match {self.pattern!r}.")
+        self.files = resolve_source_files(path_or_glob, what="transcript files")
         if meeting_start is not None and len(self.files) > 1:
             raise ConfigurationError("meeting_start can only be used with a single transcript")
 

--- a/ingestion/src/zep_ingest/nodes.py
+++ b/ingestion/src/zep_ingest/nodes.py
@@ -128,7 +128,7 @@ def ingest_nodes(
     the result, then wait on it, so the resume handles survive a timeout::
 
         result = ingest_nodes(client, nodes, graph_id="g1")
-        result.wait(timeout=600)
+        result.wait()
         # result.node_uuids[i] matches the i-th submitted node (or None)
     """
     destination = Destination(graph_id=graph_id, user_id=user_id)

--- a/ingestion/src/zep_ingest/pipeline.py
+++ b/ingestion/src/zep_ingest/pipeline.py
@@ -36,7 +36,7 @@ from zep_ingest.submitters import Method, submit_episodes
 from zep_ingest.transforms.canonicalizer import DEFAULT_RISKY_WORDS, AliasCanonicalizer
 from zep_ingest.transforms.chunker import TextChunker
 from zep_ingest.transforms.limits import LimitGuard
-from zep_ingest.types import Destination, Episode
+from zep_ingest.types import Destination, Episode, SourcePaths
 
 
 @dataclass
@@ -176,7 +176,7 @@ class Pipeline:
         resume handles survive a timeout::
 
             result = pipeline.run(client, graph_id="company_kb")
-            result.wait(timeout=600)
+            result.wait()
         """
         destination = Destination(graph_id=graph_id, user_id=user_id)
         if self.submitter is not None and (method != "auto" or batch_metadata is not None):
@@ -262,7 +262,7 @@ def ingest_slack_export(
 
 def ingest_documents(
     client: Zep,
-    path_or_glob: str | Path,
+    path_or_glob: SourcePaths,
     *,
     graph_id: str | None = None,
     user_id: str | None = None,
@@ -291,7 +291,7 @@ def ingest_documents(
 
 def ingest_transcripts(
     client: Zep,
-    path_or_glob: str | Path,
+    path_or_glob: SourcePaths,
     *,
     graph_id: str | None = None,
     user_id: str | None = None,
@@ -316,7 +316,7 @@ def ingest_transcripts(
 
 def ingest_emails(
     client: Zep,
-    path_or_glob: str | Path,
+    path_or_glob: SourcePaths,
     *,
     graph_id: str | None = None,
     user_id: str | None = None,
@@ -333,7 +333,7 @@ def ingest_emails(
 
 def ingest_json_records(
     client: Zep,
-    path_or_glob: str | Path,
+    path_or_glob: SourcePaths,
     *,
     graph_id: str | None = None,
     user_id: str | None = None,
@@ -346,7 +346,13 @@ def ingest_json_records(
     record_type: str | None = None,
     **run_kwargs: Any,
 ) -> IngestResult:
-    """One-liner: structured records (JSONL/CSV/JSON array) → one json episode per record."""
+    """One-liner: structured records (JSONL/CSV/JSON array) → one json episode per record.
+
+    ``path_or_glob`` may be one file, a glob, or a sequence of files/globs.
+    Every matching file is submitted together; processing is not waited on
+    between files. Call ``result.wait()`` once after submit if you need the
+    graph to finish extracting.
+    """
     loader = JsonRecordsLoader(
         path_or_glob,
         format=format,

--- a/ingestion/src/zep_ingest/result.py
+++ b/ingestion/src/zep_ingest/result.py
@@ -200,8 +200,9 @@ class IngestResult:
             if episode.processed:
                 self._processed_uuids.add(uuid)
         if only_last and self.episode_uuids[-1] in self._processed_uuids:
-            # Per-graph processing is ordered: the last episode finishing means
-            # the queue in front of it has already drained.
+            # Plain graph.add and thread backfills are ordered by submission
+            # (or request-array order within a thread.add_messages call): the
+            # tail finishing means the queue in front of it has drained.
             self._processed_uuids.update(self.episode_uuids)
 
     def _refresh_tasks(self) -> None:
@@ -344,12 +345,30 @@ class IngestResult:
     ) -> "IngestResult":
         """Poll until processing reaches a terminal state.
 
-        Episode ingest polls only the last submitted episode: earlier items
-        share the same per-graph queue, so the tail is a sufficient completion
-        signal. The default timeout scales with how many items were submitted
+        Which handle ``wait()`` polls depends on how the data was submitted
+        (see `Check data ingestion status
+        <https://help.getzep.com/check-data-ingestion-status>`_):
+
+        - **Batch API** (default for ``zep-ingest`` episodes and thread
+          backfills): ``batch.get`` on the last batch id — not per-episode
+          polling.
+        - **Sequential ``graph.add``** (batch fallback): the last-submitted
+          episode's ``processed`` flag. ``zep-ingest`` does not set
+          ``document_id``, so submission order matches ingestion order for plain
+          ``graph.add`` chunks.
+        - **Sequential ``thread.add_messages``**: the last message UUID in the
+          last request (``message_uuids[-1]`` from each call is recorded).
+        - **Tasks** (``add_nodes``, ``add_fact_triple``): every ``task_id`` on
+          each tick — tasks are not the same FIFO as graph episodes.
+
+        The default timeout scales with ``items_submitted``
         (``wait_timeout_seconds``). Pass ``timeout=None`` to wait without a
         deadline. Reconstructed ``from_batch_ids()`` results have no item
         count, so ``timeout="auto"`` also waits without a deadline.
+
+        Do not mix Batch API and sequential ``graph.add`` into the same graph
+        and expect one ``wait()`` to cover both — they are not globally
+        serialized.
 
         Raises IngestTimeoutError on timeout, or IngestUntrackedError when the
         API returned no completion handle; the result stays usable.
@@ -375,23 +394,26 @@ class IngestResult:
             time.sleep(poll_interval)
 
     def _poll_for_wait(self) -> None:
-        """Poll the tail of the graph queue, and always poll task handles.
+        """Poll the tail of each submission path, and always poll task handles.
 
-        Tasks (nodes, triples, sequential threads) are not the same FIFO as
-        graph episodes, so they are refreshed every tick even while the episode
-        or batch tail is still in flight — otherwise a combined
-        ``nodes.combine(docs).wait()`` would hide a failed seed until the
-        episode batch finished.
+        Tasks (nodes, triples) are not the same FIFO as graph episodes, so they
+        are refreshed every tick even while the episode or batch tail is still
+        in flight — otherwise a combined ``nodes.combine(docs).wait()`` would
+        hide a failed seed until the episode batch finished.
         """
         if self.episode_uuids:
             self._refresh_episodes(only_last=True)
             if self.episode_uuids[-1] in self._processed_uuids:
-                self._refresh_batches()
+                self._refresh_batches(only_last=False)
+            if self.batch_ids:
+                # Batch + sequential graph.add on one graph is discouraged, but
+                # poll the batch tail each tick when both handles are present.
+                self._refresh_batches(only_last=True)
         elif self.batch_ids:
             self._refresh_batches(only_last=True)
             last = self._batch_summaries.get(self.batch_ids[-1])
             if last is not None and last.status in _TERMINAL_BATCH_STATUSES:
-                self._refresh_batches()
+                self._refresh_batches(only_last=False)
         self._refresh_tasks()
 
     def _is_terminal(self) -> bool:

--- a/ingestion/src/zep_ingest/result.py
+++ b/ingestion/src/zep_ingest/result.py
@@ -147,6 +147,9 @@ class IngestResult:
     # True when node_uuids was filled from the add_nodes response (submission order).
     # Task-param recovery must not overwrite or reorder that list.
     _node_uuids_from_submit: bool = field(default=False, repr=False, compare=False)
+    # Plain graph.add (and single-thread backfills) share one per-graph queue, so
+    # polling the last UUID is enough. Multiple threads are independent sagas.
+    _single_queue_episode_poll: bool = field(default=True, repr=False, compare=False)
 
     @classmethod
     def from_batch_ids(cls, client: "Zep", batch_ids: "Sequence[str]") -> "IngestResult":
@@ -192,15 +195,24 @@ class IngestResult:
             raise RuntimeError("IngestResult has no client; cannot refresh.")
         if not self.episode_uuids:
             return
-        uuids = [self.episode_uuids[-1]] if only_last else self.episode_uuids
+        if only_last and self._single_queue_episode_poll:
+            uuids = [self.episode_uuids[-1]]
+        elif only_last:
+            uuids = list(dict.fromkeys(self.episode_uuids))
+        else:
+            uuids = self.episode_uuids
         for uuid in uuids:
             if uuid in self._processed_uuids:
                 continue
             episode = self.client.graph.episode.get(uuid_=uuid)
             if episode.processed:
                 self._processed_uuids.add(uuid)
-        if only_last and self.episode_uuids[-1] in self._processed_uuids:
-            # Plain graph.add and thread backfills are ordered by submission
+        if (
+            only_last
+            and self._single_queue_episode_poll
+            and self.episode_uuids[-1] in self._processed_uuids
+        ):
+            # Plain graph.add and single-thread backfills are ordered by submission
             # (or request-array order within a thread.add_messages call): the
             # tail finishing means the queue in front of it has drained.
             self._processed_uuids.update(self.episode_uuids)
@@ -301,16 +313,14 @@ class IngestResult:
             combined.batch_ids.extend(part.batch_ids)
             combined.episode_uuids.extend(part.episode_uuids)
             combined.task_ids.extend(part.task_ids)
-            combined.node_uuids.extend(part.node_uuids)
-            combined.edge_uuids.extend(part.edge_uuids)
             combined.add_errors.extend(part.add_errors)
             combined.warnings.extend(part.warnings)
             combined._batch_summaries.update(part._batch_summaries)
             combined._processed_uuids.update(part._processed_uuids)
             combined._task_statuses.update(part._task_statuses)
             combined._task_params.update(part._task_params)
-            combined._node_uuids_from_submit = (
-                combined._node_uuids_from_submit or part._node_uuids_from_submit
+            combined._single_queue_episode_poll = (
+                combined._single_queue_episode_poll and part._single_queue_episode_poll
             )
         return combined
 
@@ -357,7 +367,9 @@ class IngestResult:
           ``document_id``, so submission order matches ingestion order for plain
           ``graph.add`` chunks.
         - **Sequential ``thread.add_messages``**: the last message UUID in the
-          last request (``message_uuids[-1]`` from each call is recorded).
+          last request per thread (``message_uuids[-1]``). Regular
+          ``thread.add_messages`` does not return a ``task_id`` — only
+          ``add_messages_batch`` does.
         - **Tasks** (``add_nodes``, ``add_fact_triple``): every ``task_id`` on
           each tick — tasks are not the same FIFO as graph episodes.
 

--- a/ingestion/src/zep_ingest/result.py
+++ b/ingestion/src/zep_ingest/result.py
@@ -79,7 +79,7 @@ def _identity_from_task_params(params: Any) -> tuple[list[str], list[str]]:
 
 # Graph extraction is queued per destination. Wait budgets scale with how many
 # items still have to drain through that queue, not with how many we poll.
-SECONDS_PER_SUBMITTED_ITEM = 15.0
+SECONDS_PER_SUBMITTED_ITEM = 60.0
 MIN_WAIT_TIMEOUT_SECONDS = 120.0
 
 

--- a/ingestion/src/zep_ingest/result.py
+++ b/ingestion/src/zep_ingest/result.py
@@ -6,7 +6,12 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
 from zep_ingest._validation import require_int_range, require_nonnegative_number
-from zep_ingest.exceptions import IngestFailedError, IngestTimeoutError, IngestUntrackedError
+from zep_ingest.exceptions import (
+    ConfigurationError,
+    IngestFailedError,
+    IngestTimeoutError,
+    IngestUntrackedError,
+)
 
 if TYPE_CHECKING:
     from zep_cloud.client import Zep
@@ -70,6 +75,23 @@ def _identity_from_task_params(params: Any) -> tuple[list[str], list[str]]:
     if edge_uuid:
         edge_uuids = [str(edge_uuid)]
     return node_uuids, edge_uuids
+
+
+# Graph extraction is queued per destination. Wait budgets scale with how many
+# items still have to drain through that queue, not with how many we poll.
+SECONDS_PER_SUBMITTED_ITEM = 15.0
+MIN_WAIT_TIMEOUT_SECONDS = 120.0
+
+
+def wait_timeout_seconds(item_count: int) -> float:
+    """Timeout for ``IngestResult.wait()`` given how many items were submitted.
+
+    The graph processes episodes in order, so waiting on the last one still has
+    to cover the work ahead of it. Floor is ``MIN_WAIT_TIMEOUT_SECONDS`` so a
+    tiny run is not given an unrealistically short deadline.
+    """
+    require_int_range("item_count", item_count, minimum=0)
+    return max(MIN_WAIT_TIMEOUT_SECONDS, item_count * SECONDS_PER_SUBMITTED_ITEM)
 
 
 @dataclass(slots=True)
@@ -151,26 +173,47 @@ class IngestResult:
         """Fetch the latest processing state from the API."""
         if self.client is None:
             raise RuntimeError("IngestResult has no client; cannot refresh.")
-        if self.method == "batch":
-            for batch_id in self.batch_ids:
-                summary = self._batch_summaries.get(batch_id)
-                if summary is not None and summary.status in _TERMINAL_BATCH_STATUSES:
-                    continue
-                self._batch_summaries[batch_id] = self.client.batch.get(batch_id)
-        else:
-            for uuid in self.episode_uuids:
-                if uuid in self._processed_uuids:
-                    continue
-                episode = self.client.graph.episode.get(uuid_=uuid)
-                if episode.processed:
-                    self._processed_uuids.add(uuid)
-            for task_id in self.task_ids:
-                if self._task_statuses.get(task_id) in _TERMINAL_TASK_STATUSES:
-                    continue
-                task = self.client.task.get(task_id)
-                self._task_statuses[task_id] = _normalize_task_status(task.status)
-                self._task_params[task_id] = getattr(task, "params", None)
-            self._sync_identities_from_task_params()
+        self._refresh_batches()
+        self._refresh_episodes(only_last=False)
+        self._refresh_tasks()
+
+    def _refresh_batches(self, *, only_last: bool = False) -> None:
+        if self.client is None:
+            raise RuntimeError("IngestResult has no client; cannot refresh.")
+        batch_ids = self.batch_ids[-1:] if only_last and self.batch_ids else self.batch_ids
+        for batch_id in batch_ids:
+            summary = self._batch_summaries.get(batch_id)
+            if summary is not None and summary.status in _TERMINAL_BATCH_STATUSES:
+                continue
+            self._batch_summaries[batch_id] = self.client.batch.get(batch_id)
+
+    def _refresh_episodes(self, *, only_last: bool) -> None:
+        if self.client is None:
+            raise RuntimeError("IngestResult has no client; cannot refresh.")
+        if not self.episode_uuids:
+            return
+        uuids = [self.episode_uuids[-1]] if only_last else self.episode_uuids
+        for uuid in uuids:
+            if uuid in self._processed_uuids:
+                continue
+            episode = self.client.graph.episode.get(uuid_=uuid)
+            if episode.processed:
+                self._processed_uuids.add(uuid)
+        if only_last and self.episode_uuids[-1] in self._processed_uuids:
+            # Per-graph processing is ordered: the last episode finishing means
+            # the queue in front of it has already drained.
+            self._processed_uuids.update(self.episode_uuids)
+
+    def _refresh_tasks(self) -> None:
+        if self.client is None:
+            raise RuntimeError("IngestResult has no client; cannot refresh.")
+        for task_id in self.task_ids:
+            if self._task_statuses.get(task_id) in _TERMINAL_TASK_STATUSES:
+                continue
+            task = self.client.task.get(task_id)
+            self._task_statuses[task_id] = _normalize_task_status(task.status)
+            self._task_params[task_id] = getattr(task, "params", None)
+        self._sync_identities_from_task_params()
 
     def _param_identity_prefix(self, *, kind: Literal["node", "edge"]) -> list[str | None]:
         """Identities from cached task params in ``task_ids`` order.
@@ -205,7 +248,7 @@ class IngestResult:
     def status(self) -> str:
         """Aggregate status, including explicit ``untracked`` completion state."""
         statuses: list[str] = []
-        if self.method == "batch":
+        if self.batch_ids:
             for batch_id in self.batch_ids:
                 summary = self._batch_summaries.get(batch_id)
                 raw = summary.status if summary is not None else "queued"
@@ -215,13 +258,12 @@ class IngestResult:
                     statuses.append("failed")
                 else:
                     statuses.append(str(raw))
-        else:
-            if self.episode_uuids:
-                if len(self._processed_uuids) >= len(set(self.episode_uuids)):
-                    statuses.append("succeeded")
-                else:
-                    statuses.append("processing")
-            statuses.extend(self._task_statuses.get(task_id, "queued") for task_id in self.task_ids)
+        if self.episode_uuids:
+            if len(self._processed_uuids) >= len(set(self.episode_uuids)):
+                statuses.append("succeeded")
+            else:
+                statuses.append("processing")
+        statuses.extend(self._task_statuses.get(task_id, "queued") for task_id in self.task_ids)
         if self.untracked_items:
             statuses.append("untracked")
         if self.add_errors:
@@ -233,15 +275,87 @@ class IngestResult:
                 return candidate
         return statuses[0]
 
-    def wait(self, *, poll_interval: float = 10.0, timeout: float | None = None) -> "IngestResult":
+    def combine(self, *others: "IngestResult") -> "IngestResult":
+        """Merge later submits into this result so ``wait()`` can poll once.
+
+        Submission is independent of processing: call every ingest into the same
+        graph, combine the results, then ``wait()`` (or skip waiting entirely).
+        Sequential vs batch only chooses the submit API; it does not mean
+        "finish processing this file before sending the next."
+        """
+        parts = (self, *others)
+        clients = {id(part.client): part.client for part in parts if part.client is not None}
+        if len(clients) > 1:
+            raise ConfigurationError("Cannot combine IngestResults from different Zep clients")
+        client = next(iter(clients.values()), None)
+        has_batches = any(part.batch_ids for part in parts)
+        has_sequential_handles = any(part.episode_uuids or part.task_ids for part in parts)
+        method: Literal["batch", "sequential"] = (
+            "batch" if has_batches and not has_sequential_handles else "sequential"
+        )
+        combined = IngestResult(method=method, client=client)
+        for part in parts:
+            combined.items_submitted += part.items_submitted
+            combined.untracked_items += part.untracked_items
+            combined.batch_ids.extend(part.batch_ids)
+            combined.episode_uuids.extend(part.episode_uuids)
+            combined.task_ids.extend(part.task_ids)
+            combined.node_uuids.extend(part.node_uuids)
+            combined.edge_uuids.extend(part.edge_uuids)
+            combined.add_errors.extend(part.add_errors)
+            combined.warnings.extend(part.warnings)
+            combined._batch_summaries.update(part._batch_summaries)
+            combined._processed_uuids.update(part._processed_uuids)
+            combined._task_statuses.update(part._task_statuses)
+            combined._task_params.update(part._task_params)
+            combined._node_uuids_from_submit = (
+                combined._node_uuids_from_submit or part._node_uuids_from_submit
+            )
+        return combined
+
+    def _queued_item_count(self) -> int | None:
+        """Known queued work, or ``None`` when only opaque batch ids exist."""
+        if self.items_submitted > 0:
+            return self.items_submitted
+        count = len(self.episode_uuids) + len(self.task_ids)
+        if count > 0:
+            return count
+        if self.batch_ids:
+            return None
+        return 0
+
+    def _resolve_wait_timeout(self, timeout: float | Literal["auto"] | None) -> float | None:
+        if timeout is None:
+            return None
+        if timeout == "auto":
+            count = self._queued_item_count()
+            if count is None:
+                # from_batch_ids() has no item count; do not invent a 120s cap.
+                return None
+            return wait_timeout_seconds(count)
+        require_nonnegative_number("timeout", timeout)
+        return timeout
+
+    def wait(
+        self,
+        *,
+        poll_interval: float = 10.0,
+        timeout: float | Literal["auto"] | None = "auto",
+    ) -> "IngestResult":
         """Poll until processing reaches a terminal state.
+
+        Episode ingest polls only the last submitted episode: earlier items
+        share the same per-graph queue, so the tail is a sufficient completion
+        signal. The default timeout scales with how many items were submitted
+        (``wait_timeout_seconds``). Pass ``timeout=None`` to wait without a
+        deadline. Reconstructed ``from_batch_ids()`` results have no item
+        count, so ``timeout="auto"`` also waits without a deadline.
 
         Raises IngestTimeoutError on timeout, or IngestUntrackedError when the
         API returned no completion handle; the result stays usable.
         """
         require_nonnegative_number("poll_interval", poll_interval)
-        if timeout is not None:
-            require_nonnegative_number("timeout", timeout)
+        resolved_timeout = self._resolve_wait_timeout(timeout)
         if self.untracked_items:
             raise IngestUntrackedError(
                 f"Cannot wait for {self.untracked_items} submitted item(s): the API returned "
@@ -250,42 +364,60 @@ class IngestResult:
             )
         start = time.monotonic()
         while True:
-            self.refresh()
+            self._poll_for_wait()
             if self._is_terminal():
                 return self
-            if timeout is not None and time.monotonic() - start >= timeout:
+            if resolved_timeout is not None and time.monotonic() - start >= resolved_timeout:
                 raise IngestTimeoutError(
-                    f"Ingestion still {self.status!r} after {timeout}s; call wait() "
+                    f"Ingestion still {self.status!r} after {resolved_timeout}s; call wait() "
                     "again or inspect progress via refresh()/status."
                 )
             time.sleep(poll_interval)
 
+    def _poll_for_wait(self) -> None:
+        """Poll the tail of the graph queue, and always poll task handles.
+
+        Tasks (nodes, triples, sequential threads) are not the same FIFO as
+        graph episodes, so they are refreshed every tick even while the episode
+        or batch tail is still in flight — otherwise a combined
+        ``nodes.combine(docs).wait()`` would hide a failed seed until the
+        episode batch finished.
+        """
+        if self.episode_uuids:
+            self._refresh_episodes(only_last=True)
+            if self.episode_uuids[-1] in self._processed_uuids:
+                self._refresh_batches()
+        elif self.batch_ids:
+            self._refresh_batches(only_last=True)
+            last = self._batch_summaries.get(self.batch_ids[-1])
+            if last is not None and last.status in _TERMINAL_BATCH_STATUSES:
+                self._refresh_batches()
+        self._refresh_tasks()
+
     def _is_terminal(self) -> bool:
         if self.untracked_items:
             return False
-        if self.method == "batch":
-            return all(
+        if self.batch_ids:
+            batches_terminal = all(
                 (summary := self._batch_summaries.get(batch_id)) is not None
                 and summary.status in _TERMINAL_BATCH_STATUSES
                 for batch_id in self.batch_ids
             )
-        episodes_terminal = len(self._processed_uuids) >= len(set(self.episode_uuids))
-        tasks_terminal = all(
+            if not batches_terminal:
+                return False
+        if self.episode_uuids and len(self._processed_uuids) < len(set(self.episode_uuids)):
+            return False
+        return all(
             self._task_statuses.get(task_id) in _TERMINAL_TASK_STATUSES
             for task_id in set(self.task_ids)
         )
-        return episodes_terminal and tasks_terminal
 
     def failed_items(self, *, limit: int = 100) -> "list[BatchItemDetail | AddError]":
         """Failed item details from submission and server-side batch processing."""
         require_int_range("limit", limit, minimum=1)
-        if self.method == "sequential":
-            sequential_errors: list[BatchItemDetail | AddError] = []
-            sequential_errors.extend(self.add_errors[:limit])
-            return sequential_errors
         collected: list[BatchItemDetail | AddError] = list(self.add_errors[:limit])
-        if len(collected) >= limit:
-            return collected
+        if len(collected) >= limit or not self.batch_ids:
+            return collected[:limit]
         if self.client is None:
             raise RuntimeError("IngestResult has no client; cannot list failed items.")
         for batch_id in self.batch_ids:

--- a/ingestion/src/zep_ingest/submitters/sequential.py
+++ b/ingestion/src/zep_ingest/submitters/sequential.py
@@ -5,7 +5,8 @@ off exponentially with jitter. One call at a time also preserves stream order,
 which correct valid_at sequencing depends on. Sequential means the Batch API
 is not used — each episode is submitted with graph.add — not that processing
 must finish before the next episode or file is sent. The HTTP add returns as
-soon as the episode is queued; wait() is opt-in and polls the last episode.
+soon as the episode is queued; wait() is opt-in and polls the last-submitted
+episode (plain graph.add without document_id).
 """
 
 import math

--- a/ingestion/src/zep_ingest/submitters/sequential.py
+++ b/ingestion/src/zep_ingest/submitters/sequential.py
@@ -2,7 +2,10 @@
 
 Rate-limit aware: honors the Retry-After header on 429s and otherwise backs
 off exponentially with jitter. One call at a time also preserves stream order,
-which correct valid_at sequencing depends on.
+which correct valid_at sequencing depends on. Sequential means the Batch API
+is not used — each episode is submitted with graph.add — not that processing
+must finish before the next episode or file is sent. The HTTP add returns as
+soon as the episode is queued; wait() is opt-in and polls the last episode.
 """
 
 import math

--- a/ingestion/src/zep_ingest/threads.py
+++ b/ingestion/src/zep_ingest/threads.py
@@ -19,7 +19,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, replace
 from itertools import islice
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import httpx
 from zep_cloud.client import Zep
@@ -29,7 +29,7 @@ from zep_cloud.types.batch_add_item import BatchAddItem
 from zep_cloud.types.message import Message
 
 from zep_ingest._errors import format_api_error
-from zep_ingest._io import load_rows, rows_to_fields
+from zep_ingest._io import load_rows, resolve_source_files, rows_to_fields
 from zep_ingest._validation import (
     check_required_string,
     check_scalar_map,
@@ -55,6 +55,7 @@ from zep_ingest.types import (
     MAX_ITEMS_PER_ADD,
     MAX_MESSAGES_PER_THREAD_ADD,
     MAX_METADATA_KEYS,
+    SourcePaths,
 )
 
 logger = logging.getLogger("zep_ingest")
@@ -131,6 +132,22 @@ def _validate_ignore_roles(ignore_roles: Sequence[str] | None) -> list[str] | No
 def _load_messages(path: Path) -> list[ThreadMessage]:
     rows = rows_to_fields(load_rows(path), ThreadMessage)
     return [ThreadMessage(**row) for row in rows]
+
+
+def _is_source_paths(value: object) -> bool:
+    if isinstance(value, str | Path):
+        return True
+    if isinstance(value, Sequence) and not isinstance(value, bytes):
+        items = list(value)
+        return bool(items) and all(isinstance(item, str | Path) for item in items)
+    return False
+
+
+def _load_message_sources(path_or_glob: SourcePaths) -> list[ThreadMessage]:
+    messages: list[ThreadMessage] = []
+    for file in resolve_source_files(path_or_glob):
+        messages.extend(_load_messages(file))
+    return messages
 
 
 def _prepare(messages: list[ThreadMessage], warnings: list[str]) -> list[ThreadMessage]:
@@ -356,7 +373,7 @@ def _submit_sequential(
 
 def ingest_thread_messages(
     client: Zep,
-    messages: Iterable[ThreadMessage] | str | Path,
+    messages: Iterable[ThreadMessage] | SourcePaths,
     *,
     user_id: str | None = None,
     method: Literal["auto", "batch", "sequential"] = "auto",
@@ -368,9 +385,10 @@ def ingest_thread_messages(
 ) -> IngestResult:
     """Backfill chat history into a user's graph via threads.
 
-    Accepts ThreadMessage objects or a JSONL / JSON-object / JSON-array path with columns
-    thread_id/role/name/content/created_at (all required except metadata). The
-    user must already exist; every referenced thread is created if missing (the
+    Accepts ThreadMessage objects, a JSONL / JSON-object / JSON-array path, a
+    glob, or a sequence of those paths (files are submitted in caller order).
+    Columns are thread_id/role/name/content/created_at (all required except metadata).
+    The user must already exist; every referenced thread is created if missing (the
     Batch API requires threads to exist), and per-thread message order is
     preserved on both submission paths.
 
@@ -387,7 +405,7 @@ def ingest_thread_messages(
     handles survive a timeout::
 
         result = ingest_thread_messages(client, messages, user_id="u1")
-        result.wait(timeout=600)
+        result.wait()
     """
     if not user_id:
         raise ConfigurationError(
@@ -408,10 +426,10 @@ def ingest_thread_messages(
     if thread_id_suffix is not None and not isinstance(thread_id_suffix, str):
         raise ConfigurationError("thread_id_suffix must be a string or None")
     normalized_ignore_roles = _validate_ignore_roles(ignore_roles)
-    if isinstance(messages, str | Path):
-        materialized = _load_messages(Path(messages))
+    if _is_source_paths(messages):
+        materialized = _load_message_sources(cast(SourcePaths, messages))
     else:
-        materialized = list(messages)
+        materialized = list(cast(Iterable[ThreadMessage], messages))
     if thread_id_suffix:
         materialized = [
             replace(m, thread_id=f"{m.thread_id}{thread_id_suffix}") for m in materialized

--- a/ingestion/src/zep_ingest/threads.py
+++ b/ingestion/src/zep_ingest/threads.py
@@ -353,20 +353,27 @@ def _submit_sequential(
                 )
             else:
                 result.items_submitted += len(chunk)
-                task_id = getattr(response, "task_id", None)
-                if task_id:
-                    normalized_task_id = str(task_id)
-                    if normalized_task_id not in result.task_ids:
-                        result.task_ids.append(normalized_task_id)
+                message_uuids = getattr(response, "message_uuids", None) or []
+                if message_uuids:
+                    # Docs: poll the last message in the last request (request-array
+                    # order within a call; submission order across calls).
+                    result.episode_uuids.append(str(message_uuids[-1]))
                 else:
-                    missing_task_handles += 1
-                    result.untracked_items += len(chunk)
+                    task_id = getattr(response, "task_id", None)
+                    if task_id:
+                        normalized_task_id = str(task_id)
+                        if normalized_task_id not in result.task_ids:
+                            result.task_ids.append(normalized_task_id)
+                    else:
+                        missing_task_handles += 1
+                        result.untracked_items += len(chunk)
             chunk_index += 1
     if missing_task_handles:
         result.warnings.append(
             f"{missing_task_handles} successful thread.add_messages call(s) returned no "
-            "completion handle; wait()/status cannot track their server-side extraction. "
-            "Poll your own read (e.g. zep_ingest.search_when_ready) before querying."
+            "message UUID or task handle; wait()/status cannot track their server-side "
+            "extraction. Poll your own read (e.g. zep_ingest.search_when_ready) before "
+            "querying."
         )
     return result
 

--- a/ingestion/src/zep_ingest/threads.py
+++ b/ingestion/src/zep_ingest/threads.py
@@ -318,8 +318,9 @@ def _submit_sequential(
     max_retries: int,
 ) -> IngestResult:
     result = IngestResult(method="sequential", client=client)
-    missing_task_handles = 0
+    missing_message_uuids = 0
     by_thread: dict[str, list[ThreadMessage]] = {}
+    thread_poll_uuids: dict[str, str] = {}
     for message in messages:
         by_thread.setdefault(message.thread_id, []).append(message)
     chunk_index = 0
@@ -355,25 +356,20 @@ def _submit_sequential(
                 result.items_submitted += len(chunk)
                 message_uuids = getattr(response, "message_uuids", None) or []
                 if message_uuids:
-                    # Docs: poll the last message in the last request (request-array
-                    # order within a call; submission order across calls).
-                    result.episode_uuids.append(str(message_uuids[-1]))
+                    # Docs: poll the last message in the last request per thread.
+                    # thread.add_messages does not return task_id (only batch mode does).
+                    thread_poll_uuids[thread_id] = str(message_uuids[-1])
                 else:
-                    task_id = getattr(response, "task_id", None)
-                    if task_id:
-                        normalized_task_id = str(task_id)
-                        if normalized_task_id not in result.task_ids:
-                            result.task_ids.append(normalized_task_id)
-                    else:
-                        missing_task_handles += 1
-                        result.untracked_items += len(chunk)
+                    missing_message_uuids += 1
+                    result.untracked_items += len(chunk)
             chunk_index += 1
-    if missing_task_handles:
+    result.episode_uuids = list(thread_poll_uuids.values())
+    result._single_queue_episode_poll = len(thread_poll_uuids) <= 1
+    if missing_message_uuids:
         result.warnings.append(
-            f"{missing_task_handles} successful thread.add_messages call(s) returned no "
-            "message UUID or task handle; wait()/status cannot track their server-side "
-            "extraction. Poll your own read (e.g. zep_ingest.search_when_ready) before "
-            "querying."
+            f"{missing_message_uuids} successful thread.add_messages call(s) returned no "
+            "message UUIDs; wait()/status cannot track their server-side extraction. "
+            "Poll your own read (e.g. zep_ingest.search_when_ready) before querying."
         )
     return result
 

--- a/ingestion/src/zep_ingest/triples.py
+++ b/ingestion/src/zep_ingest/triples.py
@@ -174,7 +174,7 @@ def ingest_fact_triples(
     handles survive a timeout::
 
         result = ingest_fact_triples(client, triples, graph_id="g1")
-        result.wait(timeout=600)
+        result.wait()
     """
     destination = Destination(graph_id=graph_id, user_id=user_id)
     if isinstance(triples, str | Path):

--- a/ingestion/src/zep_ingest/types.py
+++ b/ingestion/src/zep_ingest/types.py
@@ -1,6 +1,8 @@
 """Core data model: Episode, Destination, API limits, and API mappings."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Literal
 
 from zep_cloud.types.batch_add_item import BatchAddItem
@@ -19,6 +21,8 @@ MAX_MESSAGES_PER_THREAD_ADD = 30  # thread.add_messages per call; not MAX_ITEMS_
 MAX_METADATA_KEYS = 10
 
 DataType = Literal["text", "json", "message"]
+#: A glob, a single path, or several globs/paths ingested in caller order.
+SourcePaths = str | Path | Sequence[str | Path]
 
 
 @dataclass(slots=True)

--- a/ingestion/tests/conftest.py
+++ b/ingestion/tests/conftest.py
@@ -75,7 +75,7 @@ def mock_zep() -> MagicMock:
     client.thread = MagicMock()
     client.thread.create = MagicMock()
     client.thread.add_messages = MagicMock(
-        return_value=AddThreadMessagesResponse(task_id="thread-task-1")
+        return_value=AddThreadMessagesResponse(message_uuids=["msg-1"], task_id="thread-task-1")
     )
     client.task = MagicMock()
     client.task.get = MagicMock(return_value=GetTaskResponse(task_id="task-1", status="succeeded"))

--- a/ingestion/tests/conftest.py
+++ b/ingestion/tests/conftest.py
@@ -75,7 +75,7 @@ def mock_zep() -> MagicMock:
     client.thread = MagicMock()
     client.thread.create = MagicMock()
     client.thread.add_messages = MagicMock(
-        return_value=AddThreadMessagesResponse(message_uuids=["msg-1"], task_id="thread-task-1")
+        return_value=AddThreadMessagesResponse(message_uuids=["msg-1"])
     )
     client.task = MagicMock()
     client.task.get = MagicMock(return_value=GetTaskResponse(task_id="task-1", status="succeeded"))

--- a/ingestion/tests/test_basic.py
+++ b/ingestion/tests/test_basic.py
@@ -21,6 +21,8 @@ def test_public_api_exports():
         "MAX_ITEMS_PER_BATCH",
         "DEFAULT_ITEMS_PER_BATCH",
         "MAX_METADATA_KEYS",
+        "MIN_WAIT_TIMEOUT_SECONDS",
+        "SECONDS_PER_SUBMITTED_ITEM",
         # protocols
         "Loader",
         "Transform",
@@ -45,6 +47,8 @@ def test_public_api_exports():
         "JsonRecordsLoader",
         "EmlLoader",
         "TranscriptLoader",
+        "ConcatLoader",
+        "SourcePaths",
         # transforms
         "TextChunker",
         "LLMContextualizer",
@@ -61,6 +65,7 @@ def test_public_api_exports():
         "NodeItem",
         # verification
         "search_when_ready",
+        "wait_timeout_seconds",
         # exceptions
         "ZepIngestError",
         "ConfigurationError",

--- a/ingestion/tests/test_io.py
+++ b/ingestion/tests/test_io.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from zep_ingest._io import load_rows, rows_to_fields
+from zep_ingest._io import load_rows, resolve_source_files, rows_to_fields
 from zep_ingest.exceptions import ConfigurationError
 from zep_ingest.threads import ThreadMessage
 
@@ -57,3 +57,19 @@ def test_json_scalar_is_rejected_with_clear_error(tmp_path):
 
     with pytest.raises(ConfigurationError, match="must contain JSON objects"):
         load_rows(path)
+
+
+def test_resolve_source_files_sequence_preserves_order_and_dedupes(tmp_path):
+    first = tmp_path / "issues.jsonl"
+    second = tmp_path / "prs.jsonl"
+    first.write_text("{}\n")
+    second.write_text("{}\n")
+
+    files = resolve_source_files([second, first, second])
+
+    assert files == [second, first]
+
+
+def test_resolve_source_files_empty_sequence_is_rejected():
+    with pytest.raises(ConfigurationError, match="No files were provided"):
+        resolve_source_files([])

--- a/ingestion/tests/test_json_records_loader.py
+++ b/ingestion/tests/test_json_records_loader.py
@@ -88,6 +88,16 @@ class TestFormats:
         episodes = list(JsonRecordsLoader(str(tmp_path / "*.jsonl")).load())
         assert len(episodes) == 2
 
+    def test_sequence_of_files_keeps_caller_order(self, tmp_path):
+        later = tmp_path / "b.jsonl"
+        earlier = tmp_path / "a.jsonl"
+        later.write_text(json.dumps({"id": "prs"}))
+        earlier.write_text(json.dumps({"id": "issues"}))
+
+        episodes = list(JsonRecordsLoader([later, earlier]).load())
+
+        assert [json.loads(episode.data)["id"] for episode in episodes] == ["prs", "issues"]
+
     def test_no_match_raises(self, tmp_path):
         with pytest.raises(ConfigurationError):
             JsonRecordsLoader(str(tmp_path / "*.jsonl"))

--- a/ingestion/tests/test_pipeline.py
+++ b/ingestion/tests/test_pipeline.py
@@ -7,6 +7,8 @@ import pytest
 
 from tests.conftest import make_zep_episode
 from zep_ingest.exceptions import ConfigurationError
+from zep_ingest.loaders.concat import ConcatLoader
+from zep_ingest.loaders.json_records import JsonRecordsLoader
 from zep_ingest.pipeline import (
     Pipeline,
     ingest,
@@ -151,6 +153,27 @@ class TestRun:
         result.wait(poll_interval=0)
         assert result.status == "succeeded"
         mock_zep.batch.get.assert_called()
+
+
+class TestConcatLoader:
+    def test_one_submit_stream_from_several_loaders(self, mock_zep, tmp_path):
+        issues = tmp_path / "issues.jsonl"
+        prs = tmp_path / "prs.jsonl"
+        issues.write_text('{"id": "ISSUE-1"}\n')
+        prs.write_text('{"id": "PR-1"}\n')
+        loader = ConcatLoader(
+            [
+                JsonRecordsLoader(issues),
+                JsonRecordsLoader(prs),
+            ]
+        )
+        result = Pipeline(loader).run(mock_zep, graph_id="g1")
+        assert result.items_submitted == 2
+        [add_call] = mock_zep.batch.add.call_args_list
+        assert [item.data for item in add_call.kwargs["items"]] == [
+            '{"id": "ISSUE-1"}',
+            '{"id": "PR-1"}',
+        ]
 
 
 class TestPreview:

--- a/ingestion/tests/test_result.py
+++ b/ingestion/tests/test_result.py
@@ -221,6 +221,26 @@ class TestSequentialResult:
         ]
         assert result.status == "succeeded"
 
+    def test_wait_does_not_mark_all_episodes_done_when_multi_thread_tail_finishes_first(
+        self, mock_zep
+    ):
+        result = IngestResult(
+            method="sequential",
+            episode_uuids=["e-thread-1", "e-thread-2"],
+            items_submitted=2,
+            client=mock_zep,
+            _single_queue_episode_poll=False,
+        )
+        mock_zep.graph.episode.get.side_effect = [
+            make_zep_episode("e-thread-1", processed=False),
+            make_zep_episode("e-thread-2", processed=True),
+        ]
+
+        with pytest.raises(IngestTimeoutError):
+            result.wait(poll_interval=0, timeout=0)
+
+        assert "e-thread-1" not in result._processed_uuids
+
     def test_combine_then_wait_polls_the_combined_tail(self, mock_zep):
         first = IngestResult(
             method="sequential", episode_uuids=["e1"], items_submitted=1, client=mock_zep
@@ -237,6 +257,27 @@ class TestSequentialResult:
         assert combined.episode_uuids == ["e1", "e2"]
         mock_zep.graph.episode.get.assert_called_once_with(uuid_="e2")
         assert combined.status == "succeeded"
+
+    def test_combine_does_not_merge_identity_lists(self, mock_zep):
+        nodes = IngestResult(
+            method="sequential",
+            node_uuids=["node-1"],
+            task_ids=["t1"],
+            client=mock_zep,
+        )
+        docs = IngestResult(
+            method="batch",
+            batch_ids=["b1"],
+            edge_uuids=["edge-1"],
+            client=mock_zep,
+        )
+
+        combined = nodes.combine(docs)
+
+        assert combined.node_uuids == []
+        assert combined.edge_uuids == []
+        assert combined.task_ids == ["t1"]
+        assert combined.batch_ids == ["b1"]
 
     def test_combine_rejects_different_clients(self, mock_zep):
         other = MagicMock()

--- a/ingestion/tests/test_result.py
+++ b/ingestion/tests/test_result.py
@@ -245,6 +245,35 @@ class TestSequentialResult:
         with pytest.raises(ConfigurationError, match="different Zep clients"):
             left.combine(right)
 
+    def test_wait_polls_batch_tail_when_mixed_with_episodes(self, mock_zep):
+        result = IngestResult(
+            method="sequential",
+            batch_ids=["b1"],
+            episode_uuids=["e1"],
+            items_submitted=5,
+            client=mock_zep,
+        )
+        order: list[str] = []
+
+        def get_episode(uuid_: str):
+            order.append("episode")
+            return make_zep_episode(uuid_, processed=order.count("episode") >= 2)
+
+        def get_batch(batch_id: str):
+            order.append("batch")
+            if order.count("batch") <= 1:
+                return make_batch_summary("b1", "processing")
+            return make_batch_summary("b1", "succeeded")
+
+        mock_zep.graph.episode.get.side_effect = get_episode
+        mock_zep.batch.get.side_effect = get_batch
+
+        result.wait(poll_interval=0)
+
+        assert "batch" in order
+        assert "episode" in order
+        assert result.status == "succeeded"
+
     def test_wait_polls_tasks_while_batch_tail_still_in_flight(self, mock_zep):
         from zep_cloud.types.get_task_response import GetTaskResponse
 

--- a/ingestion/tests/test_result.py
+++ b/ingestion/tests/test_result.py
@@ -1,5 +1,7 @@
 """Tests for IngestResult: status aggregation, refresh, wait, failed_items."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from tests.conftest import make_batch_summary, make_item_detail, make_item_list, make_zep_episode
@@ -9,7 +11,13 @@ from zep_ingest.exceptions import (
     IngestTimeoutError,
     IngestUntrackedError,
 )
-from zep_ingest.result import AddError, IngestResult
+from zep_ingest.result import (
+    MIN_WAIT_TIMEOUT_SECONDS,
+    SECONDS_PER_SUBMITTED_ITEM,
+    AddError,
+    IngestResult,
+    wait_timeout_seconds,
+)
 
 
 class TestBatchResult:
@@ -64,6 +72,35 @@ class TestBatchResult:
         assert returned is result
         assert result.status == "succeeded"
         assert mock_zep.batch.get.call_count == 3
+
+    def test_wait_polls_last_batch_until_terminal_then_confirms_others(self, mock_zep):
+        result = IngestResult(method="batch", batch_ids=["b1", "b2"], client=mock_zep)
+        mock_zep.batch.get.side_effect = [
+            make_batch_summary("b2", "processing"),
+            make_batch_summary("b2", "succeeded"),
+            make_batch_summary("b1", "succeeded"),
+        ]
+        result.wait(poll_interval=0)
+        assert [call.args[0] for call in mock_zep.batch.get.call_args_list] == ["b2", "b2", "b1"]
+        assert result.status == "succeeded"
+
+    def test_auto_timeout_scales_with_submitted_items(self, mock_zep, monkeypatch):
+        clock = iter(float(seconds) for seconds in range(0, 10_000_000, 1_000_000))
+        monkeypatch.setattr("zep_ingest.result.time.monotonic", lambda: next(clock))
+        monkeypatch.setattr("zep_ingest.result.time.sleep", lambda _: None)
+        result = IngestResult(method="batch", batch_ids=["b1"], items_submitted=10, client=mock_zep)
+        mock_zep.batch.get.return_value = make_batch_summary("b1", "processing")
+
+        with pytest.raises(IngestTimeoutError) as excinfo:
+            result.wait(poll_interval=0)
+
+        expected = wait_timeout_seconds(10)
+        assert expected == max(MIN_WAIT_TIMEOUT_SECONDS, 10 * SECONDS_PER_SUBMITTED_ITEM)
+        assert f"after {expected}s" in str(excinfo.value)
+
+    def test_from_batch_ids_auto_timeout_is_unlimited(self, mock_zep):
+        result = IngestResult.from_batch_ids(mock_zep, ["b1"])
+        assert result._resolve_wait_timeout("auto") is None
 
     def test_wait_timeout_raises_but_result_usable(self, mock_zep):
         result = IngestResult(method="batch", batch_ids=["b1"], client=mock_zep)
@@ -163,6 +200,80 @@ class TestSequentialResult:
         result.refresh()
         assert result.status == "succeeded"
         assert mock_zep.graph.episode.get.call_count == 3
+
+    def test_wait_polls_only_the_last_episode(self, mock_zep):
+        result = IngestResult(
+            method="sequential",
+            episode_uuids=["e1", "e2", "e3"],
+            items_submitted=3,
+            client=mock_zep,
+        )
+        mock_zep.graph.episode.get.side_effect = [
+            make_zep_episode("e3", processed=False),
+            make_zep_episode("e3", processed=True),
+        ]
+
+        result.wait(poll_interval=0)
+
+        assert [call.kwargs["uuid_"] for call in mock_zep.graph.episode.get.call_args_list] == [
+            "e3",
+            "e3",
+        ]
+        assert result.status == "succeeded"
+
+    def test_combine_then_wait_polls_the_combined_tail(self, mock_zep):
+        first = IngestResult(
+            method="sequential", episode_uuids=["e1"], items_submitted=1, client=mock_zep
+        )
+        second = IngestResult(
+            method="sequential", episode_uuids=["e2"], items_submitted=1, client=mock_zep
+        )
+        mock_zep.graph.episode.get.return_value = make_zep_episode("e2", processed=True)
+
+        combined = first.combine(second)
+        combined.wait(poll_interval=0)
+
+        assert combined.items_submitted == 2
+        assert combined.episode_uuids == ["e1", "e2"]
+        mock_zep.graph.episode.get.assert_called_once_with(uuid_="e2")
+        assert combined.status == "succeeded"
+
+    def test_combine_rejects_different_clients(self, mock_zep):
+        other = MagicMock()
+        left = IngestResult(method="sequential", client=mock_zep)
+        right = IngestResult(method="sequential", client=other)
+        with pytest.raises(ConfigurationError, match="different Zep clients"):
+            left.combine(right)
+
+    def test_wait_polls_tasks_while_batch_tail_still_in_flight(self, mock_zep):
+        from zep_cloud.types.get_task_response import GetTaskResponse
+
+        result = IngestResult(
+            method="sequential",
+            batch_ids=["b1"],
+            task_ids=["t1"],
+            items_submitted=5,
+            client=mock_zep,
+        )
+        order: list[str] = []
+
+        def get_batch(batch_id: str):
+            order.append("batch")
+            if order.count("batch") == 1:
+                return make_batch_summary("b1", "processing")
+            return make_batch_summary("b1", "succeeded")
+
+        def get_task(task_id: str):
+            order.append("task")
+            return GetTaskResponse(task_id="t1", status="succeeded")
+
+        mock_zep.batch.get.side_effect = get_batch
+        mock_zep.task.get.side_effect = get_task
+
+        result.wait(poll_interval=0)
+
+        assert order == ["batch", "task", "batch"]
+        assert result.status == "succeeded"
 
     def test_add_errors_make_status_partial(self, mock_zep):
         result = IngestResult(

--- a/ingestion/tests/test_threads.py
+++ b/ingestion/tests/test_threads.py
@@ -368,7 +368,7 @@ class TestSequentialPath:
         sizes = [len(c.kwargs["messages"]) for c in mock_zep.thread.add_messages.call_args_list]
         assert sizes == [MAX_MESSAGES_PER_THREAD_ADD, 1]
 
-    def test_sequential_polls_last_message_uuid(self, mock_zep):
+    def test_sequential_polls_last_message_uuid_per_thread(self, mock_zep):
         mock_zep.thread.add_messages.side_effect = [
             AddThreadMessagesResponse(message_uuids=["msg-a1", "msg-a2"]),
             AddThreadMessagesResponse(message_uuids=["msg-b1"]),
@@ -379,30 +379,20 @@ class TestSequentialPath:
 
         assert result.episode_uuids == ["msg-a2", "msg-b1"]
         assert result.task_ids == []
-        mock_zep.graph.episode.get.return_value = make_zep_episode("msg-b1", processed=True)
+        assert result._single_queue_episode_poll is False
+        mock_zep.graph.episode.get.side_effect = [
+            make_zep_episode("msg-a2", processed=False),
+            make_zep_episode("msg-b1", processed=True),
+            make_zep_episode("msg-a2", processed=True),
+            make_zep_episode("msg-b1", processed=True),
+        ]
         assert result.wait(poll_interval=0) is result
         assert result.status == "succeeded"
-        mock_zep.graph.episode.get.assert_called_with(uuid_="msg-b1")
+        polled = [call.kwargs["uuid_"] for call in mock_zep.graph.episode.get.call_args_list]
+        assert set(polled) == {"msg-a2", "msg-b1"}
         mock_zep.task.get.assert_not_called()
 
-    def test_sequential_falls_back_to_task_ids_when_no_message_uuids(self, mock_zep):
-        mock_zep.thread.add_messages.side_effect = [
-            AddThreadMessagesResponse(task_id="thread-task-1"),
-            AddThreadMessagesResponse(task_id="thread-task-2"),
-        ]
-        msgs = [message(), message(thread_id="support-43")]
-
-        result = ingest_thread_messages(mock_zep, msgs, user_id="avery-brown", method="sequential")
-
-        assert result.task_ids == ["thread-task-1", "thread-task-2"]
-        assert result.episode_uuids == []
-        assert result.status == "queued"
-        assert not any("no completion handle" in warning for warning in result.warnings)
-        assert result.wait(poll_interval=0) is result
-        assert result.status == "succeeded"
-        assert mock_zep.task.get.call_count == 2
-
-    def test_sequential_warns_when_response_has_no_handle(self, mock_zep):
+    def test_sequential_warns_when_response_has_no_message_uuids(self, mock_zep):
         mock_zep.thread.add_messages.return_value = AddThreadMessagesResponse()
 
         result = ingest_thread_messages(
@@ -412,7 +402,7 @@ class TestSequentialPath:
         assert result.task_ids == []
         assert result.untracked_items == 1
         assert result.status == "untracked"
-        assert any("message UUID or task handle" in warning for warning in result.warnings)
+        assert any("message UUIDs" in warning for warning in result.warnings)
         with pytest.raises(IngestUntrackedError):
             result.wait()
 

--- a/ingestion/tests/test_threads.py
+++ b/ingestion/tests/test_threads.py
@@ -10,7 +10,7 @@ from zep_cloud.errors.not_found_error import NotFoundError
 from zep_cloud.types.add_thread_messages_response import AddThreadMessagesResponse
 from zep_cloud.types.batch_summary import BatchSummary
 
-from tests.conftest import make_batch_summary
+from tests.conftest import make_batch_summary, make_zep_episode
 from zep_ingest.exceptions import (
     BatchUnavailableError,
     ConfigurationError,
@@ -245,10 +245,11 @@ class TestSequentialPath:
         assert result.method == "batch"
 
     def test_wait_polls_until_terminal(self, mock_zep):
+        mock_zep.graph.episode.get.return_value = make_zep_episode("msg-1", processed=True)
         result = ingest_thread_messages(mock_zep, [message()], user_id="u1", method="sequential")
         result.wait(poll_interval=0)
         assert result.status == "succeeded"
-        mock_zep.task.get.assert_called()
+        mock_zep.graph.episode.get.assert_called_with(uuid_="msg-1")
 
     def test_auto_falls_back_to_sequential_when_endpoint_not_found(self, mock_zep):
         # a 404 means this deployment does not serve the batch endpoint, which
@@ -367,7 +368,24 @@ class TestSequentialPath:
         sizes = [len(c.kwargs["messages"]) for c in mock_zep.thread.add_messages.call_args_list]
         assert sizes == [MAX_MESSAGES_PER_THREAD_ADD, 1]
 
-    def test_sequential_tracks_task_ids_for_waiting(self, mock_zep):
+    def test_sequential_polls_last_message_uuid(self, mock_zep):
+        mock_zep.thread.add_messages.side_effect = [
+            AddThreadMessagesResponse(message_uuids=["msg-a1", "msg-a2"]),
+            AddThreadMessagesResponse(message_uuids=["msg-b1"]),
+        ]
+        msgs = [message(), message(thread_id="support-43")]
+
+        result = ingest_thread_messages(mock_zep, msgs, user_id="avery-brown", method="sequential")
+
+        assert result.episode_uuids == ["msg-a2", "msg-b1"]
+        assert result.task_ids == []
+        mock_zep.graph.episode.get.return_value = make_zep_episode("msg-b1", processed=True)
+        assert result.wait(poll_interval=0) is result
+        assert result.status == "succeeded"
+        mock_zep.graph.episode.get.assert_called_with(uuid_="msg-b1")
+        mock_zep.task.get.assert_not_called()
+
+    def test_sequential_falls_back_to_task_ids_when_no_message_uuids(self, mock_zep):
         mock_zep.thread.add_messages.side_effect = [
             AddThreadMessagesResponse(task_id="thread-task-1"),
             AddThreadMessagesResponse(task_id="thread-task-2"),
@@ -377,13 +395,14 @@ class TestSequentialPath:
         result = ingest_thread_messages(mock_zep, msgs, user_id="avery-brown", method="sequential")
 
         assert result.task_ids == ["thread-task-1", "thread-task-2"]
+        assert result.episode_uuids == []
         assert result.status == "queued"
         assert not any("no completion handle" in warning for warning in result.warnings)
         assert result.wait(poll_interval=0) is result
         assert result.status == "succeeded"
         assert mock_zep.task.get.call_count == 2
 
-    def test_sequential_warns_when_response_has_no_task_id(self, mock_zep):
+    def test_sequential_warns_when_response_has_no_handle(self, mock_zep):
         mock_zep.thread.add_messages.return_value = AddThreadMessagesResponse()
 
         result = ingest_thread_messages(
@@ -393,7 +412,7 @@ class TestSequentialPath:
         assert result.task_ids == []
         assert result.untracked_items == 1
         assert result.status == "untracked"
-        assert any("no completion handle" in warning for warning in result.warnings)
+        assert any("message UUID or task handle" in warning for warning in result.warnings)
         with pytest.raises(IngestUntrackedError):
             result.wait()
 


### PR DESCRIPTION
## Summary
- **zep-ingest 0.3.0:** Submit all sources into a graph before any optional wait. Sequential vs batch only chooses `graph.add` vs the Batch API — not “finish extracting this file before sending the next.”
- **`wait()` is opt-in** and aligned with [Check data ingestion status](https://help.getzep.com/check-data-ingestion-status):
  - Batch path: poll last `batch_id` via `batch.get`
  - Sequential `graph.add`: poll last-submitted episode
  - Sequential `thread.add_messages`: poll last message UUID **per thread** (`message_uuids` only — regular `add_messages` does not return `task_id`)
  - Nodes/triples: poll every `task_id`
- Default timeout: `max(120s, 60s × items_submitted)`. Pass `timeout=None` for unbounded wait.
- `SourcePaths` sequences, `ConcatLoader`, and `IngestResult.combine()` for mixed/multi-call submits. `combine()` merges poll handles only (not `node_uuids`/`edge_uuids`). Prefer separate `wait()` for seeding vs episodes.
- Multi-thread sequential fix: each thread saga polled independently (no false-complete when one thread finishes first).

## Test plan
- [x] `cd ingestion && uv sync --extra dev && uv run pytest tests/ -m "not integration"` (678 passed)
- [x] `uv run ruff check . && uv run ruff format --check . && uv run mypy src/`
- [x] Production smoke: `keybank run zep-prod -- env ZEP_API_URL=https://api.getzep.com uv run python scripts/release_smoke_prod.py` (7/7)
- [x] Pytest integration against prod (2/2)
- [ ] After merge: dispatch **Release Ingestion Package** on `main` → publishes `zep-ingest` 0.3.0 (`zep-ingest-v0.3.0`)